### PR TITLE
fix: CDK Bootstrapをデプロイワークフローから削除し、env変数名を修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,6 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
-      - name: CDK Bootstrap
-        run: npx cdk bootstrap
-        working-directory: cdk
-
       - name: CDK Deploy
         run: npm run deploy
         working-directory: cdk

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -8,7 +8,7 @@ export default defineNuxtConfig({
   },
   runtimeConfig: {
     public: {
-      apiBaseUrl: process.env.API_BASE_URL || '',
+      apiBaseUrl: '', // NUXT_PUBLIC_API_BASE_URL 環境変数で上書き可能
     },
   },
 })


### PR DESCRIPTION
- cdk bootstrapは初回のみ手動実行が必要なため、CI/CDパイプラインから除外
  毎回実行すると IAM の広範な権限が必要で権限不足エラーが発生していた
- nuxt.config.ts の runtimeConfig で参照する環境変数名を修正
  process.env.API_BASE_URL は未使用で、Nuxt 3 の NUXT_PUBLIC_API_BASE_URL
  による自動オーバーライドに統一

https://claude.ai/code/session_01GPvLSnuQPD7cBKR1mbkubR