### PR TITLE
ci: CloudFormation OutputからAPI Base URLを自動取得してセット

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,20 +20,8 @@ jobs:
           node-version: '20'
 
       # ----------------------------------------
-      # フロントエンド: Nuxt SPA ビルド
-      # ----------------------------------------
-      - name: Install frontend dependencies
-        run: npm install
-
-      - name: Build frontend
-        run: npm run generate
-        env:
-          # API Gateway URL は GitHub Secrets に設定する
-          # 初回デプロイ後に CDK Outputs の ApiUrl を登録してください
-          NUXT_PUBLIC_API_BASE_URL: ${{ secrets.API_BASE_URL }}
-
-      # ----------------------------------------
-      # CDK デプロイ
+      # CDK 依存関係インストール & AWS 認証
+      # (API URL 取得のためにフロントエンドビルドより前に実行)
       # ----------------------------------------
       - name: Install CDK dependencies
         run: npm install
@@ -46,6 +34,35 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ap-northeast-1
 
+      # ----------------------------------------
+      # デプロイ済みスタックから API Base URL を取得
+      # CDK Outputs の ApiUrl を GITHUB_OUTPUT に書き出す
+      # ----------------------------------------
+      - name: Get API Base URL from CloudFormation
+        id: get-api-url
+        run: |
+          API_URL=$(aws cloudformation describe-stacks \
+            --stack-name ClassicalMusicLakeStack \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' \
+            --output text)
+          echo "api_url=$API_URL" >> $GITHUB_OUTPUT
+
+      # ----------------------------------------
+      # フロントエンド: Nuxt SPA ビルド
+      # ----------------------------------------
+      - name: Install frontend dependencies
+        run: npm install
+
+      - name: Build frontend
+        run: npm run generate
+        env:
+          # CloudFormation Outputs から取得した API Gateway URL をセット
+          NUXT_PUBLIC_API_BASE_URL: ${{ steps.get-api-url.outputs.api_url }}
+
+      # ----------------------------------------
+      # CDK デプロイ
+      # (インフラ更新 + ビルド済みフロントエンドを S3 へ反映)
+      # ----------------------------------------
       - name: CDK Deploy
         run: npm run deploy
         working-directory: cdk


### PR DESCRIPTION
secrets.API_BASE_URLの手動設定に代わり、デプロイ済みスタックの
CloudFormation Outputsから直接ApiUrlを取得するように変更。

- AWS認証とCDK依存インストールをフロントエンドビルドより前に移動
- aws cloudformation describe-stacksでApiUrlを取得しGITHUB_OUTPUTに書き出し
- NUXT_PUBLIC_API_BASE_URLにCloudFormation取得値をセット
- CDKデプロイをビルド後に実行し、新しいフロントエンドをS3へ反映

https://claude.ai/code/session_011R53T9zLN2CdczHDzKcJzk