### PR TITLE
fix: PR#5レビューコメント修正 - SPEC.mdのDYNAMO_TABLE_CONCERTSを削除

### DIFF
--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -242,7 +242,6 @@ DELETE /listening-logs/{id}
 
 #### バックエンド（Lambda）
 - `DYNAMO_TABLE_LISTENING_LOGS`: 視聴ログテーブル名
-- `DYNAMO_TABLE_CONCERTS`: コンサートテーブル名
 
 ---
 


### PR DESCRIPTION
## 概要

PR #5 (`feature/remove-concert-feature`) のレビューコメントを修正します。

## 変更内容

- `docs/SPEC.md` のセクション5.2（環境変数）に残っていた `DYNAMO_TABLE_CONCERTS` の記述を削除

## 背景

コンサート機能削除の際、セクション5.1（AWSリソース）では `DYNAMO_TABLE_CONCERTS` が正しく削除されていたが、セクション5.2（環境変数）には記述が残ったままになっていた。

https://claude.ai/code/session_01CKB33L9h45etjEDVsrSYJV