### PR TITLE
fix: cdk bootstrap を ci に追加しデプロイエラーを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -89,6 +89,15 @@ jobs:
           NUXT_PUBLIC_API_BASE_URL: ${{ steps.get-api-url.outputs.api_url }}
 
       # ----------------------------------------
+      # CDK Bootstrap（bootstrap スタックを最新バージョンに更新）
+      # ----------------------------------------
+      - name: CDK Bootstrap
+        run: npx cdk bootstrap
+        working-directory: cdk
+        env:
+          STAGE_NAME: ${{ env.STAGE_NAME }}
+
+      # ----------------------------------------
       # CDK デプロイ
       # (インフラ更新 + ビルド済みフロントエンドを S3 へ反映)
       # ----------------------------------------

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -39,7 +39,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       // prod は RETAIN、staging は DESTROY（スタック削除時にテーブルも削除）
       removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       // ポイントインタイムリカバリ（PITR）有効化（35日間のバックアップ自動保持）
-      pointInTimeRecovery: true,
+      pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
 
     // -------------------------
@@ -51,7 +51,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       DYNAMO_TABLE_LISTENING_LOGS: listeningLogsTable.tableName,
     };
 
-    const commonFnProps: Omit<lambdaNodejs.NodejsFunctionProps, "entry"> = {
+    const commonFnProps: Omit<lambdaNodejs.NodejsFunctionProps, "entry" | "logGroup"> = {
       runtime: lambda.Runtime.NODEJS_24_X,
       // ARM64（Graviton2）: x86_64 比で約 20% 安価かつ高速
       architecture: lambda.Architecture.ARM_64,
@@ -62,8 +62,6 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       environment: commonEnv,
       // X-Ray トレーシング有効化（コールドスタート・レスポンスタイムの可視化）
       tracing: lambda.Tracing.ACTIVE,
-      // CloudWatch Logs の保持期間を 3 ヶ月に設定（デフォルトは無期限）
-      logRetention: logs.RetentionDays.THREE_MONTHS,
       bundling: {
         minify: true,
         sourceMap: false,
@@ -71,12 +69,19 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       },
     };
 
-    const fn = (id: string, entry: string): lambdaNodejs.NodejsFunction =>
-      new lambdaNodejs.NodejsFunction(this, id, {
+    const fn = (id: string, entry: string): lambdaNodejs.NodejsFunction => {
+      // CloudWatch Logs 保持期間を 3 ヶ月に設定（カスタムリソース不要の explicit LogGroup）
+      const logGroup = new logs.LogGroup(this, `${id}LogGroup`, {
+        retention: logs.RetentionDays.THREE_MONTHS,
+        removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      });
+      return new lambdaNodejs.NodejsFunction(this, id, {
         ...commonFnProps,
         entry: path.join(backendSrcDir, entry),
         handler: "handler",
+        logGroup,
       });
+    };
 
     // -------------------------
     // Lambda 関数


### PR DESCRIPTION
## 問題

CDK CLI のバージョンアップにより bootstrap スタック v30+ が必要になったが、AWS 環境の bootstrap が v21 のままだったためデプロイが失敗していた。

```
Bootstrap toolkit stack version 30 or later is needed; current version: 21.
```

## 修正内容

- `deploy.yml` に `cdk bootstrap` ステップを追加し、デプロイ前に bootstrap スタックを常に最新バージョンへ更新するようにした
- `pointInTimeRecovery` → `pointInTimeRecoverySpecification` に移行（deprecated 対応）
- `logRetention` → explicit `LogGroup` + `logGroup` プロパティに移行（deprecated 対応。カスタムリソース Lambda が不要になり bootstrap 依存も排除）

## Test plan

- [ ] GitHub Actions の Deploy ワークフローが成功すること
- [ ] CDK Bootstrap ステップが正常に実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **インフラストラクチャの改善**
  * CI/CDパイプラインにCDKブートストラップステップを追加
  
* **データ保護**
  * DynamoDBテーブルのPoint-in-Time Recovery機能を有効化

* **運用改善**
  * Lambda関数のCloudWatch Logsに明示的なログ保持ポリシー（3ヶ月）を適用

<!-- end of auto-generated comment: release notes by coderabbit.ai -->