### PR TITLE
fix: bootstrap 前に ecr リポジトリを再作成しデプロイを修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,17 @@ jobs:
 
       # ----------------------------------------
       # CDK Bootstrap（bootstrap スタックを最新バージョンに更新）
+      # CDKToolkit が参照する ECR リポジトリが削除されていると bootstrap が
+      # 失敗するため、事前に存在確認・作成する
       # ----------------------------------------
+      - name: Ensure ECR repository for CDK bootstrap
+        run: |
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          REPO="cdk-hnb659fds-container-assets-${ACCOUNT}-ap-northeast-1"
+          aws ecr describe-repositories --repository-names "$REPO" 2>/dev/null \
+            || aws ecr create-repository --repository-name "$REPO" 2>/dev/null \
+            || true
+
       - name: CDK Bootstrap
         run: npx cdk bootstrap
         working-directory: cdk


### PR DESCRIPTION
## 問題

CDKToolkit スタックが参照する ECR リポジトリ（`cdk-hnb659fds-container-assets-{account}-ap-northeast-1`）が AWS 環境から削除されており、`cdk bootstrap` の UPDATE が失敗していた。

## 修正内容

`cdk bootstrap` の前に ECR リポジトリの存在確認・作成ステップを追加。

```bash
# リポジトリが存在しなければ作成（すでに存在する場合は何もしない）
aws ecr describe-repositories --repository-names "$REPO" 2>/dev/null \
  || aws ecr create-repository --repository-name "$REPO" 2>/dev/null \
  || true
```

Node.js Lambda のみ使用しているため ECR は実際には不要だが、CDKToolkit スタックのリソースとして参照されているため再作成が必要。

## Test plan

- [ ] Deploy ワークフローが成功すること
- [ ] CDK Bootstrap ステップが正常終了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **バグ修正**
  * デプロイメント時に ECR リポジトリが削除されている場合に発生するブートストラップ失敗を防ぐ処理を追加しました。リポジトリが見つからない場合は自動的に作成されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->