### PR TITLE
fix: api gateway アクセスログ用 cloudwatch ロールを設定

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from "aws-cdk-lib";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
+import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
@@ -104,6 +105,20 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // -------------------------
     // API Gateway
     // -------------------------
+    // API Gateway が CloudWatch Logs に書き込むためのアカウントレベル設定
+    // （アカウントに一度設定すれば全リージョン共通だが CDK では Stack ごとに管理）
+    const apiGatewayCloudWatchRole = new iam.Role(this, "ApiGatewayCloudWatchRole", {
+      assumedBy: new iam.ServicePrincipal("apigateway.amazonaws.com"),
+      managedPolicies: [
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+          "service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+        ),
+      ],
+    });
+    const apiGatewayAccount = new apigateway.CfnAccount(this, "ApiGatewayAccount", {
+      cloudWatchRoleArn: apiGatewayCloudWatchRole.roleArn,
+    });
+
     // API Gateway アクセスログ用ロググループ（保持期間 3 ヶ月）
     const apiAccessLogGroup = new logs.LogGroup(this, "ApiAccessLogs", {
       logGroupName: `/aws/apigateway/classical-music-lake-${stageName}`,
@@ -132,6 +147,9 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
         }),
       },
     });
+
+    // CfnAccount の設定完了後に API Gateway ステージが作成されるよう順序を保証
+    api.node.addDependency(apiGatewayAccount);
 
     const integ = (fn: lambda.IFunction) => new apigateway.LambdaIntegration(fn);
 


### PR DESCRIPTION
## 問題

API Gateway のアクセスログを有効にするためにアカウントレベルで CloudWatch Logs IAM ロールの設定が必要だが未設定だった。

```
CloudWatch Logs role ARN must be set in account settings to enable logging
```

## 修正内容

- `AWS::IAM::Role`（`AmazonAPIGatewayPushToCloudWatchLogs` ポリシー付き）を作成
- `AWS::ApiGateway::Account` で CloudWatch ロール ARN をアカウントに設定
- `api.node.addDependency(apiGatewayAccount)` で `CfnAccount` 完了後に API Gateway ステージが作成されるよう順序を保証

## Test plan

- [ ] Deploy ワークフローが成功すること
- [ ] API Gateway アクセスログが CloudWatch Logs に出力されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **API Gateway ロギング機能の追加**
  * API Gateway がCloudWatch Logs へのロギングを記録できるよう設定しました。これにより、API のアクティビティを詳細に監視できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->