### PR TITLE
fix: deployワークフローにconcurrencyを追加して同時デプロイを防止

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,10 @@ on:
           - staging
           - prod
 
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 問題

連続したpushにより2つのDeployワークフローが同時実行され、CloudFormationスタックが`UPDATE_IN_PROGRESS`状態でロックされた状態で2つ目のデプロイが実行されて失敗していた。

```
ValidationError: Stack ClassicalMusicLakeStack is in UPDATE_IN_PROGRESS state and can not be updated.
```

## 修正

`concurrency`を追加し、同じブランチへのデプロイは順番に実行されるよう制御する（`cancel-in-progress: false`で後続のデプロイはキャンセルせずキューイング）。

https://claude.ai/code/session_013aSqtqtxseRVbmGpjBmBbd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **その他**
  * デプロイメントワークフローに同時実行制御を追加し、デプロイメント処理を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->