### PR TITLE
ci: konabe の自己レビューを許可する自動承認ワークフローを追加

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -1,0 +1,19 @@
+name: Auto Approve
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-approve:
+    name: Auto Approve (konabe)
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    if: github.event.pull_request.user.login == 'konabe'
+
+    steps:
+      - uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
konabe が PR を作成した際に GITHUB_TOKEN を使って自動承認することで、
CODEOWNERS による自己レビュー制限を回避できるようにする。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * 開発ワークフローの改善を実施しました。

※ このリリースにはエンドユーザー向けの機能変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->