### PR TITLE
Refactor request body validation tests with parameterized tests

### DIFF
--- a/backend/src/listening-logs/create.test.ts
+++ b/backend/src/listening-logs/create.test.ts
@@ -43,28 +43,17 @@ describe("POST /listening-logs (create)", () => {
     vi.clearAllMocks();
   });
 
-  it("body がない場合は 400 を返す", async () => {
-    const result = await handler(makeEvent(null), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("不正な JSON の場合は 422 を返す", async () => {
-    const result = await handler(makeEvent("invalid json"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(422);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Invalid or malformed JSON was provided");
-  });
-
-  it("JSON が null の場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("null"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("JSON が配列の場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("[]"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body must be a JSON object");
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(makeEvent(body), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
   });
 
   it.each([0, 6, -1, 1.5, "5", null])(

--- a/backend/src/listening-logs/update.test.ts
+++ b/backend/src/listening-logs/update.test.ts
@@ -57,16 +57,17 @@ describe("PUT /listening-logs/:id (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  it("body がない場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("abc-123", null), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("不正な JSON の場合は 422 を返す", async () => {
-    const result = await handler(makeEvent("abc-123", "invalid json"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(422);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Invalid or malformed JSON was provided");
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(makeEvent("abc-123", body), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
   });
 
   it.each([0, 6, -1, 1.5, "5", null])(

--- a/backend/src/pieces/create.test.ts
+++ b/backend/src/pieces/create.test.ts
@@ -43,28 +43,17 @@ describe("POST /pieces (create)", () => {
     vi.useRealTimers();
   });
 
-  it("body がない場合は 400 を返す", async () => {
-    const result = await handler(makeEvent(null), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("不正な JSON の場合は 422 を返す", async () => {
-    const result = await handler(makeEvent("invalid json"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(422);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Invalid or malformed JSON was provided");
-  });
-
-  it("JSON が null の場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("null"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("JSON が配列の場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("[]"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body must be a JSON object");
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(makeEvent(body), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
   });
 
   it("title がない場合は 400 を返す", async () => {

--- a/backend/src/pieces/update.test.ts
+++ b/backend/src/pieces/update.test.ts
@@ -54,16 +54,17 @@ describe("PUT /pieces/{id} (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  it("body がない場合は 400 を返す", async () => {
-    const result = await handler(makeEvent("abc-123", null), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(400);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Request body is required");
-  });
-
-  it("不正な JSON の場合は 422 を返す", async () => {
-    const result = await handler(makeEvent("abc-123", "invalid json"), mockContext, mockCallback);
-    expect(result?.statusCode).toBe(422);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Invalid or malformed JSON was provided");
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(makeEvent("abc-123", body), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
   });
 
   it("title が空文字の場合は 400 を返す", async () => {


### PR DESCRIPTION
## 概要

リクエストボディの異常系テストを、個別のテストケースから `it.each` を使用したパラメータ化テストに統合しました。4つのエンドポイント（listening-logs create/update、pieces create/update）のテストを一貫性のある形式に統一しています。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [x] テスト
- [ ] その他（　　）

## 変更内容

- **listening-logs create テスト**: 4つの個別テストを1つのパラメータ化テストに統合
  - body がない場合（null）
  - JSON が null の場合
  - JSON が配列の場合
  - 不正な JSON の場合
  
- **pieces create テスト**: 同様に4つのテストを1つのパラメータ化テストに統合

- **listening-logs update テスト**: 2つのテストをパラメータ化テストに統合し、create テストと同じ4パターンをカバー

- **pieces update テスト**: 同様に2つのテストをパラメータ化テストに統合

すべてのテストケースは `describe("リクエストボディ異常系")` でグループ化され、テストの意図がより明確になりました。

## テスト

- [x] ユニットテストを追加・更新した
- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [ ] 実装を含む変更の場合、`docs/SPEC.md` を更新した（テストのみの変更のため不要）

https://claude.ai/code/session_01NZprMS9gwg4fYrT7wmHyLr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * リクエストボディの検証テストを効率化し、複数の異常系ケースをパラメータ化されたテストでカバーするように改善しました。テスト動作に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->