### PR TITLE
Migrate to GitHub OIDC + IAM Role Assume for keyless auth

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -52,6 +52,19 @@ jobs:
         run: npm install
         working-directory: cdk
 
+      # ----------------------------------------
+      # AWS_ROLE_TO_ASSUME シークレットの存在確認
+      # 未設定の場合は後続ステップが不明なエラーで落ちるため事前に検出する
+      # ----------------------------------------
+      - name: Validate required secrets
+        env:
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        run: |
+          if [ -z "$AWS_ROLE_TO_ASSUME" ]; then
+            echo "::error::AWS_ROLE_TO_ASSUME secret is not set. Please configure GitHub OIDC and set the IAM role ARN as AWS_ROLE_TO_ASSUME in repository secrets."
+            exit 1
+          fi
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v6
         with:

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ cdk deploy
 
 以下のシークレットをリポジトリに設定してください：
 
-| シークレット名       | 説明                                  |
-| -------------------- | ------------------------------------- |
-| `AWS_ROLE_TO_ASSUME` | AssumeRole 対象の IAM ロール ARN      |
+| シークレット名       | 説明                             |
+| -------------------- | -------------------------------- |
+| `AWS_ROLE_TO_ASSUME` | AssumeRole 対象の IAM ロール ARN |
 
 > **注意**: `AWS_REGION` はワークフロー内に `ap-northeast-1` でハードコードされています。API GatewayのURLはCloudFormation Outputsから自動取得するため、シークレットとして設定する必要はありません。
 
@@ -82,7 +82,11 @@ cdk deploy
 このワークフローは GitHub Actions OIDC を使ったキーレス認証を採用しています。事前に以下を設定してください：
 
 1. AWS IAM で ID プロバイダー（`token.actions.githubusercontent.com`）を作成
-2. 最小権限の IAM ロールを作成し、上記 ID プロバイダーからの Assume Role を許可
+2. 最小権限の IAM ロールを作成し、信頼ポリシーに以下を設定：
+   - **Action**: `sts:AssumeRoleWithWebIdentity`
+   - **Condition**:
+     - `token.actions.githubusercontent.com:aud` = `sts.amazonaws.com`
+     - `token.actions.githubusercontent.com:sub` = `repo:<org>/<repo>:ref:refs/heads/<branch>`（例: `repo:konabe/classical-music-lake:ref:refs/heads/main`）
 3. ロール ARN を `AWS_ROLE_TO_ASSUME` シークレットに設定
 
 `main` ブランチへのプッシュで自動デプロイされます。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -360,11 +360,18 @@ DELETE /listening-logs/{id}
 
 #### CI/CD（GitHub Secrets）
 
-| シークレット名       | 用途                                     |
-| -------------------- | ---------------------------------------- |
+| シークレット名       | 用途                                          |
+| -------------------- | --------------------------------------------- |
 | `AWS_ROLE_TO_ASSUME` | GitHub OIDC で AssumeRole する IAM ロール ARN |
 
 > **シークレット管理方針**: CI/CD 認証は GitHub Actions OIDC + IAM Role Assume によるキーレス認証を採用。長期 AWS アクセスキーを使用しない。Lambda 環境変数に秘密情報は含まれない（テーブル名・CORS オリジンのみ）。将来フェーズで認証機能を追加する場合は AWS Secrets Manager の導入を検討すること。
+>
+> **IAM 信頼ポリシー要件**: IAM ロールの信頼ポリシーには以下を必ず設定すること。誤設定を防ぐため、Action・Condition キー・値を明記する。
+>
+> - **Action**: `sts:AssumeRoleWithWebIdentity`
+> - **Condition**:
+>   - `token.actions.githubusercontent.com:aud` = `sts.amazonaws.com`
+>   - `token.actions.githubusercontent.com:sub` = `repo:<org>/<repo>:ref:refs/heads/<branch>`（例: `repo:konabe/classical-music-lake:ref:refs/heads/main`）
 
 ---
 


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローの認証方式を、長期 AWS アクセスキーから GitHub OIDC + IAM Role Assume によるキーレス認証に移行しました。セキュリティを向上させ、認証情報の漏洩リスクを低減します。

## 変更の種類

- [x] セキュリティ改善
- [x] ドキュメント

## 変更内容

### GitHub Actions ワークフロー (.github/workflows/deploy.yml)
- `permissions` に `id-token: write` を追加し、OIDC トークン生成を許可
- `aws-actions/configure-aws-credentials@v6` の認証方式を変更：
  - 削除: `aws-access-key-id` と `aws-secret-access-key`
  - 追加: `role-to-assume` で IAM ロール ARN を指定

### ドキュメント更新 (README.md, docs/SPEC.md)
- GitHub Secrets テーブルを更新：
  - `AWS_ACCESS_KEY_ID` と `AWS_SECRET_ACCESS_KEY` を削除
  - `AWS_ROLE_TO_ASSUME` のみに統一
- GitHub OIDC + IAM ロール設定手順を新規追加
- シークレット管理方針を更新：キーレス認証採用を明記

## テスト

- [x] 既存テストがすべて通ることを確認した
- ワークフロー構文は有効（GitHub Actions の OIDC 標準機能を使用）
- 実際の動作確認は、AWS IAM 設定後に CI/CD パイプラインで検証予定

## チェックリスト

- [x] コーディング規約に従っている
- [x] ドキュメント（README.md, docs/SPEC.md）を更新した
- [x] セキュリティベストプラクティスに準拠している

https://claude.ai/code/session_01A3cqdmEQR6CsWRJx2Fiuss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **セキュリティ向上**
  * CI/CDの認証をアクセスキー方式からGitHub OIDC＋IAMロールへ移行し、キー不要の安全なデプロイを実現しました。
* **信頼性向上**
  * デプロイ前に必要なロール情報の存在を検証する事前チェックを追加し、設定不足時に早期に明確なエラーを出すようにしました。
* **ドキュメント**
  * デプロイとシークレット管理の手順を更新し、OIDC／IAMロール設定ガイダンスを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->