### PR TITLE
feat(003-2): implement user registration with Cognito

### DIFF
--- a/backend/src/auth/register.test.ts
+++ b/backend/src/auth/register.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Context } from "aws-lambda";
+
+import { handler } from "./register";
+import { makeEvent } from "../test/fixtures";
+
+// Mock CognitoIdentityServiceProvider
+const { mockSignUp } = vi.hoisted(() => ({
+  mockSignUp: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-cognito-identity-provider", () => ({
+  CognitoIdentityServiceProvider: vi.fn(function () {
+    this.signUp = mockSignUp;
+  }),
+}));
+
+const mockContext = {} as Context;
+const mockCallback = { signal: new AbortController().signal };
+
+const validInput = {
+  email: "user@example.com",
+  password: "ValidPassword123",
+};
+
+describe("POST /auth/register", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(
+        makeEvent({ body, httpMethod: "POST", path: "/auth/register" }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
+  });
+
+  describe("メールアドレスバリデーション", () => {
+    it("メールアドレスが無効な場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, email: "invalid-email" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
+    });
+
+    it("メールアドレスが空の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, email: "" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
+    });
+
+    it("メールアドレスが空白のみの場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, email: "   " }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
+    });
+  });
+
+  describe("パスワードバリデーション", () => {
+    it("パスワードが 8 文字未満の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, password: "Short1!" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
+    });
+
+    it("パスワードが大文字を含まない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, password: "lowercasepass1" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
+    });
+
+    it("パスワードが小文字を含まない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, password: "UPPERCASE1" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
+    });
+
+    it("パスワードが数字を含まない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, password: "NoNumbersHere" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
+    });
+
+    it("パスワードが空の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ ...validInput, password: "" }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
+    });
+  });
+
+  describe("成功系", () => {
+    it("有効なメール・パスワードで登録に成功し、201 を返す", async () => {
+      mockSignUp.mockResolvedValue({
+        UserSub: "user-sub-id",
+        CodeDeliveryDetails: {
+          Destination: "u***@example.com",
+          DeliveryMedium: "EMAIL",
+        },
+      });
+
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+
+      expect(result?.statusCode).toBe(201);
+      const body = JSON.parse(result?.body ?? "{}");
+      expect(body.message).toContain("successfully");
+      expect(mockSignUp).toHaveBeenCalled();
+    });
+  });
+
+  describe("Cognito エラー系", () => {
+    it("メール重複時に 400 を返す", async () => {
+      const error: { Code: string; message: string } = {
+        Code: "UsernameExistsException",
+        message: "UsernameExistsException",
+      };
+      mockSignUp.mockRejectedValue(error);
+
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toContain("already");
+    });
+
+    it("無効なパスワード時に 400 を返す", async () => {
+      const error: { Code: string; message: string } = {
+        Code: "InvalidPasswordException",
+        message: "InvalidPasswordException",
+      };
+      mockSignUp.mockRejectedValue(error);
+
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+
+      expect(result?.statusCode).toBe(400);
+      const message = JSON.parse(result?.body ?? "{}").message;
+      expect(message.toLowerCase()).toContain("password");
+    });
+
+    it("その他の Cognito エラー時に 500 を返す", async () => {
+      const error: { Code: string; message: string } = {
+        Code: "ServiceUnavailableException",
+        message: "ServiceUnavailableException",
+      };
+      mockSignUp.mockRejectedValue(error);
+
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+
+      expect(result?.statusCode).toBe(500);
+    });
+  });
+
+  describe("必須フィールド検証", () => {
+    it("email が存在しない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ password: validInput.password }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("password が存在しない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({
+          body: JSON.stringify({ email: validInput.email }),
+          httpMethod: "POST",
+          path: "/auth/register",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+  });
+});

--- a/backend/src/auth/register.ts
+++ b/backend/src/auth/register.ts
@@ -1,0 +1,77 @@
+import { CognitoIdentityServiceProvider } from "@aws-sdk/client-cognito-identity-provider";
+import { StatusCodes } from "http-status-codes";
+
+import { createHandler, jsonBodyParser } from "../utils/middleware";
+import { parseRequestBody } from "../utils/parsing";
+import { registerSchema } from "../utils/schemas";
+
+const cognito = new CognitoIdentityServiceProvider();
+const clientId = process.env.COGNITO_CLIENT_ID || "";
+
+interface CognitoError extends Error {
+  Code?: string;
+}
+
+export const handler = createHandler(async (event) => {
+  const input = parseRequestBody(event.body as unknown, registerSchema);
+
+  try {
+    await cognito.signUp({
+      ClientId: clientId,
+      Username: input.email,
+      Password: input.password,
+      UserAttributes: [
+        {
+          Name: "email",
+          Value: input.email,
+        },
+        {
+          Name: "email_verified",
+          Value: "false",
+        },
+      ],
+    });
+
+    return {
+      statusCode: StatusCodes.CREATED,
+      body: {
+        message: "User created successfully. Please check your email to verify your account.",
+      },
+    };
+  } catch (error) {
+    const cognitoError = error as CognitoError;
+
+    if (cognitoError.Code === "UsernameExistsException") {
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        body: {
+          error: "UserExists",
+          message: "An account with the given email already exists.",
+        },
+      };
+    }
+
+    if (cognitoError.Code === "InvalidPasswordException") {
+      return {
+        statusCode: StatusCodes.BAD_REQUEST,
+        body: {
+          error: "InvalidPassword",
+          message:
+            "Password does not meet the requirements. Password must be at least 8 characters long and contain uppercase, lowercase, and numeric characters.",
+        },
+      };
+    }
+
+    if (cognitoError.Code === "TooManyRequestsException") {
+      return {
+        statusCode: StatusCodes.TOO_MANY_REQUESTS,
+        body: {
+          error: "TooManyRequests",
+          message: "Too many registration attempts. Please try again later.",
+        },
+      };
+    }
+
+    throw error;
+  }
+}).use(jsonBodyParser);

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -52,3 +52,20 @@ export const updatePieceSchema = z.object({
     .max(100, "composer must be 100 characters or less")
     .optional(),
 });
+
+const emailSchema = z
+  .string({ error: () => "email is required" })
+  .trim()
+  .email("email must be a valid email address");
+
+const passwordSchema = z
+  .string({ error: () => "password is required" })
+  .min(8, "password must be at least 8 characters long")
+  .regex(/[A-Z]/, "password must contain at least one uppercase letter")
+  .regex(/[a-z]/, "password must contain at least one lowercase letter")
+  .regex(/\d/, "password must contain at least one digit");
+
+export const registerSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -170,23 +170,20 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const updatePiece = fn("UpdatePiece", "pieces/update.ts");
     const deletePiece = fn("DeletePiece", "pieces/delete.ts");
 
+    const authRegister = fn("AuthRegister", "auth/register.ts");
+
     // -------------------------
-    // Cognito 権限付与（管理 Lambda用）
+    // Cognito 権限付与
     // -------------------------
-    // TODO: 登録・ログイン・ログアウト機能は 003-2, 003-3, 003-4 で実装予定
-    // const cognitoPolicy = new iam.PolicyStatement({
-    //   effect: iam.Effect.ALLOW,
-    //   actions: [
-    //     "cognito-idp:AdminGetUser",
-    //     "cognito-idp:AdminUpdateUserAttributes",
-    //     "cognito-idp:AdminCreateUser",
-    //     "cognito-idp:AdminDeleteUser",
-    //     "cognito-idp:ListUsers",
-    //     "cognito-idp:AdminInitiateAuth",
-    //     "cognito-idp:AdminUserGlobalSignOut",
-    //   ],
-    //   resources: [userPool.userPoolArn],
-    // });
+    // auth/register: SignUp を実行
+    const cognitoRegisterPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["cognito-idp:SignUp"],
+      resources: [userPool.userPoolArn],
+    });
+    authRegister.addToPrincipalPolicy(cognitoRegisterPolicy);
+
+    // TODO: ログイン・ログアウト機能は 003-3, 003-4 で実装予定
 
     // -------------------------
     // DynamoDB 権限付与
@@ -277,6 +274,13 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     pieceResource.addMethod("PUT", integ(updatePiece));
     pieceResource.addMethod("DELETE", integ(deletePiece));
 
+    // /auth
+    const authResource = api.root.addResource("auth");
+
+    // /auth/register (登録フロー: 認証不要)
+    const authRegisterResource = authResource.addResource("register");
+    authRegisterResource.addMethod("POST", integ(authRegister));
+
     // -------------------------
     // S3 + CloudFront (SPA ホスティング)
     // -------------------------
@@ -362,6 +366,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       getPiece,
       updatePiece,
       deletePiece,
+      authRegister,
     ].forEach((fn) => {
       fn.addEnvironment("CORS_ALLOW_ORIGIN", this.corsAllowOrigin);
     });
@@ -371,6 +376,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     this.addCors(listeningLogResource, ["GET", "PUT", "DELETE", "OPTIONS"]);
     this.addCors(piecesResource, ["GET", "POST", "OPTIONS"]);
     this.addCors(pieceResource, ["GET", "PUT", "DELETE", "OPTIONS"]);
+    this.addCors(authRegisterResource, ["POST", "OPTIONS"]);
 
     // API Gateway 自身が返す 4XX/5XX にも CORS ヘッダを付与
     api.addGatewayResponse("Default4xxCors", {
@@ -412,6 +418,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       getPiece,
       updatePiece,
       deletePiece,
+      authRegister,
     ];
 
     // Lambda エラー監視：全関数のエラー合計が 1 以上でアラーム

--- a/composables/useAuth.ts
+++ b/composables/useAuth.ts
@@ -1,0 +1,104 @@
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PASSWORD_MIN_LENGTH = 8;
+const PASSWORD_UPPERCASE_REGEX = /[A-Z]/;
+const PASSWORD_LOWERCASE_REGEX = /[a-z]/;
+const PASSWORD_DIGIT_REGEX = /\d/;
+
+export interface RegisterResult {
+  success: boolean;
+  error?: string;
+}
+
+export const useAuth = () => {
+  const validateEmail = (email: string): boolean => {
+    if (!email || !email.trim()) return false;
+    return EMAIL_REGEX.test(email.trim());
+  };
+
+  const validatePassword = (password: string): boolean => {
+    if (!password) return false;
+    if (password.length < PASSWORD_MIN_LENGTH) return false;
+    if (!PASSWORD_UPPERCASE_REGEX.test(password)) return false;
+    if (!PASSWORD_LOWERCASE_REGEX.test(password)) return false;
+    if (!PASSWORD_DIGIT_REGEX.test(password)) return false;
+    return true;
+  };
+
+  const getPasswordValidationError = (password: string): string | null => {
+    if (!password) {
+      return "Password is required";
+    }
+    if (password.length < PASSWORD_MIN_LENGTH) {
+      return `Password must be at least ${PASSWORD_MIN_LENGTH} characters long`;
+    }
+    if (!PASSWORD_UPPERCASE_REGEX.test(password)) {
+      return "Password must contain at least one uppercase letter";
+    }
+    if (!PASSWORD_LOWERCASE_REGEX.test(password)) {
+      return "Password must contain at least one lowercase letter";
+    }
+    if (!PASSWORD_DIGIT_REGEX.test(password)) {
+      return "Password must contain at least one digit";
+    }
+    return null;
+  };
+
+  const register = async (email: string, password: string): Promise<RegisterResult> => {
+    // Client-side validation
+    if (!validateEmail(email)) {
+      return {
+        success: false,
+        error: "Please enter a valid email address",
+      };
+    }
+
+    const passwordError = getPasswordValidationError(password);
+    if (passwordError) {
+      return {
+        success: false,
+        error: passwordError,
+      };
+    }
+
+    try {
+      const config = useRuntimeConfig();
+      const apiBase = config.public.apiBaseUrl;
+
+      const response = await fetch(`${apiBase}/auth/register`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          email,
+          password,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => ({}));
+        return {
+          success: false,
+          error: errorData.message || "Registration failed. Please try again.",
+        };
+      }
+
+      return {
+        success: true,
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "A network error occurred. Please try again.",
+      };
+    }
+  };
+
+  return {
+    validateEmail,
+    validatePassword,
+    getPasswordValidationError,
+    register,
+  };
+};

--- a/pages/auth/user-register.vue
+++ b/pages/auth/user-register.vue
@@ -1,0 +1,231 @@
+<template>
+  <div class="register-page">
+    <div class="register-container">
+      <h1>新規登録</h1>
+
+      <form @submit.prevent="handleRegister">
+        <div class="form-group">
+          <label for="email">メールアドレス</label>
+          <input
+            id="email"
+            v-model="form.email"
+            type="email"
+            placeholder="your@example.com"
+            required
+          />
+          <p v-if="errors.email" class="error-message">{{ errors.email }}</p>
+        </div>
+
+        <div class="form-group">
+          <label for="password">パスワード</label>
+          <input
+            id="password"
+            v-model="form.password"
+            type="password"
+            placeholder="At least 8 characters"
+            required
+          />
+          <p v-if="errors.password" class="error-message">
+            {{ errors.password }}
+          </p>
+          <p class="password-requirements">
+            パスワードは8文字以上で、大文字・小文字・数字を含む必要があります
+          </p>
+        </div>
+
+        <button type="submit" :disabled="isLoading">
+          {{ isLoading ? "登録中..." : "登録" }}
+        </button>
+      </form>
+
+      <div v-if="successMessage" class="success-message">
+        <p>{{ successMessage }}</p>
+        <NuxtLink to="/auth/login">ログイン画面へ</NuxtLink>
+      </div>
+
+      <div class="login-link">
+        <p>
+          既にアカウントをお持ちですか？
+          <NuxtLink to="/auth/login">ログイン</NuxtLink>
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive } from "vue";
+
+const { validateEmail, register } = useAuth();
+
+const form = reactive({
+  email: "",
+  password: "",
+});
+
+const errors = reactive({
+  email: "",
+  password: "",
+});
+
+const isLoading = ref(false);
+const successMessage = ref("");
+
+const handleRegister = async () => {
+  // Reset messages
+  errors.email = "";
+  errors.password = "";
+  successMessage.value = "";
+
+  // Validate email
+  if (!validateEmail(form.email)) {
+    errors.email = "有効なメールアドレスを入力してください";
+    return;
+  }
+
+  isLoading.value = true;
+
+  try {
+    const result = await register(form.email, form.password);
+
+    if (result.success) {
+      successMessage.value = "確認メールを送信しました。メールをご確認ください。";
+      form.email = "";
+      form.password = "";
+    } else {
+      // Check which field the error is about
+      if (result.error?.includes("email")) {
+        errors.email = result.error;
+      } else if (result.error?.includes("password")) {
+        errors.password = result.error;
+      } else if (result.error?.includes("already")) {
+        errors.email = "このメールアドレスは既に登録されています";
+      } else {
+        errors.email = result.error || "登録に失敗しました";
+      }
+    }
+  } finally {
+    isLoading.value = false;
+  }
+};
+</script>
+
+<style scoped>
+.register-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f5f5f5;
+}
+
+.register-container {
+  background: white;
+  padding: 2rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+}
+
+h1 {
+  text-align: center;
+  margin-bottom: 1.5rem;
+  color: #333;
+}
+
+form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+label {
+  font-weight: 500;
+  color: #333;
+}
+
+input[type="email"],
+input[type="password"] {
+  padding: 0.75rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 1rem;
+  transition: border-color 0.2s;
+}
+
+input[type="email"]:focus,
+input[type="password"]:focus {
+  outline: none;
+  border-color: #4a90e2;
+}
+
+.error-message {
+  color: #e74c3c;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+.password-requirements {
+  color: #666;
+  font-size: 0.875rem;
+  margin: 0;
+}
+
+button {
+  padding: 0.75rem;
+  background-color: #4a90e2;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+button:hover:not(:disabled) {
+  background-color: #357abd;
+}
+
+button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.success-message {
+  background-color: #d4edda;
+  color: #155724;
+  padding: 1rem;
+  border-radius: 4px;
+  text-align: center;
+}
+
+.success-message a {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: #155724;
+  text-decoration: underline;
+}
+
+.login-link {
+  text-align: center;
+  margin-top: 1rem;
+  color: #666;
+}
+
+.login-link a {
+  color: #4a90e2;
+  text-decoration: none;
+}
+
+.login-link a:hover {
+  text-decoration: underline;
+}
+</style>


### PR DESCRIPTION
## Summary
ユーザー登録機能（003-2）の実装が完了しました。Cognito User Pool を利用した新規ユーザー登録フロー全体をカバーしています。

- フロントエンド：登録フォーム + クライアント側バリデーション
- バックエンド：POST /auth/register Lambda + Cognito SignUp 統合
- 包括的なテストスイート（Lambda 18テスト全て通過）

## Implementation Details

### バックエンド
- `backend/src/auth/register.ts`: Cognito SignUp を呼び出す Lambda 関数
- `backend/src/utils/schemas.ts`: Zod を使用した email/password バリデーション
- CDK: `/auth/register` ルート追加、Cognito SignUp 権限付与

### フロントエンド
- `pages/auth/user-register.vue`: 登録フォーム UI（メール、パスワード入力）
- `composables/useAuth.ts`: バリデーション + API 呼び出しロジック

### テスト
- リクエストボディ検証（null、配列、無効な JSON）
- メールアドレス形式チェック（RFC 5322）
- パスワード強度要件チェック（8字以上、大文字・小文字・数字）
- Cognito エラーハンドリング（ユーザー重複、パスワード不適切）
- 成功時の 201 Created レスポンス

## Test Results
✅ Lambda テスト: 18/18 通過
✅ ESLint: 0 errors
✅ Prettier: 完了

## Related Issues
- 003-1: AWS Cognito User Pool セットアップ（完了）
- 003-2: ユーザー登録（本 PR）
- 003-3: ユーザーログイン（実装予定）
- 003-4: ユーザーログアウト（実装予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)