### PR TITLE
fix: remove read-only email_verified attribute from cognito signup

### DIFF
--- a/backend/src/auth/register.ts
+++ b/backend/src/auth/register.ts
@@ -25,10 +25,6 @@ export const handler = createHandler(async (event) => {
           Name: "email",
           Value: input.email,
         },
-        {
-          Name: "email_verified",
-          Value: "false",
-        },
       ],
     });
 


### PR DESCRIPTION
## Summary
- Remove `email_verified` attribute from Cognito SignUp request
- `email_verified` is a read-only attribute and cannot be set during registration

## Why
The read-only attribute was causing Cognito SignUp to fail with an error, resulting in Internal Server Error responses to the client.

## Test plan
- [x] Backend tests pass
- [x] Frontend tests pass
- [ ] Verify user registration works in production
- [ ] Test email verification flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * ユーザー登録プロセスでのメール認証状態の処理を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->