### PR TITLE
docs: ユーザー登録機能の実装内容をドキュメントに反映

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,23 +31,25 @@
 
 ```
 classical-music-lake/
-├── pages/                        # Nuxt ページ（ルーティング）
-│   ├── index.vue                 # トップページ（管理者向けリンクセクション含む）
-│   ├── index.test.ts             # トップページのコンポーネントテスト
-│   ├── listening-logs/           # 視聴ログ関連ページ
-│   │   ├── index.vue             # 一覧
-│   │   ├── new.vue               # 新規作成
-│   │   └── [id]/
-│   │       ├── index.vue         # 詳細
-│   │       └── edit.vue          # 編集
-│   └── pieces/                   # 楽曲マスタ関連ページ
-│       ├── index.vue             # 一覧
-│       ├── new.vue               # 新規作成
-│       └── [id]/
-│           └── edit.vue          # 編集
-├── components/                   # 共通UIコンポーネント
-├── composables/                  # Vue Composables（共通ロジック）
-├── types/                        # フロントエンド共通型定義
+├── app/                          # Nuxt アプリケーションディレクトリ
+│   ├── pages/                    # Nuxt ページ（ルーティング）
+│   │   ├── index.vue             # トップページ（管理者向けリンクセクション含む）
+│   │   ├── auth/
+│   │   │   └── user-register.vue # ユーザー登録ページ
+│   │   ├── listening-logs/       # 視聴ログ関連ページ
+│   │   │   ├── index.vue         # 一覧
+│   │   │   ├── new.vue           # 新規作成
+│   │   │   └── [id]/
+│   │   │       ├── index.vue     # 詳細
+│   │   │       └── edit.vue      # 編集
+│   │   └── pieces/               # 楽曲マスタ関連ページ
+│   │       ├── index.vue         # 一覧
+│   │       ├── new.vue           # 新規作成
+│   │       └── [id]/
+│   │           └── edit.vue      # 編集
+│   ├── components/               # 共通UIコンポーネント
+│   ├── composables/              # Vue Composables（共通ロジック）
+│   └── types/                    # フロントエンド共通型定義
 ├── backend/
 │   └── src/
 │       ├── auth/                 # 認証 Lambda 関数
@@ -126,11 +128,11 @@ classical-music-lake/
 
 ## 設計上の制約・トレードオフ
 
-### 認証なし（現在）
+### 認証（実装済み）
 
-- **理由**: MVP として機能優先
-- **リスク**: 誰でもデータ操作可能
-- **対応予定**: Cognito によるユーザー認証（フェーズ3）
+- **状態**: AWS Cognito によるユーザー登録を実装済み（メールアドレス + パスワード）
+- **実装内容**: `POST /auth/register` エンドポイント、Cognito User Pool、メール確認フロー
+- **残タスク**: ログイン・ログアウト・JWT 検証による API 保護は将来フェーズで実装予定
 
 ### DynamoDB Scan による全件取得
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -32,13 +32,12 @@ cdk bootstrap aws://<AWS_ACCOUNT_ID>/ap-northeast-1
 
 ### 必要な GitHub Secrets
 
-| シークレット名          | 説明                        |
-| ----------------------- | --------------------------- |
-| `AWS_ACCESS_KEY_ID`     | AWSアクセスキーID           |
-| `AWS_SECRET_ACCESS_KEY` | AWSシークレットアクセスキー |
+| シークレット名       | 説明                                          |
+| -------------------- | --------------------------------------------- |
+| `AWS_ROLE_TO_ASSUME` | GitHub OIDC で AssumeRole する IAM ロール ARN |
 
 > `AWS_REGION` と `API_BASE_URL` はワークフロー内で自動取得するため不要。
-> **⚠️ セキュリティ注意事項**: 長期 AWS アクセスキー（`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`）は常設シークレットとして管理しており、漏洩リスクが存在します。将来的には **GitHub OIDC + IAM AssumeRole** を使ったキーレス認証への移行を推奨します。
+> 認証方式は **GitHub OIDC + IAM AssumeRole** によるキーレス認証。長期 AWS アクセスキーは使用しない。
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -9,6 +9,7 @@
 ### 1.2 主要機能
 
 - **視聴ログ管理**: CD・配信サービス等で聴いた録音の記録
+- **ユーザー登録**: メールアドレスとパスワードによるアカウント作成（メール確認付き）
 
 ### 1.3 スコープ
 
@@ -50,11 +51,12 @@
 
 #### フロントエンド Composables
 
-| Composable         | 役割                                               |
-| ------------------ | -------------------------------------------------- |
-| `useApiBase`       | API Gateway のベース URL を返す                    |
-| `usePieces`        | 曲一覧を取得する                                   |
-| `useRatingDisplay` | 評価値（0〜5）を星文字列に変換する (`ratingStars`) |
+| Composable         | 役割                                                      |
+| ------------------ | --------------------------------------------------------- |
+| `useApiBase`       | API Gateway のベース URL を返す                           |
+| `useAuth`          | ユーザー登録・認証関連の API 呼び出しと入力バリデーション |
+| `usePieces`        | 曲一覧を取得する                                          |
+| `useRatingDisplay` | 評価値（0〜5）を星文字列に変換する (`ratingStars`)        |
 
 #### フロントエンド コンポーネント
 
@@ -155,10 +157,46 @@ interface Piece {
 - **ベースURL**: `https://{api-gateway-url}/prod`
 - **認証**: AWS Cognito User Pool (Bearer Token)
   - 認証が必要なエンドポイント: `/listening-logs/*`（読み取り・書き込み）
-  - 公開エンドポイント: `/pieces/*`（読み取りのみ）
+  - 公開エンドポイント: `/auth/*`、`/pieces/*`
 - **CORS**: CloudFront URL のみ許可（プリフライト・GatewayResponse の両方で設定）
 
-### 4.2 視聴ログAPI
+### 4.2 認証API
+
+#### `POST /auth/register`
+
+新規ユーザーを登録する
+
+**リクエスト**
+
+```json
+POST /auth/register
+Content-Type: application/json
+
+{
+  "email": "user@example.com",
+  "password": "SecurePass1"
+}
+```
+
+**レスポンス**
+
+- 成功: `200 OK`（空レスポンス）— Cognito がメール確認メールを送信する
+- バリデーションエラー: `400 Bad Request`
+- 既存ユーザー: `409 Conflict`
+
+**パスワードルール**（Cognito User Pool 設定）
+
+- 8文字以上
+- 大文字・小文字・数字をそれぞれ1文字以上含む
+
+**フロー**
+
+1. フロントエンドがメールアドレス・パスワードを送信
+2. Lambda が Cognito `signUp` を呼び出す
+3. Cognito がメール確認リンクを送信
+4. ユーザーがメールリンクをクリックして確認完了
+
+### 4.3 視聴ログAPI
 
 #### `GET /listening-logs`
 
@@ -277,7 +315,7 @@ DELETE /listening-logs/{id}
 
 - 成功: `204 No Content`
 
-### 4.3 エラーレスポンス一覧
+### 4.4 エラーレスポンス一覧
 
 全エラーレスポンスは以下の形式で返される：
 
@@ -293,7 +331,7 @@ DELETE /listening-logs/{id}
 | `404 Not Found`             | リソース未存在     | 指定IDの視聴ログが存在しない                   |
 | `500 Internal Server Error` | サーバー内部エラー | DynamoDB接続エラーなど予期しないエラー         |
 
-### 4.4 データバリデーションルール
+### 4.5 データバリデーションルール
 
 #### 視聴ログ（ListeningLog）
 
@@ -328,9 +366,20 @@ DELETE /listening-logs/{id}
 #### Lambda
 
 - **ランタイム**: Node.js 24.x
-- **関数数**: 5個（視聴ログ用CRUD操作）
+- **関数数**: 6個（視聴ログ用CRUD操作 × 5 + ユーザー登録 × 1）
 - **環境変数**:
   - `DYNAMO_TABLE_LISTENING_LOGS`
+  - `COGNITO_USER_POOL_ID`（認証系 Lambda で使用）
+  - `COGNITO_CLIENT_ID`（認証系 Lambda で使用）
+
+#### Cognito
+
+- **User Pool**: メールアドレスベースのサインアップ/サインイン
+- **自己登録**: 有効（`selfSignUpEnabled: true`）
+- **メール確認**: 必須（確認コードをメール送信）
+- **パスワードポリシー**: 8文字以上、大文字・小文字・数字を必須
+- **App Client**: SRP 認証フロー（シークレットなし）
+- **CDK Output**: `CognitoUserPoolId`, `CognitoClientId`, `CognitoUserPoolArn`
 
 #### API Gateway
 
@@ -551,6 +600,7 @@ cdk deploy
 
 | 日付       | バージョン | 変更内容                                                                             |
 | ---------- | ---------- | ------------------------------------------------------------------------------------ |
+| 2026-03-21 | 1.3.0      | AWS Cognito ユーザー登録機能を追加（`POST /auth/register`、`useAuth` composable）    |
 | 2026-03-17 | 1.2.5      | CDK CORS 設定を DRY 化（`addCors` ヘルパー）、型定義ファイルの管理方針コメントを整備 |
 | 2026-03-17 | 1.2.4      | Create入力の実体バリデーション強化（空白のみ禁止・最大文字数制限）                   |
 | 2026-03-16 | 1.2.3      | Zod を導入しリクエストボディのパース処理にバリデーションを統合                       |


### PR DESCRIPTION
## Summary

- **SPEC.md**: 主要機能にユーザー登録を追加、`useAuth` composable を追加、`POST /auth/register` API仕様を追加、Cognito リソース情報を追加、変更履歴 v1.3.0 を追加
- **ARCHITECTURE.md**: ディレクトリ構造を `app/` プレフィックスに修正、「認証なし（現在）」の制約セクションを実装済みの内容に更新
- **OPERATIONS.md**: GitHub Secrets を旧来の長期アクセスキーから現在使用中の OIDC（`AWS_ROLE_TO_ASSUME`）に修正

## Test plan

- [ ] ドキュメントの内容が実装コードと一致していることを確認
- [ ] SPEC.md の `POST /auth/register` 仕様が `backend/src/auth/register.ts` と整合していることを確認
- [ ] OPERATIONS.md の GitHub Secrets が `.github/workflows/deploy.yml` と整合していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ユーザー登録機能の実装を文書化しました
  * AWS Cognito統合による認証機能の詳細を追加しました
  * インフラストラクチャ管理のセキュリティ設定を更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->