### PR TITLE
fix: add auth/login Lambda and API Gateway route to CDK stack

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -171,6 +171,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const deletePiece = fn("DeletePiece", "pieces/delete.ts");
 
     const authRegister = fn("AuthRegister", "auth/register.ts");
+    const authLogin = fn("AuthLogin", "auth/login.ts");
 
     // -------------------------
     // Cognito 権限付与
@@ -183,7 +184,13 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     });
     authRegister.addToRolePolicy(cognitoRegisterPolicy);
 
-    // TODO: ログイン・ログアウト機能は 003-3, 003-4 で実装予定
+    // auth/login: InitiateAuth を実行
+    const cognitoLoginPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["cognito-idp:InitiateAuth"],
+      resources: [userPool.userPoolArn],
+    });
+    authLogin.addToRolePolicy(cognitoLoginPolicy);
 
     // -------------------------
     // DynamoDB 権限付与
@@ -281,6 +288,10 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const authRegisterResource = authResource.addResource("register");
     authRegisterResource.addMethod("POST", integ(authRegister));
 
+    // /auth/login (ログインフロー: 認証不要)
+    const authLoginResource = authResource.addResource("login");
+    authLoginResource.addMethod("POST", integ(authLogin));
+
     // -------------------------
     // S3 + CloudFront (SPA ホスティング)
     // -------------------------
@@ -367,6 +378,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       updatePiece,
       deletePiece,
       authRegister,
+      authLogin,
     ].forEach((fn) => {
       fn.addEnvironment("CORS_ALLOW_ORIGIN", this.corsAllowOrigin);
     });
@@ -377,6 +389,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     this.addCors(piecesResource, ["GET", "POST", "OPTIONS"]);
     this.addCors(pieceResource, ["GET", "PUT", "DELETE", "OPTIONS"]);
     this.addCors(authRegisterResource, ["POST", "OPTIONS"]);
+    this.addCors(authLoginResource, ["POST", "OPTIONS"]);
 
     // API Gateway 自身が返す 4XX/5XX にも CORS ヘッダを付与
     api.addGatewayResponse("Default4xxCors", {
@@ -419,6 +432,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       updatePiece,
       deletePiece,
       authRegister,
+      authLogin,
     ];
 
     // Lambda エラー監視：各関数ごとにアラーム作成


### PR DESCRIPTION
## Summary

- 003-3 でログイン Lambda (`auth/login.ts`) を実装したが、CDK スタックへの追加が漏れており `/auth/login` エンドポイントが本番環境に存在しなかった
- `AuthLogin` Lambda 関数・IAM ポリシー・API Gateway ルート・CORS・CloudWatch アラームを追加

## 原因

Playwright で本番環境のログイン動作確認を行った際に `net::ERR_FAILED` が発生し発覚。

## Test plan

- [ ] CDK デプロイ後、`POST /auth/login` が 200 を返すことを確認
- [ ] ログイン画面からの実際のログインが成功することを確認

Closes #139 に関連（メール確認フローは別 issue で対応予定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ログイン機能を新たに追加しました。ユーザーはAPIを通じて認証情報を検証できるようになります。
  * ログインエンドポイントに対するCORS対応を実装し、クロスオリジンリクエストに対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->