### PR TITLE
style: 全体的な配色を古びた羊皮紙風テーマに変更

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -36,8 +36,8 @@ watch(
 
 body {
   font-family: "Georgia", serif;
-  background-color: #faf8f5;
-  color: #2c2c2c;
+  background-color: #e8d9b8;
+  color: #2d1f0e;
 }
 
 .app-header {
@@ -68,7 +68,7 @@ body {
 }
 
 .nav-links a {
-  color: #d4c9a8;
+  color: #d4b896;
   text-decoration: none;
   font-size: 0.95rem;
   transition: color 0.2s;
@@ -82,8 +82,8 @@ body {
 .logout-button {
   margin-left: auto;
   background: none;
-  border: 1px solid #d4c9a8;
-  color: #d4c9a8;
+  border: 1px solid #d4b896;
+  color: #d4b896;
   padding: 0.35rem 0.9rem;
   border-radius: 4px;
   font-size: 0.9rem;
@@ -94,7 +94,7 @@ body {
 }
 
 .logout-button:hover {
-  background-color: #d4c9a8;
+  background-color: #d4b896;
   color: #1a1a2e;
 }
 

--- a/app/assets/css/global.css
+++ b/app/assets/css/global.css
@@ -15,8 +15,8 @@
 }
 
 .btn-secondary {
-  background: #f0ece4;
-  color: #333;
+  background: #dfd0b2;
+  color: #1a1a2e;
   padding: 0.6rem 1.2rem;
   border: none;
   border-radius: 6px;
@@ -27,7 +27,7 @@
 }
 
 .btn-secondary:hover {
-  background: #e0d8cc;
+  background: #cfc0a0;
 }
 
 .btn-danger {

--- a/app/components/ListeningLogForm.vue
+++ b/app/components/ListeningLogForm.vue
@@ -99,8 +99,8 @@ function handleSubmit() {
 
 <style scoped>
 .log-form {
-  background: #fff;
-  border: 1px solid #e0d8cc;
+  background: #f2e6c9;
+  border: 1px solid #b8995e;
   border-radius: 12px;
   padding: 2rem;
   max-width: 720px;
@@ -133,12 +133,12 @@ input[type="text"],
 input[type="datetime-local"],
 textarea,
 select {
-  border: 1px solid #d0c8bc;
+  border: 1px solid #b8995e;
   border-radius: 6px;
   padding: 0.6rem 0.8rem;
   font-size: 0.95rem;
   font-family: inherit;
-  background: #faf8f5;
+  background: #faf3e0;
   transition: border-color 0.2s;
 }
 
@@ -158,7 +158,7 @@ textarea:focus {
   border: none;
   font-size: 1.6rem;
   cursor: pointer;
-  color: #d0c8bc;
+  color: #c2a878;
   transition: color 0.15s;
 }
 

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -100,22 +100,23 @@ const handleLogin = async () => {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background-color: #f5f5f5;
+  background-color: #e8d9b8;
 }
 
 .login-container {
-  background: white;
+  background: #f2e6c9;
   padding: 2rem;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(61, 36, 9, 0.15);
   width: 100%;
   max-width: 400px;
+  border: 1px solid #b8995e;
 }
 
 h1 {
   text-align: center;
   margin-bottom: 1.5rem;
-  color: #333;
+  color: #1a1a2e;
 }
 
 form {
@@ -132,26 +133,27 @@ form {
 
 label {
   font-weight: 500;
-  color: #333;
+  color: #1a1a2e;
 }
 
 input[type="email"],
 input[type="password"] {
   padding: 0.75rem;
-  border: 1px solid #ddd;
+  border: 1px solid #b8995e;
   border-radius: 4px;
   font-size: 1rem;
+  background: #faf3e0;
   transition: border-color 0.2s;
 }
 
 input[type="email"]:focus,
 input[type="password"]:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: #1a1a2e;
 }
 
 .error-message {
-  color: #e74c3c;
+  color: #a83218;
   font-size: 0.875rem;
   margin: 0;
 }
@@ -162,8 +164,8 @@ input[type="password"]:focus {
 
 button {
   padding: 0.75rem;
-  background-color: #4a90e2;
-  color: white;
+  background-color: #1a1a2e;
+  color: #fff;
   border: none;
   border-radius: 4px;
   font-size: 1rem;
@@ -173,22 +175,22 @@ button {
 }
 
 button:hover:not(:disabled) {
-  background-color: #357abd;
+  background-color: #2d2d50;
 }
 
 button:disabled {
-  background-color: #ccc;
+  background-color: #a89070;
   cursor: not-allowed;
 }
 
 .register-link {
   text-align: center;
   margin-top: 1rem;
-  color: #666;
+  color: #7a5c38;
 }
 
 .register-link a {
-  color: #4a90e2;
+  color: #2d2d50;
   text-decoration: none;
 }
 

--- a/app/pages/auth/user-register.vue
+++ b/app/pages/auth/user-register.vue
@@ -116,22 +116,23 @@ const handleRegister = async () => {
   justify-content: center;
   align-items: center;
   min-height: 100vh;
-  background-color: #f5f5f5;
+  background-color: #e8d9b8;
 }
 
 .register-container {
-  background: white;
+  background: #f2e6c9;
   padding: 2rem;
   border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 2px 8px rgba(61, 36, 9, 0.15);
   width: 100%;
   max-width: 400px;
+  border: 1px solid #b8995e;
 }
 
 h1 {
   text-align: center;
   margin-bottom: 1.5rem;
-  color: #333;
+  color: #1a1a2e;
 }
 
 form {
@@ -148,40 +149,41 @@ form {
 
 label {
   font-weight: 500;
-  color: #333;
+  color: #1a1a2e;
 }
 
 input[type="email"],
 input[type="password"] {
   padding: 0.75rem;
-  border: 1px solid #ddd;
+  border: 1px solid #b8995e;
   border-radius: 4px;
   font-size: 1rem;
+  background: #faf3e0;
   transition: border-color 0.2s;
 }
 
 input[type="email"]:focus,
 input[type="password"]:focus {
   outline: none;
-  border-color: #4a90e2;
+  border-color: #1a1a2e;
 }
 
 .error-message {
-  color: #e74c3c;
+  color: #a83218;
   font-size: 0.875rem;
   margin: 0;
 }
 
 .password-requirements {
-  color: #666;
+  color: #7a5c38;
   font-size: 0.875rem;
   margin: 0;
 }
 
 button {
   padding: 0.75rem;
-  background-color: #4a90e2;
-  color: white;
+  background-color: #1a1a2e;
+  color: #fff;
   border: none;
   border-radius: 4px;
   font-size: 1rem;
@@ -191,17 +193,17 @@ button {
 }
 
 button:hover:not(:disabled) {
-  background-color: #357abd;
+  background-color: #2d2d50;
 }
 
 button:disabled {
-  background-color: #ccc;
+  background-color: #a89070;
   cursor: not-allowed;
 }
 
 .success-message {
-  background-color: #d4edda;
-  color: #155724;
+  background-color: #d8e8c0;
+  color: #2a5218;
   padding: 1rem;
   border-radius: 4px;
   text-align: center;
@@ -210,18 +212,18 @@ button:disabled {
 .success-message a {
   display: inline-block;
   margin-top: 0.5rem;
-  color: #155724;
+  color: #2a5218;
   text-decoration: underline;
 }
 
 .login-link {
   text-align: center;
   margin-top: 1rem;
-  color: #666;
+  color: #7a5c38;
 }
 
 .login-link a {
-  color: #4a90e2;
+  color: #2d2d50;
   text-decoration: none;
 }
 

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -45,8 +45,8 @@
 
 .card {
   display: block;
-  background: #fff;
-  border: 1px solid #e0d8cc;
+  background: #f2e6c9;
+  border: 1px solid #b8995e;
   border-radius: 12px;
   padding: 2rem;
   text-decoration: none;

--- a/app/pages/listening-logs/[id]/index.vue
+++ b/app/pages/listening-logs/[id]/index.vue
@@ -61,8 +61,8 @@ const { ratingStars } = useRatingDisplay();
 }
 
 .log-detail {
-  background: #fff;
-  border: 1px solid #e0d8cc;
+  background: #f2e6c9;
+  border: 1px solid #b8995e;
   border-radius: 12px;
   padding: 2rem;
   max-width: 720px;
@@ -71,7 +71,7 @@ const { ratingStars } = useRatingDisplay();
 .log-detail header {
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid #e0d8cc;
+  border-bottom: 1px solid #b8995e;
 }
 
 .log-detail h1 {

--- a/app/pages/listening-logs/index.vue
+++ b/app/pages/listening-logs/index.vue
@@ -78,8 +78,8 @@ async function handleDelete(id: string) {
 }
 
 .log-item {
-  background: #fff;
-  border: 1px solid #e0d8cc;
+  background: #f2e6c9;
+  border: 1px solid #b8995e;
   border-radius: 10px;
   padding: 1.2rem 1.5rem;
   display: flex;


### PR DESCRIPTION
## Summary

- ページ背景を `#faf8f5` → `#e8d9b8`（焼けた羊皮紙色）に変更
- カード・フォーム背景を `#fff` → `#f2e6c9`（薄い羊皮紙色）に変更
- ボーダーを `#e0d8cc` → `#b8995e`（錆びた金茶）に変更
- 入力フィールド背景を `#faf3e0`（クリーム）に変更
- ヘッダー・ボタンのアクセントカラーはネイビー（`#1a1a2e`）を維持

## 変更ファイル

- `app/app.vue` — body背景・ヘッダー
- `app/assets/css/global.css` — 共通ボタン
- `app/components/ListeningLogForm.vue` — フォーム
- `app/pages/index.vue` — トップページ
- `app/pages/listening-logs/index.vue` — 一覧ページ
- `app/pages/listening-logs/[id]/index.vue` — 詳細ページ
- `app/pages/auth/login.vue` — ログインページ
- `app/pages/auth/user-register.vue` — 登録ページ

## Test plan

- [ ] 各ページの背景・カード色が羊皮紙風になっていることを目視確認
- [ ] ヘッダー・ボタンがネイビー系のままであることを確認
- [ ] フロントエンドテスト通過（CI）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
- アプリケーション全体の配色をウォームトーンの新しいカラーパレットに更新しました。ページ背景、フォーム要素、ボタン、カードコンポーネント、テキスト色、入力フィールドのボーダーなど、複数の UI 要素の色を一貫して変更しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->