### PR TITLE
feat: atomic design の layouts 層を導入

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,7 +1,11 @@
 import type { StorybookConfig } from "@storybook-vue/nuxt";
 
 const config: StorybookConfig = {
-  stories: ["../app/components/**/*.mdx", "../app/components/**/*.stories.@(js|jsx|ts|tsx|mdx)"],
+  stories: [
+    "../app/components/**/*.mdx",
+    "../app/components/**/*.stories.@(js|jsx|ts|tsx|mdx)",
+    "../app/layouts/**/*.stories.@(js|jsx|ts|tsx|mdx)",
+  ],
   addons: ["@storybook/addon-a11y", "@storybook/addon-docs"],
   framework: "@storybook-vue/nuxt",
   viteFinal: async (config, { configType }) => {

--- a/app/app.vue
+++ b/app/app.vue
@@ -1,31 +1,8 @@
 <template>
-  <div class="app">
-    <header class="app-header">
-      <nav>
-        <NuxtLink to="/" class="logo">🎵 Classical Music Lake</NuxtLink>
-        <ul class="nav-links">
-          <li><NuxtLink to="/listening-logs">鑑賞記録</NuxtLink></li>
-        </ul>
-        <button v-if="isLoggedIn" class="logout-button" @click="logout">ログアウト</button>
-      </nav>
-    </header>
-    <main class="app-main">
-      <NuxtPage />
-    </main>
-  </div>
+  <NuxtLayout>
+    <NuxtPage />
+  </NuxtLayout>
 </template>
-
-<script setup lang="ts">
-const { isAuthenticated, logout } = useAuth();
-const route = useRoute();
-const isLoggedIn = ref(isAuthenticated());
-watch(
-  () => route.path,
-  () => {
-    isLoggedIn.value = isAuthenticated();
-  }
-);
-</script>
 
 <style>
 * {
@@ -38,69 +15,5 @@ body {
   font-family: "Georgia", serif;
   background-color: #e8d9b8;
   color: #2d1f0e;
-}
-
-.app-header {
-  background-color: #1a1a2e;
-  color: #fff;
-  padding: 1rem 2rem;
-}
-
-.app-header nav {
-  display: flex;
-  align-items: center;
-  gap: 2rem;
-  max-width: 1200px;
-  margin: 0 auto;
-}
-
-.logo {
-  font-size: 1.3rem;
-  font-weight: bold;
-  color: #fff;
-  text-decoration: none;
-}
-
-.nav-links {
-  list-style: none;
-  display: flex;
-  gap: 1.5rem;
-}
-
-.nav-links a {
-  color: #d4b896;
-  text-decoration: none;
-  font-size: 0.95rem;
-  transition: color 0.2s;
-}
-
-.nav-links a:hover,
-.nav-links a.router-link-active {
-  color: #fff;
-}
-
-.logout-button {
-  margin-left: auto;
-  background: none;
-  border: 1px solid #d4b896;
-  color: #d4b896;
-  padding: 0.35rem 0.9rem;
-  border-radius: 4px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
-}
-
-.logout-button:hover {
-  background-color: #d4b896;
-  color: #1a1a2e;
-}
-
-.app-main {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
 }
 </style>

--- a/app/layouts/auth.stories.ts
+++ b/app/layouts/auth.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import AuthLayout from "./auth.vue";
+
+const meta: Meta<typeof AuthLayout> = {
+  title: "Layouts/AuthLayout",
+  component: AuthLayout,
+};
+
+export default meta;
+type Story = StoryObj<typeof AuthLayout>;
+
+export const Default: Story = {
+  render: () => ({
+    components: { AuthLayout },
+    template: `
+      <AuthLayout>
+        <p style="padding: 2rem; text-align: center;">認証ページのコンテンツがここに入ります。</p>
+      </AuthLayout>
+    `,
+  }),
+};

--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/app/layouts/default.stories.ts
+++ b/app/layouts/default.stories.ts
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import DefaultLayout from "./default.vue";
+
+const meta: Meta<typeof DefaultLayout> = {
+  title: "Layouts/DefaultLayout",
+  component: DefaultLayout,
+};
+
+export default meta;
+type Story = StoryObj<typeof DefaultLayout>;
+
+export const LoggedIn: Story = {
+  render: () => ({
+    components: { DefaultLayout },
+    template: `
+      <DefaultLayout>
+        <p style="padding: 1rem;">ページコンテンツがここに入ります。</p>
+      </DefaultLayout>
+    `,
+  }),
+};

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -1,0 +1,94 @@
+<script setup lang="ts">
+const { isAuthenticated, logout } = useAuth();
+const route = useRoute();
+const isLoggedIn = ref(isAuthenticated());
+watch(
+  () => route.path,
+  () => {
+    isLoggedIn.value = isAuthenticated();
+  }
+);
+</script>
+
+<template>
+  <div class="app">
+    <header class="app-header">
+      <nav>
+        <NuxtLink to="/" class="logo">🎵 Classical Music Lake</NuxtLink>
+        <ul class="nav-links">
+          <li><NuxtLink to="/listening-logs">鑑賞記録</NuxtLink></li>
+        </ul>
+        <button v-if="isLoggedIn" class="logout-button" @click="logout">ログアウト</button>
+      </nav>
+    </header>
+    <main class="app-main">
+      <slot />
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.app-header {
+  background-color: #1a1a2e;
+  color: #fff;
+  padding: 1rem 2rem;
+}
+
+.app-header nav {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.logo {
+  font-size: 1.3rem;
+  font-weight: bold;
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+}
+
+.nav-links a {
+  color: #d4b896;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s;
+}
+
+.nav-links a:hover,
+.nav-links a.router-link-active {
+  color: #fff;
+}
+
+.logout-button {
+  margin-left: auto;
+  background: none;
+  border: 1px solid #d4b896;
+  color: #d4b896;
+  padding: 0.35rem 0.9rem;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.logout-button:hover {
+  background-color: #d4b896;
+  color: #1a1a2e;
+}
+
+.app-main {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+</style>

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+definePageMeta({ layout: "auth" });
+
 const { login } = useAuth();
 const router = useRouter();
 

--- a/app/pages/auth/user-register.vue
+++ b/app/pages/auth/user-register.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+definePageMeta({ layout: "auth" });
+
 const { validateEmail, register } = useAuth();
 
 const errors = reactive({


### PR DESCRIPTION
## Summary
- `app/layouts/default.vue` を作成し、ヘッダー・ナビ・ログアウトボタン付き共通レイアウトを `app.vue` から抽出
- `app/layouts/auth.vue` を作成し、ヘッダーなしの認証ページ専用レイアウトを追加
- `app.vue` を `<NuxtLayout><NuxtPage />` のみに簡略化（グローバルリセット CSS は残存）
- `auth/login`・`auth/user-register` に `definePageMeta({ layout: 'auth' })` を追加
- Storybook の stories パスに `app/layouts/**` を追加し、各レイアウトの story を作成

## Test plan
- [ ] トップページ・鑑賞記録ページでヘッダーが表示されることを確認
- [ ] ログイン・ユーザー登録ページでヘッダーが表示されないことを確認
- [ ] ログアウトボタンが認証済み時のみ表示されることを確認
- [ ] Storybook で `Layouts/DefaultLayout`・`Layouts/AuthLayout` が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)