### PR TITLE
CI: Add Storybook build step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -113,6 +113,9 @@ jobs:
           # CloudFormation Outputs から取得した API Gateway URL をセット
           NUXT_PUBLIC_API_BASE_URL: ${{ steps.get-api-url.outputs.api_url }}
 
+      - name: Build Storybook
+        run: npm run build-storybook
+
       # ----------------------------------------
       # CDK Bootstrap（bootstrap スタックを最新バージョンに更新）
       # CDKToolkit が参照する ECR リポジトリが削除されていると bootstrap が


### PR DESCRIPTION
## 概要

デプロイワークフローに Storybook のビルドステップを追加しました。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- GitHub Actions のデプロイワークフロー（`.github/workflows/deploy.yml`）に `npm run build-storybook` を実行するステップを追加
- API Gateway URL の設定後、CDK Bootstrap 前のタイミングで Storybook をビルド

## テスト

- [x] 既存テストがすべて通ることを確認した（CI/CD パイプラインで検証）

## チェックリスト

- [x] コーディング規約に従っている
- [x] ワークフロー設定の変更のため、実装ドキュメント更新は不要

https://claude.ai/code/session_01C32dYySrm9qAQECMcZ9gZc