### PR TITLE
fix: storybook の iframe プレビューが X-Frame-Options: DENY でブロックされる問題を修正

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -354,6 +354,10 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
             override: true,
           },
           contentTypeOptions: { override: true },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: "frame-ancestors 'self';",
+            override: true,
+          },
           xssProtection: { protection: true, modeBlock: true, override: true },
           referrerPolicy: {
             referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,


### PR DESCRIPTION
## Summary

- Storybook の `/storybook/*` behavior に適用されていた `X-Frame-Options: DENY` ヘッダーが、Storybook のプレビュー iframe をブロックしていた
- Storybook 専用の `StorybookHeadersPolicy` を作成し、`X-Frame-Options` を除外
- SPA 側の `SecurityHeadersPolicy`（`X-Frame-Options: DENY`）は変更なし

## Root Cause

CloudFront の `securityHeadersPolicy` が `/storybook/*` behavior にも適用されていたため、Storybook がコンポーネントプレビューに使用する `<iframe>` が `X-Frame-Options: DENY` によってブロックされていた。

## Test plan

- [ ] デプロイ後、`/storybook/` にアクセスしてプレビュー iframe が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CloudFrontのセキュリティヘッダーポリシーを最適化しました。Storybook向けに新たなセキュリティポリシーを導入し、HSTS、XSS保護、リファラーポリシーを適用しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->