### PR TITLE
fix: storybook デプロイ後に SPA デプロイでファイルが削除される問題を修正

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -432,7 +432,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       },
     });
 
-    new s3deploy.BucketDeployment(this, "SpaDeployment", {
+    const spaDeployment = new s3deploy.BucketDeployment(this, "SpaDeployment", {
       sources: [s3deploy.Source.asset(path.join(__dirname, "../../.output/public"))],
       destinationBucket: spaBucket,
       distribution,
@@ -475,13 +475,17 @@ function handler(event) {
       }
     );
 
-    new s3deploy.BucketDeployment(this, "StorybookDeployment", {
+    // SpaDeployment は destinationKeyPrefix なし + prune: true のためバケット全体を管理する。
+    // 並列実行時に StorybookDeployment が先に完了すると storybook ファイルが削除されるため、
+    // StorybookDeployment が SpaDeployment の完了後に実行されるよう依存関係を設定する。
+    const storybookDeployment = new s3deploy.BucketDeployment(this, "StorybookDeployment", {
       sources: [s3deploy.Source.asset(path.join(__dirname, "../../storybook-static"))],
       destinationBucket: spaBucket,
       destinationKeyPrefix: "storybook",
       distribution,
       distributionPaths: ["/storybook/*"],
     });
+    storybookDeployment.node.addDependency(spaDeployment);
 
     // -------------------------
     // CloudWatch アラーム


### PR DESCRIPTION
## 問題

`SpaDeployment` と `StorybookDeployment` が CloudFormation 上で並列実行されており、実行順序によって Storybook の静的ファイルが S3 から削除されていた。

### 原因

- `SpaDeployment` は `destinationKeyPrefix` なし + `prune: true`（デフォルト）のため、S3 バケット**全体**を管理し `storybook/*` ファイルも削除対象
- 並列実行時に `StorybookDeployment` が先に完了すると、後から完了した `SpaDeployment` が storybook ファイルを削除してしまう
- PR #154 のデプロイで実際にこの問題が発生し、`https://d1mj7hc7q03mpd.cloudfront.net/storybook/` が Nuxt の 404 ページを返す状態になっていた

### 修正

`storybookDeployment.node.addDependency(spaDeployment)` を追加し、CloudFormation レベルで `StorybookDeployment` が必ず `SpaDeployment` の**後に**実行されるよう順序を固定した。

これにより毎回の実行順序が保証される：
1. `SpaDeployment` 完了（バケット全体を prune + SPA ファイルをアップロード）
2. `StorybookDeployment` 完了（`storybook/` プレフィックスに storybook ファイルをアップロード）

## Test plan

- [ ] CDK デプロイが成功すること
- [ ] `https://d1mj7hc7q03mpd.cloudfront.net/storybook/` で Storybook が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * デプロイメント処理の実行順序を明確化し、デプロイ中のデータ上書きリスクを軽減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->