### PR TITLE
docs: 004-001 認証コード入力画面の設計

### DIFF
--- a/.claude/commands/start-01-requirement.md
+++ b/.claude/commands/start-01-requirement.md
@@ -16,8 +16,6 @@
   - 採番ルールは `001`, `002` のように単純なインクリメントで、3桁でゼロ埋め
   - PR 提出直前に `/docs/features/` 内で同一の `{index}` が存在しないか再スキャンし、競合があれば再採番する
 - `/docs/features/{index}-{feature-title}/requirement.md` を作成し、要件を記載する。
-- `/docs/features/{index}-{feature-title}/checklist.md` を作成し、各workの進捗が記録できるようにする。
-  - 設計、設計レビュー、実装、受け入れ　で進捗を記録
 
 ## ルール
 

--- a/.claude/commands/start-02-splitting-work.md
+++ b/.claude/commands/start-02-splitting-work.md
@@ -16,6 +16,8 @@
 ## 4. タスク分割
 
 - `/docs/features/{index}-{feature-title}/requirement.md`の内容をもとに、`/docs/features/{index}-{feature-title}/{index}-{index-of-work}-{work}/work.md` にそれぞれファイルを配置する
+- `/docs/features/{index}-{feature-title}/checklist.md` を作成し、各workの進捗が記録できるようにする。
+  - 設計、設計レビュー、実装、受け入れ　で進捗を記録
 
 ## 5. `work.md`に記載する内容
 

--- a/.claude/commands/start-03-design.md
+++ b/.claude/commands/start-03-design.md
@@ -12,6 +12,7 @@
 ## 3. レビュー結果の反映
 
 - `design.md`に記載されたレビュー結果をもとに修正する。
+- `/docs/features/{index}-{feature-title}/checklist.md` に現状を記録する。
 
 ## 4. mainブランチへPRを発行
 

--- a/.claude/commands/start-04-implement.md
+++ b/.claude/commands/start-04-implement.md
@@ -16,6 +16,7 @@
 - リファクタリングが完了した後には必ずテストを実行すること。
 - eslintやprettier等の静的解析ツールを実行すること。
 - 完了したらコミットをする
+- `/docs/features/{index}-{feature-title}/checklist.md` に現状を記録する。
 
 ## 4. レビュー依頼
 

--- a/.claude/commands/start-05-accept.md
+++ b/.claude/commands/start-05-accept.md
@@ -11,3 +11,5 @@
 - `docs/ARCHITECTURE.md` アーキテクチャ設計書
 - `docs/SPEC.md` システム仕様書
 - `docs/OPERATIONS.md` 運用ドキュメント
+
+`/docs/features/{index}-{feature-title}/checklist.md` に現状を記録する。

--- a/docs/features/004-email-verification/004-001-verify-email-code/design.md
+++ b/docs/features/004-email-verification/004-001-verify-email-code/design.md
@@ -1,0 +1,138 @@
+# 004-001 認証コード入力画面・登録後の自動遷移 - 設計
+
+## 概要
+
+ユーザー登録完了後に認証コード入力画面へ自動遷移し、メールで受け取った認証コードを入力・検証する。
+コードが正しければ自動ログイン、誤りや期限切れの場合はエラーを表示し、再送信ボタンからコードを再発行できる。
+
+---
+
+## バックエンド設計
+
+### 新規 Lambda 関数
+
+#### `POST /auth/verify-email` — 認証コード確認
+
+- **ファイル**: `backend/src/auth/verify-email.ts`
+- **Cognito API**: `ConfirmSignUpCommand`
+- **リクエストボディ**: `{ email: string; code: string }`
+- **レスポンス**:
+  - 成功 (200): `{ message: string }`
+  - 失敗 (400): `{ error: "CodeMismatch" | "ExpiredCode", message: string }`
+  - 失敗 (400): `{ error: "NotAuthorizedException", message: string }` （既確認済み等）
+  - 失敗 (429): `{ error: "TooManyRequests", message: string }`
+
+**備考**: ConfirmSignUp 後の自動ログインはフロントエンドが既存の `/auth/login` を呼び出すことで実現する。そのため、このエンドポイントはトークンを返さない。
+
+#### `POST /auth/resend-verification-code` — 認証コード再送信
+
+- **ファイル**: `backend/src/auth/resend-verification-code.ts`
+- **Cognito API**: `ResendConfirmationCodeCommand`
+- **リクエストボディ**: `{ email: string }`
+- **レスポンス**:
+  - 成功 (200): `{ message: string }`
+  - 失敗 (400): `{ error: "UserAlreadyConfirmed", message: string }`
+  - 失敗 (429): `{ error: "TooManyRequests", message: string }`
+
+### CDK への追加
+
+- `authVerifyEmail` Lambda に `cognito-idp:ConfirmSignUp` の IAM 権限を付与
+- `authResendCode` Lambda に `cognito-idp:ResendConfirmationCode` の IAM 権限を付与
+- API Gateway に `/auth/verify-email (POST)` と `/auth/resend-verification-code (POST)` ルートを追加
+- 両エンドポイントに CORS 設定を追加（認証不要）
+
+---
+
+## フロントエンド設計
+
+### 画面遷移フロー
+
+```
+ユーザー登録フォーム送信
+        ↓ 成功
+verify-email ページへリダイレクト
+（ナビゲーションステートに email・password を渡す）
+        ↓ 認証コード入力・送信
+POST /auth/verify-email で確認
+        ↓ 成功
+POST /auth/login で自動ログイン
+        ↓ 成功
+ホーム画面へ遷移
+```
+
+**ナビゲーションステートの利用理由**: パスワードを URL クエリパラメータに含めないためにナビゲーションステートを使用する。
+
+### 新規ページ
+
+#### `app/pages/auth/verify-email.vue`
+
+- レイアウト: `auth`
+- ナビゲーションステートから `email`・`password` を取得する
+  - ステートが存在しない場合は登録ページへリダイレクト
+- `VerifyEmailTemplate` コンポーネントを使用
+
+### 新規コンポーネント（Atomic Design に従う）
+
+#### Template: `app/components/templates/VerifyEmailTemplate.vue`
+
+- Props: `email`, `isLoading`, `errors`, `infoMessage`
+- Emits: `submit(code: string)`, `resend()`
+- `VerifyEmailForm` Organism を内包する
+
+#### Organism: `app/components/organisms/VerifyEmailForm.vue`
+
+- **表示内容**:
+  - 登録したメールアドレスの表示（編集不可）
+  - 認証コード入力フィールド（数値 6 桁）
+  - 「確認する」送信ボタン
+  - 「再送信」ボタン
+  - エラーメッセージ表示エリア（`ErrorMessage` Atom を利用）
+  - 案内メッセージ表示エリア（再送信成功時等）
+
+### 既存ファイルの変更
+
+#### `app/pages/auth/user-register.vue`
+
+- 登録成功時の処理を変更:
+  - 現在: `successMessage` にメッセージをセット
+  - 変更後: `router.push('/auth/verify-email', { state: { email, password } })` でリダイレクト
+
+#### `app/composables/useAuth.ts`
+
+- `verifyEmail(email: string, code: string): Promise<VerifyEmailResult>` を追加
+  - `POST /auth/verify-email` を呼び出す
+- `resendVerificationCode(email: string): Promise<ResendCodeResult>` を追加
+  - `POST /auth/resend-verification-code` を呼び出す
+
+### 型定義の追加
+
+#### `app/composables/useAuth.ts` 内に追加
+
+```
+VerifyEmailResult:
+  success: boolean
+  error?: string
+  errorType?: "code_mismatch" | "expired_code" | "already_confirmed" | "general"
+
+ResendCodeResult:
+  success: boolean
+  error?: string
+```
+
+---
+
+## エラーハンドリング方針
+
+| エラー種別                       | 表示メッセージ                                         |
+| -------------------------------- | ------------------------------------------------------ |
+| CodeMismatch                     | 認証コードが正しくありません                           |
+| ExpiredCode                      | 認証コードの有効期限が切れています。再送信してください |
+| UserAlreadyConfirmed（再送信時） | このアカウントは既に確認済みです                       |
+| TooManyRequests                  | しばらく時間をおいてから再試行してください             |
+| その他                           | 予期しないエラーが発生しました                         |
+
+---
+
+## レビュー結果
+
+<!-- レビュアーはここにレビュー結果を記載してください -->


### PR DESCRIPTION
## Summary

- `docs/features/004-email-verification/004-001-verify-email-code/design.md` を追加
- バックエンド（新規 Lambda 2 本）・フロントエンド（新規ページ・コンポーネント・Composable 拡張）・CDK の設計を記載

## レビューポイント

- `POST /auth/verify-email` の成功レスポンスはメッセージのみとし、自動ログインはフロントエンドが既存の `/auth/login` を呼び出す方針で問題ないか
- パスワードをナビゲーションステートで verify-email ページへ渡す方式のセキュリティリスクに懸念はないか
- Atomic Design の層分けに問題はないか（Organism: VerifyEmailForm / Template: VerifyEmailTemplate）

## Test plan

- [ ] design.md の内容をレビューし、コメントを「レビュー結果」欄に記載する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * メール認証機能の設計ドキュメントを追加しました。

* **Chores**
  * 開発ワークフロー処理を更新し、進捗追跡のためのチェックリスト機能を導入しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->