### PR TITLE
Add custom domain support with Route 53 and ACM certificate

### DIFF
--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ClassicalMusicLakeStack, type StageName } from "../lib/classical-music-lake-stack";
+import { CertificateStack } from "../lib/certificate-stack";
 
 const app = new cdk.App();
 
@@ -16,11 +17,23 @@ const stageName = rawStageName as StageName;
 const stackName =
   stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
 
+// CloudFront の証明書は us-east-1 に配置する必要があるため独立したスタックで管理する
+// 前提: Route 53 で nocturne.app を登録済みであること（ホストゾーンが存在すること）
+const certStack = new CertificateStack(app, "CertificateStack", {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: "us-east-1",
+  },
+  crossRegionReferences: true,
+});
+
 new ClassicalMusicLakeStack(app, stackName, {
   stageName,
+  certificate: certStack.certificate,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
   },
   terminationProtection: stageName === "prod",
+  crossRegionReferences: true,
 });

--- a/cdk/lib/certificate-stack.ts
+++ b/cdk/lib/certificate-stack.ts
@@ -1,0 +1,27 @@
+import * as cdk from "aws-cdk-lib";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import type { Construct } from "constructs";
+
+export const ROOT_DOMAIN = "nocturne.app";
+
+export class CertificateStack extends cdk.Stack {
+  public readonly certificate: acm.ICertificate;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Route 53 で取得済みのホストゾーンを参照（ドメイン登録時に自動作成される）
+    const hostedZone = route53.HostedZone.fromLookup(this, "HostedZone", {
+      domainName: ROOT_DOMAIN,
+    });
+
+    // CloudFront は us-east-1 の証明書のみ対応のため、このスタックを us-east-1 にデプロイする
+    this.certificate = new acm.Certificate(this, "Certificate", {
+      domainName: ROOT_DOMAIN,
+      // ワイルドカードで staging.nocturne.app も同一証明書でカバー
+      subjectAlternativeNames: [`*.${ROOT_DOMAIN}`],
+      validation: acm.CertificateValidation.fromDns(hostedZone),
+    });
+  }
+}

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -1,4 +1,5 @@
 import * as cdk from "aws-cdk-lib";
+import type * as acm from "aws-cdk-lib/aws-certificatemanager";
 import * as dynamodb from "aws-cdk-lib/aws-dynamodb";
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as lambda from "aws-cdk-lib/aws-lambda";
@@ -7,6 +8,8 @@ import * as logs from "aws-cdk-lib/aws-logs";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import type { IResource } from "aws-cdk-lib/aws-apigateway";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as route53Targets from "aws-cdk-lib/aws-route53-targets";
 import * as s3 from "aws-cdk-lib/aws-s3";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
@@ -14,11 +17,13 @@ import * as s3deploy from "aws-cdk-lib/aws-s3-deployment";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import type { Construct } from "constructs";
 import * as path from "path";
+import { ROOT_DOMAIN } from "./certificate-stack";
 
 export type StageName = "staging" | "prod";
 
 export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
   stageName: StageName;
+  certificate?: acm.ICertificate;
 }
 
 export class ClassicalMusicLakeStack extends cdk.Stack {
@@ -27,8 +32,10 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ClassicalMusicLakeStackProps) {
     super(scope, id, props);
 
-    const { stageName } = props;
+    const { stageName, certificate } = props;
     const isProd = stageName === "prod";
+    const customDomain = isProd ? ROOT_DOMAIN : `staging.${ROOT_DOMAIN}`;
+    const frontendUrl = `https://${customDomain}`;
 
     // -------------------------
     // DynamoDB テーブル
@@ -115,8 +122,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
           authorizationCodeGrant: true,
         },
         scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
-        callbackUrls: ["https://classical-music-lake.example.com/auth/callback"],
-        logoutUrls: ["https://classical-music-lake.example.com/login"],
+        callbackUrls: [`${frontendUrl}/auth/callback`],
+        logoutUrls: [`${frontendUrl}/login`],
       },
       accessTokenValidity: cdk.Duration.minutes(60),
       idTokenValidity: cdk.Duration.minutes(60),
@@ -394,6 +401,10 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     );
 
     const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
+      ...(certificate && {
+        domainNames: [customDomain],
+        certificate,
+      }),
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -428,8 +439,27 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       ],
     });
 
-    // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
-    this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
+    // カスタムドメインが設定されている場合はそれを使用し、未設定時は CloudFront URL にフォールバック
+    this.corsAllowOrigin = certificate
+      ? frontendUrl
+      : `https://${distribution.distributionDomainName}`;
+
+    // Route 53 レコード作成（カスタムドメインが設定されている場合）
+    if (certificate) {
+      const hostedZone = route53.HostedZone.fromLookup(this, "HostedZone", {
+        domainName: ROOT_DOMAIN,
+      });
+      new route53.ARecord(this, "AliasRecord", {
+        zone: hostedZone,
+        recordName: customDomain,
+        target: route53.RecordTarget.fromAlias(new route53Targets.CloudFrontTarget(distribution)),
+      });
+      new route53.AaaaRecord(this, "AliasRecordAAAA", {
+        zone: hostedZone,
+        recordName: customDomain,
+        target: route53.RecordTarget.fromAlias(new route53Targets.CloudFrontTarget(distribution)),
+      });
+    }
     [
       listeningLogsList,
       listeningLogsGet,
@@ -610,13 +640,20 @@ function handler(event) {
 
     new cdk.CfnOutput(this, "SpaUrl", {
       value: this.corsAllowOrigin,
-      description: "CloudFront URL (フロントエンド)",
+      description: "フロントエンド URL (カスタムドメインまたは CloudFront URL)",
     });
 
     new cdk.CfnOutput(this, "StorybookUrl", {
       value: `${this.corsAllowOrigin}/storybook/`,
       description: "Storybook URL",
     });
+
+    if (certificate) {
+      new cdk.CfnOutput(this, "CustomDomain", {
+        value: frontendUrl,
+        description: "カスタムドメイン (nocturne.app)",
+      });
+    }
 
     new cdk.CfnOutput(this, "CognitoUserPoolId", {
       value: userPool.userPoolId,

--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -14,6 +14,9 @@
         "esbuild": "^0.27.4",
         "ts-node": "^10.9.0",
         "typescript": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.14.0"
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -485,9 +485,18 @@ Authorization: Bearer {accessToken}
 - **パブリックアクセス**: ブロック（CloudFront経由のみ）
 - **削除ポリシー**: DESTROY（自動削除）
 
+#### Route 53 / ACM
+
+- **ドメイン**: `nocturne.app`（prod）/ `staging.nocturne.app`（staging）
+- **証明書**: `nocturne.app` + `*.nocturne.app`（ワイルドカード）を ACM で管理
+- **証明書リージョン**: `us-east-1`（CloudFront の要件）
+- **スタック**: `CertificateStack`（us-east-1）として独立管理し、メインスタックへ `crossRegionReferences` で渡す
+- **前提**: Route 53 でドメイン登録済みであること（ホストゾーンが存在すること）
+
 #### CloudFront
 
 - **用途**: SPAの配信
+- **カスタムドメイン**: `nocturne.app`（prod）/ `staging.nocturne.app`（staging）
 - **エラーハンドリング**: 404/403 → index.html（SPA対応）
 - **プロトコル**: HTTPS強制
 
@@ -692,6 +701,7 @@ cdk deploy
 
 | 日付       | バージョン | 変更内容                                                                                 |
 | ---------- | ---------- | ---------------------------------------------------------------------------------------- |
+| 2026-03-22 | 1.4.0      | Route 53 カスタムドメイン対応（nocturne.app）、ACM 証明書・CertificateStack 追加         |
 | 2026-03-21 | 1.3.1      | ログアウト機能追加（useAuth: logout/isAuthenticated、auth ミドルウェア、ナビバーボタン） |
 | 2026-03-21 | 1.3.0      | AWS Cognito ユーザー登録機能を追加（`POST /auth/register`、`useAuth` composable）        |
 | 2026-03-17 | 1.2.5      | CDK CORS 設定を DRY 化（`addCors` ヘルパー）、型定義ファイルの管理方針コメントを整備     |


### PR DESCRIPTION
## 概要

CloudFront に ACM 証明書を使用したカスタムドメイン対応を追加しました。`nocturne.app`（本番）と `staging.nocturne.app`（ステージング）でアクセス可能になります。

## 変更の種類

- [x] 新機能
- [x] ドキュメント

## 変更内容

### インフラストラクチャ
- **CertificateStack 新規作成**: ACM 証明書を `us-east-1` で管理する独立スタック
  - `nocturne.app` + `*.nocturne.app`（ワイルドカード）の証明書を作成
  - Route 53 DNS 検証で自動的に証明書を検証
  
- **ClassicalMusicLakeStack の拡張**:
  - `certificate` プロパティを `ClassicalMusicLakeStackProps` に追加
  - CloudFront Distribution にカスタムドメインと証明書を設定
  - Route 53 A/AAAA レコードを作成し、CloudFront にエイリアス設定
  - CORS オリジンをカスタムドメイン（設定時）または CloudFront URL に動的に切り替え
  - Cognito コールバック URL を環境に応じた動的 URL に変更

- **app.ts の更新**:
  - CertificateStack をインスタンス化し、ClassicalMusicLakeStack に証明書を渡す
  - クロスリージョン参照を有効化（us-east-1 ↔ ap-northeast-1）

### ドキュメント
- `docs/SPEC.md` に Route 53 / ACM セクションを追加
- デプロイ前提条件（Route 53 でドメイン登録済み）を明記
- バージョン履歴に 1.4.0 を追加

## テスト

- [ ] ユニットテストを追加・更新した
- [ ] 既存テストがすべて通ることを確認した
- [ ] 動作確認をローカルで実施した

**注**: 本変更は CDK インフラストラクチャの追加であり、既存の Lambda/API ロジックに影響なし。デプロイ時に Route 53 ホストゾーンが存在することが前提条件です。

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] `docs/SPEC.md` を更新した

https://claude.ai/code/session_01Guz3uTNVrK1g69RENb3CZ4