### PR TITLE
fix: listenedAt を ISO 8601 UTC 形式に変換してから送信する

### DIFF
--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -127,7 +127,7 @@ describe("ListeningLogForm", () => {
       const wrapper = await mountSuspended(ListeningLogForm, {
         props: {
           initialValues: {
-            listenedAt: "2024-01-15T20:00",
+            listenedAt: "2024-01-15T20:00:00.000Z",
             composer: "ベートーヴェン",
             piece: "交響曲第9番",
             rating: 5,
@@ -143,6 +143,25 @@ describe("ListeningLogForm", () => {
       expect(emittedData.composer).toBe("ベートーヴェン");
       expect(emittedData.piece).toBe("交響曲第9番");
       expect(emittedData.isFavorite).toBe(true);
+    });
+
+    it("listenedAt は ISO 8601 UTC 形式（Zサフィックス）で emit される", async () => {
+      const wrapper = await mountSuspended(ListeningLogForm, {
+        props: {
+          initialValues: {
+            listenedAt: "2024-01-15T20:00:00.000Z",
+            composer: "ベートーヴェン",
+            piece: "交響曲第9番",
+            rating: 5,
+            isFavorite: false,
+          },
+        },
+      });
+
+      await wrapper.find("form").trigger("submit.prevent");
+      const emitted = wrapper.emitted("submit");
+      const emittedData = emitted![0][0] as Record<string, unknown>;
+      expect(emittedData.listenedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
     });
   });
 

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { nowAsDatetimeLocal } from "~/utils/date";
+import { nowAsDatetimeLocal, toDatetimeLocal } from "~/utils/date";
 import type { CreateListeningLogInput } from "~/types";
 
 const props = defineProps<{
@@ -14,7 +14,9 @@ const emit = defineEmits<{
 const { data: pieces, pending: piecesPending } = usePieces();
 
 const form = reactive<CreateListeningLogInput>({
-  listenedAt: props.initialValues?.listenedAt ?? nowAsDatetimeLocal(),
+  listenedAt: props.initialValues?.listenedAt
+    ? toDatetimeLocal(props.initialValues.listenedAt)
+    : nowAsDatetimeLocal(),
   composer: props.initialValues?.composer ?? "",
   piece: props.initialValues?.piece ?? "",
   rating: props.initialValues?.rating ?? 3,
@@ -30,7 +32,7 @@ function handlePieceSelect(e: Event) {
 }
 
 function handleSubmit() {
-  emit("submit", { ...form });
+  emit("submit", { ...form, listenedAt: new Date(form.listenedAt).toISOString() });
 }
 </script>
 

--- a/app/utils/date.test.ts
+++ b/app/utils/date.test.ts
@@ -22,12 +22,19 @@ describe("formatDatetime", () => {
 });
 
 describe("toDatetimeLocal", () => {
-  it("datetime-local input 用に YYYY-MM-DDTHH:mm 形式を返す", () => {
-    expect(toDatetimeLocal("2024-03-15T10:30:00.000Z")).toBe("2024-03-15T10:30");
+  it("YYYY-MM-DDTHH:mm 形式（datetime-local input 用）を返す", () => {
+    const result = toDatetimeLocal("2024-03-15T10:30:00.000Z");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
   });
 
-  it("秒以降を切り捨てる", () => {
-    expect(toDatetimeLocal("2024-12-31T23:59:59.999Z")).toBe("2024-12-31T23:59");
+  it("ローカル時刻に変換する", () => {
+    const isoString = "2024-03-15T10:30:00.000Z";
+    const expected = (() => {
+      const date = new Date(isoString);
+      date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+      return date.toISOString().slice(0, 16);
+    })();
+    expect(toDatetimeLocal(isoString)).toBe(expected);
   });
 });
 

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -3,7 +3,11 @@ export const formatDate = (isoString: string): string => isoString.slice(0, 10);
 export const formatDatetime = (isoString: string): string =>
   isoString.replace("T", " ").slice(0, 16);
 
-export const toDatetimeLocal = (isoString: string): string => isoString.slice(0, 16);
+export const toDatetimeLocal = (isoString: string): string => {
+  const date = new Date(isoString);
+  date.setMinutes(date.getMinutes() - date.getTimezoneOffset());
+  return date.toISOString().slice(0, 16);
+};
 
 export const nowAsDatetimeLocal = (): string => {
   const now = new Date();

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -120,7 +120,7 @@ interface ListeningLog {
 #### バリデーション
 
 - `rating`: 1〜5の範囲
-- `listenedAt`: ISO 8601形式の日時文字列
+- `listenedAt`: ISO 8601形式の日時文字列（UTC、Zサフィックス必須。例: `2024-01-15T19:30:00.000Z`）。フロントエンドは `datetime-local` 入力値をローカル時刻として `toISOString()` で変換して送信する
 - `composer`: 空文字・空白のみ不可、最大100文字
 - `piece`: 空文字・空白のみ不可、最大200文字
 - `memo`: 最大1000文字


### PR DESCRIPTION
## 原因

`datetime-local` input の値（`YYYY-MM-DDTHH:mm`）をそのまま API に送信していたため、バックエンドの `z.iso.datetime({ offset: false })` バリデーションで **400 Bad Request** が発生し、新規記録の追加ができない状態だった。

バックエンドは `2024-01-15T19:30:00Z` のような **Z サフィックス付き UTC 形式**を要求している。

## 修正内容

### 即時修正
- `ListeningLogForm.vue` の `handleSubmit` で `new Date(form.listenedAt).toISOString()` を使い、UTC ISO 8601 形式に変換してから emit するよう修正

### 恒久的対策
- `toDatetimeLocal()` をタイムゾーン対応に修正（ISO UTC → ローカル `datetime-local` 形式への変換を正確化）
- `ListeningLogForm` の初期値設定で `initialValues.listenedAt` を `toDatetimeLocal()` 経由で変換し、編集フォームでのタイムゾーンずれも解消
- `listenedAt` が ISO 8601 UTC 形式で emit されることを検証するテストを追加（回帰防止）
- `SPEC.md` に `listenedAt` のフォーマット仕様を明記

## 検証フォーマット

| 送信フォーマット | バックエンド検証結果 |
|---|---|
| `2026-03-23T07:37` (修正前) | ❌ 400 Invalid ISO datetime |
| `2026-03-23T07:37:00Z` (修正後) | ✅ 201 Created |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * リスニングログのタイムゾーン処理を改善しました。ユーザーがローカル時刻で日時を入力すると、システムに送信される際に正しくUTC ISO 8601形式に変換されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->