### PR TITLE
ci: release PR に対してチェック CI を走らせないようにする

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   audit-frontend:
     name: Security (Frontend)
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
 
     steps:
@@ -33,7 +33,7 @@ jobs:
 
   audit-backend:
     name: Security (Backend)
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
 
     steps:
@@ -55,7 +55,7 @@ jobs:
 
   audit-cdk:
     name: Security (CDK)
-    if: github.actor != 'dependabot[bot]'
+    if: github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'release-please--')
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
   test-frontend:
     name: Frontend (Vitest)
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read
 
@@ -33,6 +34,7 @@ jobs:
   test-backend:
     name: Backend (Vitest)
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read
 
@@ -60,6 +62,7 @@ jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'release-please--') }}
     permissions:
       contents: read
 


### PR DESCRIPTION
test.yml と security.yml の各ジョブに if 条件を追加し、
release-please が作成する release PR（ブランチ名が
release-please-- で始まる）に対してはジョブをスキップする。

https://claude.ai/code/session_01976dGBfxKDyx8xobopUemh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * GitHub Workflowsの条件付き実行ロジックを最適化し、自動テストとセキュリティ監査ジョブの実行効率を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->