### PR TITLE
refactor: atom - ButtonPrimary.vue コンポーネントの作成 (#190)

### DIFF
--- a/app/components/atoms/ButtonPrimary.test.ts
+++ b/app/components/atoms/ButtonPrimary.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ButtonPrimary from "./ButtonPrimary.vue";
+
+describe("ButtonPrimary", () => {
+  it("スロットのテキストが描画される", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      slots: { default: "保存する" },
+    });
+    expect(wrapper.text()).toBe("保存する");
+  });
+
+  it("btn-primary クラスが付いている", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      slots: { default: "保存する" },
+    });
+    expect(wrapper.find("button.btn-primary").exists()).toBe(true);
+  });
+
+  it("デフォルトの type は button", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      slots: { default: "ボタン" },
+    });
+    expect(wrapper.find("button").attributes("type")).toBe("button");
+  });
+
+  it("type=submit を渡せる", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      props: { type: "submit" },
+      slots: { default: "送信" },
+    });
+    expect(wrapper.find("button").attributes("type")).toBe("submit");
+  });
+
+  it("disabled=true のとき button に disabled 属性が付く", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      props: { disabled: true },
+      slots: { default: "ログイン中..." },
+    });
+    expect(wrapper.find("button").attributes("disabled")).toBeDefined();
+  });
+
+  it("disabled=false のとき disabled 属性が付かない", async () => {
+    const wrapper = await mountSuspended(ButtonPrimary, {
+      props: { disabled: false },
+      slots: { default: "ログイン" },
+    });
+    expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
+  });
+});

--- a/app/components/atoms/ButtonPrimary.vue
+++ b/app/components/atoms/ButtonPrimary.vue
@@ -1,0 +1,12 @@
+<script setup lang="ts">
+defineProps<{
+  type?: "button" | "submit";
+  disabled?: boolean;
+}>();
+</script>
+
+<template>
+  <button class="btn-primary" :type="type ?? 'button'" :disabled="disabled">
+    <slot />
+  </button>
+</template>

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { describe, it, expect, vi } from "vitest";
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import ListeningLogForm from "./ListeningLogForm.vue";
+import ButtonPrimary from "../atoms/ButtonPrimary.vue";
 import type { Piece } from "~/types";
 
 const { mockPieces } = vi.hoisted(() => {
@@ -48,7 +49,9 @@ describe("ListeningLogForm", () => {
     });
 
     it("送信ラベルのデフォルトは「保存する」", async () => {
-      const wrapper = await mountSuspended(ListeningLogForm);
+      const wrapper = await mountSuspended(ListeningLogForm, {
+        global: { components: { ButtonPrimary } },
+      });
       expect(wrapper.find("button[type='submit']").text()).toBe("保存する");
     });
   });
@@ -100,6 +103,7 @@ describe("ListeningLogForm", () => {
     it("カスタムラベルが反映される", async () => {
       const wrapper = await mountSuspended(ListeningLogForm, {
         props: { submitLabel: "記録する" },
+        global: { components: { ButtonPrimary } },
       });
       expect(wrapper.find("button[type='submit']").text()).toBe("記録する");
     });

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -83,7 +83,7 @@ function handleSubmit() {
 
     <div class="form-actions">
       <NuxtLink to="/listening-logs" class="btn-secondary">キャンセル</NuxtLink>
-      <button type="submit" class="btn-primary">{{ submitLabel ?? "保存する" }}</button>
+      <ButtonPrimary type="submit">{{ submitLabel ?? "保存する" }}</ButtonPrimary>
     </div>
   </form>
 </template>

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -49,9 +49,9 @@ function handleSubmit() {
 
       <ErrorMessage v-if="props.errors.general" :message="props.errors.general" :center="true" />
 
-      <button type="submit" :disabled="props.isLoading">
+      <ButtonPrimary type="submit" :disabled="props.isLoading">
         {{ props.isLoading ? "ログイン中..." : "ログイン" }}
-      </button>
+      </ButtonPrimary>
     </form>
 
     <div class="register-link">
@@ -111,27 +111,6 @@ input[type="email"]:focus,
 input[type="password"]:focus {
   outline: none;
   border-color: #1e2d5a;
-}
-
-button {
-  padding: 0.75rem;
-  background-color: #1e2d5a;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-button:hover:not(:disabled) {
-  background-color: #2d2d50;
-}
-
-button:disabled {
-  background-color: #a89070;
-  cursor: not-allowed;
 }
 
 .register-link {

--- a/app/components/organisms/PieceForm.test.ts
+++ b/app/components/organisms/PieceForm.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceForm from "./PieceForm.vue";
+import ButtonPrimary from "../atoms/ButtonPrimary.vue";
 
 describe("PieceForm", () => {
   describe("デフォルト値でのレンダリング", () => {
@@ -10,7 +11,9 @@ describe("PieceForm", () => {
     });
 
     it("送信ラベルのデフォルトは「保存する」", async () => {
-      const wrapper = await mountSuspended(PieceForm);
+      const wrapper = await mountSuspended(PieceForm, {
+        global: { components: { ButtonPrimary } },
+      });
       expect(wrapper.find("button[type='submit']").text()).toBe("保存する");
     });
 
@@ -53,6 +56,7 @@ describe("PieceForm", () => {
     it("カスタムラベルが反映される", async () => {
       const wrapper = await mountSuspended(PieceForm, {
         props: { submitLabel: "登録する" },
+        global: { components: { ButtonPrimary } },
       });
       expect(wrapper.find("button[type='submit']").text()).toBe("登録する");
     });

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -49,7 +49,7 @@ function handleSubmit() {
 
     <div class="form-actions">
       <NuxtLink to="/pieces" class="btn-secondary">キャンセル</NuxtLink>
-      <button type="submit" class="btn-primary">{{ submitLabel ?? "保存する" }}</button>
+      <ButtonPrimary type="submit">{{ submitLabel ?? "保存する" }}</ButtonPrimary>
     </div>
   </form>
 </template>

--- a/app/components/organisms/UserRegisterForm.vue
+++ b/app/components/organisms/UserRegisterForm.vue
@@ -51,9 +51,9 @@ function handleSubmit() {
         </p>
       </div>
 
-      <button type="submit" :disabled="props.isLoading">
+      <ButtonPrimary type="submit" :disabled="props.isLoading">
         {{ props.isLoading ? "登録中..." : "登録" }}
-      </button>
+      </ButtonPrimary>
     </form>
 
     <div v-if="props.successMessage" class="success-message">
@@ -124,27 +124,6 @@ input[type="password"]:focus {
   color: #7a5c38;
   font-size: 0.875rem;
   margin: 0;
-}
-
-button {
-  padding: 0.75rem;
-  background-color: #1e2d5a;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-button:hover:not(:disabled) {
-  background-color: #2d2d50;
-}
-
-button:disabled {
-  background-color: #a89070;
-  cursor: not-allowed;
 }
 
 .success-message {

--- a/app/components/organisms/VerifyEmailForm.test.ts
+++ b/app/components/organisms/VerifyEmailForm.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import VerifyEmailForm from "./VerifyEmailForm.vue";
 import ErrorMessage from "../atoms/ErrorMessage.vue";
+import ButtonPrimary from "../atoms/ButtonPrimary.vue";
 
 describe("VerifyEmailForm", () => {
   const defaultProps = {
@@ -23,7 +24,10 @@ describe("VerifyEmailForm", () => {
     });
 
     it("「確認する」ボタンが表示される", async () => {
-      const wrapper = await mountSuspended(VerifyEmailForm, { props: defaultProps });
+      const wrapper = await mountSuspended(VerifyEmailForm, {
+        props: defaultProps,
+        global: { components: { ButtonPrimary } },
+      });
       expect(wrapper.find("button[type='submit']").text()).toBe("確認する");
     });
 
@@ -57,6 +61,7 @@ describe("VerifyEmailForm", () => {
     it("isLoading が true のとき確認ボタンが無効化される", async () => {
       const wrapper = await mountSuspended(VerifyEmailForm, {
         props: { ...defaultProps, isLoading: true },
+        global: { components: { ButtonPrimary } },
       });
       expect(wrapper.find("button[type='submit']").attributes("disabled")).toBeDefined();
     });

--- a/app/components/organisms/VerifyEmailForm.vue
+++ b/app/components/organisms/VerifyEmailForm.vue
@@ -47,9 +47,9 @@ function handleResend() {
 
       <p v-if="props.infoMessage" class="info-message">{{ props.infoMessage }}</p>
 
-      <button type="submit" :disabled="props.isLoading">
+      <ButtonPrimary type="submit" :disabled="props.isLoading">
         {{ props.isLoading ? "確認中..." : "確認する" }}
-      </button>
+      </ButtonPrimary>
     </form>
 
     <div class="resend-section">
@@ -123,27 +123,6 @@ input[type="text"]:focus {
   border-radius: 4px;
   font-size: 0.9rem;
   margin: 0;
-}
-
-button[type="submit"] {
-  padding: 0.75rem;
-  background-color: #1e2d5a;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  font-size: 1rem;
-  font-weight: 500;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-button[type="submit"]:hover:not(:disabled) {
-  background-color: #2d2d50;
-}
-
-button[type="submit"]:disabled {
-  background-color: #a89070;
-  cursor: not-allowed;
 }
 
 .resend-section {


### PR DESCRIPTION
## Summary

- `atoms/ButtonPrimary.vue` を新規作成（`type` / `disabled` プロパティ、デフォルトスロット対応）
- `LoginForm`, `UserRegisterForm`, `VerifyEmailForm` の scoped `button` スタイルを削除し `ButtonPrimary` へ置き換え
- `ListeningLogForm`, `PieceForm` の `class="btn-primary"` button を `ButtonPrimary` へ置き換え
- 各 Organism のテストに `ButtonPrimary` を明示的にインポートして対応

## Test plan

- [x] `ButtonPrimary.test.ts` 6件 新規追加・全パス
- [x] フロントエンドテスト 154件 全パス
- [x] バックエンドテスト 209件 全パス

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ButtonPrimary コンポーネント用の包括的なテストスイートを追加しました。プロップの動作とスロットのレンダリングを検証します。

* **リファクタリング**
  * 複数のフォームコンポーネント（ListeningLogForm、LoginForm、PieceForm、UserRegisterForm、VerifyEmailForm）を、新しい再利用可能な ButtonPrimary コンポーネントを使用するように更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->