### PR TITLE
test: vitestのオートインポートを設定

### DIFF
--- a/app/components/atoms/ButtonPrimary.test.ts
+++ b/app/components/atoms/ButtonPrimary.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ButtonPrimary from "./ButtonPrimary.vue";
 

--- a/app/components/atoms/EmptyState.test.ts
+++ b/app/components/atoms/EmptyState.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import EmptyState from "./EmptyState.vue";
 

--- a/app/components/atoms/ErrorMessage.test.ts
+++ b/app/components/atoms/ErrorMessage.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ErrorMessage from "./ErrorMessage.vue";
 

--- a/app/components/atoms/RequiredMark.test.ts
+++ b/app/components/atoms/RequiredMark.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import RequiredMark from "./RequiredMark.vue";
 

--- a/app/components/molecules/FavoriteIndicator.test.ts
+++ b/app/components/molecules/FavoriteIndicator.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import FavoriteIndicator from "./FavoriteIndicator.vue";
 

--- a/app/components/molecules/RatingDisplay.test.ts
+++ b/app/components/molecules/RatingDisplay.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import RatingDisplay from "./RatingDisplay.vue";
 

--- a/app/components/molecules/RatingSelector.test.ts
+++ b/app/components/molecules/RatingSelector.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import RatingSelector from "./RatingSelector.vue";
 

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -1,5 +1,4 @@
 import { ref } from "vue";
-import { describe, it, expect, vi } from "vitest";
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import ListeningLogForm from "./ListeningLogForm.vue";
 import ButtonPrimary from "../atoms/ButtonPrimary.vue";

--- a/app/components/organisms/PieceForm.test.ts
+++ b/app/components/organisms/PieceForm.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceForm from "./PieceForm.vue";
 import ButtonPrimary from "../atoms/ButtonPrimary.vue";

--- a/app/components/organisms/VerifyEmailForm.test.ts
+++ b/app/components/organisms/VerifyEmailForm.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import VerifyEmailForm from "./VerifyEmailForm.vue";
 import ErrorMessage from "../atoms/ErrorMessage.vue";

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useAuth, ACCESS_TOKEN_KEY, ID_TOKEN_KEY } from "./useAuth";
 
 const mockFetch = vi.fn();

--- a/app/composables/useListeningLogs.test.ts
+++ b/app/composables/useListeningLogs.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { useListeningLogs } from "./useListeningLogs";
 import { ACCESS_TOKEN_KEY, ID_TOKEN_KEY } from "./useAuth";

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -1,5 +1,4 @@
 import { ref } from "vue";
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { usePieces, usePiece } from "./usePieces";
 

--- a/app/composables/useRatingDisplay.test.ts
+++ b/app/composables/useRatingDisplay.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { useRatingDisplay } from "./useRatingDisplay";
 
 describe("useRatingDisplay", () => {

--- a/app/layouts/default.test.ts
+++ b/app/layouts/default.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import DefaultLayout from "./default.vue";
 

--- a/app/pages/auth/login.test.ts
+++ b/app/pages/auth/login.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import LoginPage from "./login.vue";
 

--- a/app/pages/index.test.ts
+++ b/app/pages/index.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import IndexPage from "./index.vue";
 

--- a/app/utils/date.test.ts
+++ b/app/utils/date.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { formatDate, formatDatetime, toDatetimeLocal, nowAsDatetimeLocal } from "./date";
 
 describe("formatDate", () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "strict": true,
     "noUnusedLocals": true,
-    "noUnusedParameters": true
+    "noUnusedParameters": true,
+    "types": ["vitest/globals"]
   },
   "exclude": ["backend/**", "cdk/**", "node_modules", ".nuxt", "dist", ".output"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineVitestConfig } from "@nuxt/test-utils/config";
 
 export default defineVitestConfig({
   test: {
+    globals: true,
     environment: "nuxt",
     environmentOptions: {
       nuxt: {


### PR DESCRIPTION
## 概要

closes #202

vitestのグローバルAPI（`describe`, `it`, `expect`, `vi`, `beforeEach` など）をオートインポートするよう設定しました。

## 変更内容

- `vitest.config.ts`: `globals: true` を追加
- `tsconfig.json`: `"types": ["vitest/globals"]` を追加してTypeScriptが型を認識できるように設定
- 全18テストファイル（`app/` 配下）から `import { ... } from "vitest"` を削除

## テスト結果

18ファイル・154テストすべてパス

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **テスト**
  * テスト環境の設定を最適化し、テスト実行基盤を改善しました。

* **その他**
  * 開発環境の構成を更新し、テストスイートの実行効率を向上させています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->