### PR TITLE
refactor: atom - FormGroup.vue コンポーネントの作成と適用

### DIFF
--- a/app/components/atoms/FormGroup.vue
+++ b/app/components/atoms/FormGroup.vue
@@ -1,0 +1,32 @@
+<script setup lang="ts">
+defineProps<{
+  label: string;
+  inputId?: string;
+  required?: boolean;
+  errorMessage?: string;
+}>();
+</script>
+
+<template>
+  <div class="form-group">
+    <label :for="inputId">
+      {{ label }}
+      <RequiredMark v-if="required" />
+    </label>
+    <slot />
+    <ErrorMessage v-if="errorMessage" :message="errorMessage" />
+  </div>
+</template>
+
+<style scoped>
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+label {
+  font-weight: 500;
+  color: #333;
+}
+</style>

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -38,36 +38,31 @@ function handleSubmit() {
 
 <template>
   <form class="log-form" @submit.prevent="handleSubmit">
-    <div class="form-group">
-      <label>鑑賞日時 <RequiredMark /></label>
+    <FormGroup label="鑑賞日時" required>
       <input v-model="form.listenedAt" type="datetime-local" required />
-    </div>
+    </FormGroup>
 
-    <div class="form-group">
-      <label>楽曲マスタから選択</label>
+    <FormGroup label="楽曲マスタから選択">
       <select class="piece-select" :disabled="piecesPending" @change="handlePieceSelect">
         <option value="">{{ piecesPending ? "読み込み中..." : "選択しない" }}</option>
         <option v-for="piece in pieces" :key="piece.id" :value="piece.id">
           {{ piece.title }} / {{ piece.composer }}
         </option>
       </select>
-    </div>
+    </FormGroup>
 
     <div class="form-row">
-      <div class="form-group">
-        <label>作曲家 <RequiredMark /></label>
+      <FormGroup label="作曲家" required>
         <TextInput v-model="form.composer" placeholder="例: ベートーヴェン" required />
-      </div>
-      <div class="form-group">
-        <label>曲名 <RequiredMark /></label>
+      </FormGroup>
+      <FormGroup label="曲名" required>
         <TextInput v-model="form.piece" placeholder="例: 交響曲第9番" required />
-      </div>
+      </FormGroup>
     </div>
 
-    <div class="form-group">
-      <label>評価</label>
+    <FormGroup label="評価">
       <RatingSelector v-model="form.rating" />
-    </div>
+    </FormGroup>
 
     <div class="form-group">
       <label class="checkbox-label">
@@ -76,10 +71,9 @@ function handleSubmit() {
       </label>
     </div>
 
-    <div class="form-group">
-      <label>感想・メモ</label>
+    <FormGroup label="感想・メモ">
       <textarea v-model="form.memo" rows="4" placeholder="自由に感想を書いてください..." />
-    </div>
+    </FormGroup>
 
     <div class="form-actions">
       <ButtonSecondary label="キャンセル" @click="$router.push('/listening-logs')" />
@@ -95,6 +89,9 @@ function handleSubmit() {
   border-radius: 12px;
   padding: 2rem;
   max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
 .form-row {
@@ -107,13 +104,6 @@ function handleSubmit() {
   display: flex;
   flex-direction: column;
   gap: 0.4rem;
-  margin-bottom: 1.2rem;
-}
-
-label {
-  font-size: 0.9rem;
-  font-weight: bold;
-  color: #444;
 }
 
 input[type="datetime-local"],

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -23,8 +23,7 @@ function handleSubmit() {
     <h1>ログイン</h1>
 
     <form @submit.prevent="handleSubmit">
-      <div class="form-group">
-        <label for="email">メールアドレス</label>
+      <FormGroup label="メールアドレス" input-id="email" :error-message="props.errors.email">
         <TextInput
           id="email"
           v-model="form.email"
@@ -32,11 +31,9 @@ function handleSubmit() {
           placeholder="your@example.com"
           required
         />
-        <ErrorMessage v-if="props.errors.email" :message="props.errors.email" />
-      </div>
+      </FormGroup>
 
-      <div class="form-group">
-        <label for="password">パスワード</label>
+      <FormGroup label="パスワード" input-id="password" :error-message="props.errors.password">
         <TextInput
           id="password"
           v-model="form.password"
@@ -44,8 +41,7 @@ function handleSubmit() {
           placeholder="パスワードを入力"
           required
         />
-        <ErrorMessage v-if="props.errors.password" :message="props.errors.password" />
-      </div>
+      </FormGroup>
 
       <ErrorMessage v-if="props.errors.general" :message="props.errors.general" :center="true" />
 
@@ -84,17 +80,6 @@ form {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-label {
-  font-weight: 500;
-  color: #1e2d5a;
 }
 
 .register-link {

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -31,15 +31,13 @@ function handleSubmit() {
 
 <template>
   <form class="piece-form" @submit.prevent="handleSubmit">
-    <div class="form-group">
-      <label for="title">曲名 <RequiredMark /></label>
+    <FormGroup label="曲名" input-id="title" required>
       <TextInput id="title" v-model="form.title" required placeholder="例：交響曲第9番" />
-    </div>
+    </FormGroup>
 
-    <div class="form-group">
-      <label for="composer">作曲家 <RequiredMark /></label>
+    <FormGroup label="作曲家" input-id="composer" required>
       <TextInput id="composer" v-model="form.composer" required placeholder="例：ベートーヴェン" />
-    </div>
+    </FormGroup>
 
     <div class="form-actions">
       <ButtonSecondary label="キャンセル" @click="$router.push('/pieces')" />
@@ -51,18 +49,9 @@ function handleSubmit() {
 <style scoped>
 .piece-form {
   max-width: 480px;
-}
-
-.form-group {
-  margin-bottom: 1.2rem;
-}
-
-.form-group label {
-  display: block;
-  font-weight: bold;
-  margin-bottom: 0.4rem;
-  color: #333;
-  font-size: 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
 }
 
 .form-actions {

--- a/app/components/organisms/UserRegisterForm.vue
+++ b/app/components/organisms/UserRegisterForm.vue
@@ -24,8 +24,7 @@ function handleSubmit() {
     <h1>新規登録</h1>
 
     <form @submit.prevent="handleSubmit">
-      <div class="form-group">
-        <label for="email">メールアドレス</label>
+      <FormGroup label="メールアドレス" input-id="email" :error-message="props.errors.email">
         <TextInput
           id="email"
           v-model="form.email"
@@ -33,11 +32,9 @@ function handleSubmit() {
           placeholder="your@example.com"
           required
         />
-        <ErrorMessage v-if="props.errors.email" :message="props.errors.email" />
-      </div>
+      </FormGroup>
 
-      <div class="form-group">
-        <label for="password">パスワード</label>
+      <FormGroup label="パスワード" input-id="password" :error-message="props.errors.password">
         <TextInput
           id="password"
           v-model="form.password"
@@ -45,11 +42,10 @@ function handleSubmit() {
           placeholder="At least 8 characters"
           required
         />
-        <ErrorMessage v-if="props.errors.password" :message="props.errors.password" />
         <p class="password-requirements">
           パスワードは8文字以上で、大文字・小文字・数字を含む必要があります
         </p>
-      </div>
+      </FormGroup>
 
       <ButtonPrimary type="submit" :disabled="props.isLoading">
         {{ props.isLoading ? "登録中..." : "登録" }}
@@ -91,17 +87,6 @@ form {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-}
-
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-label {
-  font-weight: 500;
-  color: #1e2d5a;
 }
 
 .password-requirements {


### PR DESCRIPTION
## 概要

Issue #194 に対応。Atomic Design の Atoms 層に `FormGroup.vue` を追加し、フォームの入力グループ構造（ラベル + 入力 + エラー）を一元管理するようにリファクタリングした。

## 変更内容

- `components/atoms/FormGroup.vue` を新規作成
  - `label` プロパティ: ラベルテキスト
  - `inputId` プロパティ（任意）: `<label for>` に対応
  - `required` プロパティ（任意）: `RequiredMark` を表示
  - `errorMessage` プロパティ（任意）: `ErrorMessage` を表示
  - デフォルトスロットで入力要素を受け取る
- 以下の4コンポーネントの重複構造を `FormGroup` に置き換え
  - `LoginForm.vue`
  - `UserRegisterForm.vue`
  - `ListeningLogForm.vue`
  - `PieceForm.vue`

## テスト

- 既存テスト 163件すべて通過

Closes #194

https://claude.ai/code/session_01H3LVRsUewEt8uZcR5ztSQG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * フォームコンポーネントの構造を最適化し、複数のフォーム全体でコード再利用性を向上させました。これにより、メンテナンス効率が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->