### PR TITLE
fix(cdk): add @types/node for TypeScript 6.0 compatibility

### DIFF
--- a/cdk/package-lock.json
+++ b/cdk/package-lock.json
@@ -10,6 +10,7 @@
         "constructs": "^10.0.0"
       },
       "devDependencies": {
+        "@types/node": "^25.5.0",
         "aws-cdk": "^2.1112.0",
         "esbuild": "^0.27.4",
         "ts-node": "^10.9.0",
@@ -566,6 +567,16 @@
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
+    },
+    "node_modules/@types/node": {
+      "version": "25.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
+      "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -1127,6 +1138,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -16,6 +16,7 @@
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@types/node": "^25.5.0",
     "aws-cdk": "^2.1112.0",
     "esbuild": "^0.27.4",
     "ts-node": "^10.9.0",

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -10,7 +10,8 @@
     "noUnusedParameters": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
   },
   "include": ["bin/**/*", "lib/**/*"],
   "exclude": ["node_modules", "dist", "cdk.out"]


### PR DESCRIPTION
## Summary

- TypeScript 6.0 では Node.js グローバル型（`process` 等）が自動インクルードされなくなった breaking change により CDK ビルドが失敗していた
- `cdk/tsconfig.json` に `"types": ["node"]` を追加
- `cdk/package.json` に `@types/node` を devDependency として明示追加
- `cdk/package-lock.json` を更新

## 原因

Dependabot PR #218 で `typescript` を 5.9.3 → 6.0.2 にアップグレードしたことで、以下のエラーが発生:

```
error TS2591: Cannot find name 'process'. Do you need to install type definitions for node?
Try `npm i --save-dev @types/node` and then add 'node' to the types field in your tsconfig.
```

## Test plan

- [ ] CDK の TypeScript ビルドが通ること（`tsc --noEmit`）
- [ ] Deploy CI が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 開発環境のTypeScript設定を更新し、Node.jsの型定義を含めるよう設定を調整しました。開発時の型チェックが強化されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->