### PR TITLE
fix: vitest worker 終了時の useAuth fetch pending エラーを修正

### DIFF
--- a/app/pages/listening-logs/[id]/index.test.ts
+++ b/app/pages/listening-logs/[id]/index.test.ts
@@ -3,6 +3,11 @@ import { flushPromises } from "@vue/test-utils";
 import ListeningLogDetailPage from "./index.vue";
 import type { ListeningLog } from "~/types";
 
+vi.mock("~/composables/useAuth", () => ({
+  ACCESS_TOKEN_KEY: "accessToken",
+  useAuth: vi.fn(),
+}));
+
 const mockDeleteLog = vi.fn();
 
 const sampleLog: ListeningLog = {


### PR DESCRIPTION
## Summary

- `app/pages/listening-logs/[id]/index.test.ts` に `vi.mock("~/composables/useAuth")` を追加
- auth ミドルウェア経由で `useAuth.ts` が評価され、`import { useRouter } from "#app"` がモジュール解決の fetch を発行していた
- vitest worker 終了時に fetch が pending のまま残り Unhandled Rejection が発生 → CI が exit code 1 で失敗していた

## Root Cause

```
ListeningLogDetailPage
  └─ definePageMeta({ middleware: "auth" })
       └─ middleware/auth.ts imports useAuth.ts
            └─ import { useRouter } from "#app"  ← fetch 発行
                                                    worker 終了時に pending → Unhandled Rejection
```

## Test plan

- [ ] `npm run test:frontend` がエラーなく通ること（31 files, 253 tests passed）
- [ ] 「Unhandled Errors」セクションが出力されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * テスト環境の認証関連の設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->