### PR TITLE
refactor: 所有権チェックロジックを getItemByOwner に共通化

### DIFF
--- a/backend/src/listening-logs/delete.test.ts
+++ b/backend/src/listening-logs/delete.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NotFound } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "./delete";
-import { dynamo } from "../utils/dynamodb";
+import { dynamo, getItemByOwner } from "../utils/dynamodb";
 
 vi.mock("../utils/dynamodb", () => ({
+  getItemByOwner: vi.fn(),
   dynamo: { send: vi.fn() },
   TABLE_LISTENING_LOGS: "test-listening-logs",
 }));
@@ -58,7 +60,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: undefined } as never);
+    vi.mocked(getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
@@ -68,31 +70,29 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("他ユーザーのアイテムを削除しようとした場合は 404 を返す（存在を隠蔽）", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: existingItem } as never);
+    vi.mocked(getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(makeEvent("abc-123", OTHER_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
-    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(1); // DeleteCommand は呼ばれない
+    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(0); // DeleteCommand は呼ばれない
   });
 
   it("userId が null のアイテム（未帰属データ）を削除しようとした場合は 404 を返す", async () => {
-    const nullUserItem = { ...existingItem, userId: null };
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: nullUserItem } as never);
+    vi.mocked(getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
   });
 
   it("正常削除して 204 を返す", async () => {
-    vi.mocked(dynamo.send)
-      .mockResolvedValueOnce({ Item: existingItem } as never) // GetCommand
-      .mockResolvedValueOnce({} as never); // DeleteCommand
+    vi.mocked(getItemByOwner).mockResolvedValueOnce(existingItem);
+    vi.mocked(dynamo.send).mockResolvedValueOnce({} as never); // DeleteCommand
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
-    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(1); // DeleteCommand のみ
   });
 
   it("DynamoDB エラー時に 500 を返す", async () => {
-    vi.mocked(dynamo.send).mockRejectedValueOnce(new Error("DynamoDB error"));
+    vi.mocked(getItemByOwner).mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/listening-logs/delete.ts
+++ b/backend/src/listening-logs/delete.ts
@@ -1,7 +1,6 @@
-import { DeleteCommand, GetCommand } from "@aws-sdk/lib-dynamodb";
-import createError from "http-errors";
+import { DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { StatusCodes } from "http-status-codes";
-import { dynamo, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
+import { dynamo, getItemByOwner, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler } from "../utils/middleware";
 import { getIdParam } from "../utils/path-params";
 import { getUserId } from "../utils/auth";
@@ -11,11 +10,7 @@ export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const userId = getUserId(event);
 
-  const result = await dynamo.send(
-    new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
-  );
-  const item = result.Item as ListeningLog | undefined;
-  if (!item || item.userId !== userId) throw new createError.NotFound("Listening log not found");
+  await getItemByOwner<ListeningLog>(TABLE_LISTENING_LOGS, id, userId);
 
   await dynamo.send(new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } }));
   return { statusCode: StatusCodes.NO_CONTENT, body: "" };

--- a/backend/src/listening-logs/update.test.ts
+++ b/backend/src/listening-logs/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Conflict } from "http-errors";
+import { Conflict, NotFound } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ListeningLog } from "../types";
 
@@ -7,8 +7,8 @@ import { handler } from "./update";
 import * as dynamodb from "../utils/dynamodb";
 
 vi.mock("../utils/dynamodb", () => ({
+  getItemByOwner: vi.fn(),
   updateItem: vi.fn(),
-  dynamo: { send: vi.fn() },
   TABLE_LISTENING_LOGS: "test-listening-logs",
 }));
 
@@ -163,7 +163,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("他ユーザーのアイテムを更新しようとした場合は 404 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), OTHER_USER_ID),
       mockContext,
@@ -174,8 +174,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("userId が null のアイテム（未帰属データ）を更新しようとした場合は 404 を返す", async () => {
-    const nullUserLog = { ...existingLog, userId: null };
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: nullUserLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
@@ -186,7 +185,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: undefined } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
@@ -196,7 +195,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("rating を含まない更新は rating のバリデーションをスキップする", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       isFavorite: true,
@@ -218,7 +217,7 @@ describe("PUT /listening-logs/:id (update)", () => {
       isFavorite: true,
       updatedAt: new Date().toISOString(),
     };
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce(updatedLog);
 
     const result = await handler(
@@ -236,7 +235,7 @@ describe("PUT /listening-logs/:id (update)", () => {
 
   it("updatedAt が更新されること", async () => {
     const now = new Date().toISOString();
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       updatedAt: now,
@@ -253,7 +252,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("id は上書きされない", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       updatedAt: new Date().toISOString(),
@@ -269,7 +268,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByOwner).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockRejectedValueOnce(
       new Conflict("Item was updated by another request")
     );
@@ -283,7 +282,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("DynamoDB エラー時に 500 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockRejectedValueOnce(new Error("DynamoDB error"));
+    vi.mocked(dynamodb.getItemByOwner).mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,

--- a/backend/src/listening-logs/update.ts
+++ b/backend/src/listening-logs/update.ts
@@ -1,7 +1,5 @@
-import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import createError from "http-errors";
 import { StatusCodes } from "http-status-codes";
-import { dynamo, updateItem, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
+import { getItemByOwner, updateItem, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler, jsonBodyParser } from "../utils/middleware";
 import { parseRequestBody } from "../utils/parsing";
 import { updateListeningLogSchema } from "../utils/schemas";
@@ -14,13 +12,7 @@ export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, updateListeningLogSchema);
   const userId = getUserId(event);
 
-  const existing = await dynamo.send(
-    new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
-  );
-  const existingItem = existing.Item as ListeningLog | undefined;
-  if (!existingItem || existingItem.userId !== userId) {
-    throw new createError.NotFound("Listening log not found");
-  }
+  await getItemByOwner<ListeningLog>(TABLE_LISTENING_LOGS, id, userId);
 
   const updated = await updateItem<ListeningLog>(TABLE_LISTENING_LOGS, id, input);
   return { statusCode: StatusCodes.OK, body: updated };

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -56,6 +56,19 @@ export async function scanAllItems<T>(tableName: string): Promise<T[]> {
   return items;
 }
 
+export async function getItemByOwner<T extends { userId: string }>(
+  tableName: string,
+  id: string,
+  userId: string
+): Promise<T> {
+  const result = await dynamo.send(new GetCommand({ TableName: tableName, Key: { id } }));
+  const item = result.Item as T | undefined;
+  if (!item || item.userId !== userId) {
+    throw new createError.NotFound("Item not found");
+  }
+  return item;
+}
+
 export async function updateItem<T extends { id: string; createdAt: string; updatedAt: string }>(
   tableName: string,
   id: string,


### PR DESCRIPTION
## 概要

`listening-logs/update.ts` と `listening-logs/delete.ts` に重複していた所有権チェックロジックを、`dynamodb.ts` の共通関数 `getItemByOwner<T>` に抽出しました。

## 変更内容

- `backend/src/utils/dynamodb.ts`: `getItemByOwner<T extends { userId: string }>` 関数を追加
- `backend/src/listening-logs/update.ts`: 重複していた GetCommand + userId チェックを `getItemByOwner` に置き換え
- `backend/src/listening-logs/delete.ts`: 同上
- `backend/src/listening-logs/update.test.ts`: モックを `getItemByOwner` に対応
- `backend/src/listening-logs/delete.test.ts`: 同上

## 動機

変更前は以下のパターンが2ファイルに重複していました：

```typescript
const result = await dynamo.send(new GetCommand({ TableName: ..., Key: { id } }));
const item = result.Item as ListeningLog | undefined;
if (!item || item.userId !== userId) {
  throw new createError.NotFound("...");
}
```

DRY 原則に従い共通化することで、所有権チェックの仕様変更が1箇所の修正で完結するようになります。また、将来的に他のリソースでも同関数を再利用できます。

## テスト

- バックエンド: 214 tests passed
- フロントエンド: 235 tests passed

https://claude.ai/code/session_01X83UQPy1rMVCf8bkKtp3EG

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * リスニングログの削除・更新操作における所有権検証ロジックを統一。新しい検証ユーティリティの導入により、認可チェック処理がより堅牢で一貫性のある実装になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->