### PR TITLE
feat: ローカル開発環境から本番 API に接続できるよう CORS を拡張

### DIFF
--- a/backend/src/utils/env.test.ts
+++ b/backend/src/utils/env.test.ts
@@ -27,7 +27,7 @@ describe("AppEnv", () => {
   describe("オプション変数のデフォルト値", () => {
     it("CORS_ALLOW_ORIGIN が未設定の場合は * をデフォルトとして使用する", () => {
       const appEnv = new AppEnv();
-      expect(appEnv.corsAllowOrigin).toBe("*");
+      expect(appEnv.corsAllowOrigins).toEqual(["*"]);
     });
 
     it("AWS_REGION が未設定の場合は ap-northeast-1 をデフォルトとして使用する", () => {
@@ -54,7 +54,7 @@ describe("AppEnv", () => {
       process.env.DYNAMO_TABLE_PIECES = "my-pieces";
 
       const appEnv = new AppEnv();
-      expect(appEnv.corsAllowOrigin).toBe("https://example.com");
+      expect(appEnv.corsAllowOrigins).toEqual(["https://example.com"]);
       expect(appEnv.awsRegion).toBe("us-east-1");
       expect(appEnv.dynamoTableListeningLogs).toBe("my-listening-logs");
       expect(appEnv.dynamoTablePieces).toBe("my-pieces");

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -1,6 +1,6 @@
 export class AppEnv {
   readonly cognitoClientId: string;
-  readonly corsAllowOrigin: string;
+  readonly corsAllowOrigins: string[];
   readonly awsRegion: string;
   readonly dynamoTableListeningLogs: string;
   readonly dynamoTablePieces: string;
@@ -11,7 +11,7 @@ export class AppEnv {
       throw new Error("COGNITO_CLIENT_ID environment variable is required");
     }
     this.cognitoClientId = cognitoClientId;
-    this.corsAllowOrigin = process.env.CORS_ALLOW_ORIGIN ?? "*";
+    this.corsAllowOrigins = (process.env.CORS_ALLOW_ORIGIN ?? "*").split(",").map((o) => o.trim());
     this.awsRegion = process.env.AWS_REGION ?? "ap-northeast-1";
     this.dynamoTableListeningLogs =
       process.env.DYNAMO_TABLE_LISTENING_LOGS ?? "classical-music-listening-logs";

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -55,7 +55,7 @@ export const createHandler = (handler: LambdaHandler) =>
     .handler(handler as middy.Handler<APIGatewayProxyEvent, APIGatewayProxyResult>)
     .use(
       httpCors({
-        origin: getEnv().corsAllowOrigin,
+        origins: getEnv().corsAllowOrigins,
         headers: "Content-Type",
         methods: "GET,POST,PUT,DELETE,OPTIONS",
       })

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -23,6 +23,7 @@ export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
 
 export class ClassicalMusicLakeStack extends cdk.Stack {
   private corsAllowOrigin: string = "";
+  private corsAllowOrigins: string[] = [];
 
   constructor(scope: Construct, id: string, props: ClassicalMusicLakeStackProps) {
     super(scope, id, props);
@@ -430,6 +431,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
 
     // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
     this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
+    this.corsAllowOrigins = [this.corsAllowOrigin, "http://localhost:3000"];
     [
       listeningLogsList,
       listeningLogsGet,
@@ -446,7 +448,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       authVerifyEmail,
       authResendCode,
     ].forEach((fn) => {
-      fn.addEnvironment("CORS_ALLOW_ORIGIN", this.corsAllowOrigin);
+      fn.addEnvironment("CORS_ALLOW_ORIGIN", this.corsAllowOrigins.join(","));
     });
 
     // API Gateway の CORS オリジンも CloudFront URL に限定
@@ -640,7 +642,7 @@ function handler(event) {
     allowHeaders: string[] = ["Content-Type"]
   ): void {
     resource.addCorsPreflight({
-      allowOrigins: [this.corsAllowOrigin],
+      allowOrigins: this.corsAllowOrigins,
       allowMethods: methods,
       allowHeaders,
     });


### PR DESCRIPTION
## Summary

- `http://localhost:3000` を CORS 許可オリジンに追加し、`npm run dev` でそのまま本番 API を使った動作確認ができるようにした
- `CORS_ALLOW_ORIGIN` 環境変数をカンマ区切りの複数オリジン形式に変更（`@middy/http-cors` の `origins` オプションを使用）
- API Gateway のプリフライト設定も複数オリジン対応に更新

## 事前準備

`.env` ファイルをプロジェクトルートに作成すること（`.gitignore` 対象）:

```
NUXT_PUBLIC_API_BASE_URL=https://41oqymld6i.execute-api.ap-northeast-1.amazonaws.com/prod
```

## 備考

デプロイ時は `storybook-static` が存在しないと失敗するため、先に `npm run build:storybook` が必要。

## Test plan

- [ ] `npm run test:backend` が全て通ること
- [ ] `npm run test:frontend` が全て通ること
- [ ] CDK deploy 後に `npm run dev` でログイン・データ取得が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 複数のCORSオリジンのサポートを追加しました。複数のドメインから同時にAPIへのアクセスが可能になります。

* **テスト**
  * CORS設定の検証テストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->