### PR TITLE
fix: dev サーバーのポートを 3000 から 3010 に変更

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -431,7 +431,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
 
     // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
     this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
-    this.corsAllowOrigins = [this.corsAllowOrigin, "http://localhost:3000"];
+    // NOTE: 3000だとなぜか起動できない
+    this.corsAllowOrigins = [this.corsAllowOrigin, "http://localhost:3010"];
     [
       listeningLogsList,
       listeningLogsGet,

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -3,6 +3,10 @@ export default defineNuxtConfig({
   compatibilityDate: "2025-01-01",
   ssr: false,
   devtools: { enabled: true },
+  // NOTE: 3000だとなぜか起動できない
+  devServer: {
+    port: 3010,
+  },
   modules: ["@nuxt/eslint", "@nuxtjs/storybook"],
   components: [{ path: "~/components", pathPrefix: false }],
   typescript: {


### PR DESCRIPTION
## Summary
- `nuxt.config.ts` の dev サーバーポートを 3000 から 3010 に変更（3000 では起動できないため）
- CDK の CORS 許可オリジンを `localhost:3000` から `localhost:3010` に合わせて更新

## Test plan
- [ ] `npm run dev` で `http://localhost:3010` が起動することを確認
- [ ] CDK デプロイ後、ローカルから本番 API へのリクエストが CORS エラーなく通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* 開発サーバーのポート番号を3000から3010に変更しました。
* CORS許可リストを新しいポート番号に対応するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->