### PR TITLE
refactor: DynamoDB取得+ユーザー権限チェックの重複を共通関数に抽出

### DIFF
--- a/backend/src/listening-logs/delete.test.ts
+++ b/backend/src/listening-logs/delete.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import createError from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "./delete";
-import { dynamo } from "../utils/dynamodb";
+import * as dynamodb from "../utils/dynamodb";
 
 vi.mock("../utils/dynamodb", () => ({
   dynamo: { send: vi.fn() },
+  getItemByIdAndUserId: vi.fn(),
   TABLE_LISTENING_LOGS: "test-listening-logs",
 }));
 
@@ -58,7 +60,9 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: undefined } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
@@ -68,31 +72,33 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("他ユーザーのアイテムを削除しようとした場合は 404 を返す（存在を隠蔽）", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: existingItem } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(makeEvent("abc-123", OTHER_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
-    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(1); // DeleteCommand は呼ばれない
+    expect(vi.mocked(dynamodb.dynamo.send)).not.toHaveBeenCalled(); // DeleteCommand は呼ばれない
   });
 
   it("userId が null のアイテム（未帰属データ）を削除しようとした場合は 404 を返す", async () => {
-    const nullUserItem = { ...existingItem, userId: null };
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: nullUserItem } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
   });
 
   it("正常削除して 204 を返す", async () => {
-    vi.mocked(dynamo.send)
-      .mockResolvedValueOnce({ Item: existingItem } as never) // GetCommand
-      .mockResolvedValueOnce({} as never); // DeleteCommand
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingItem);
+    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({} as never); // DeleteCommand
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
-    expect(vi.mocked(dynamo.send)).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(dynamodb.dynamo.send)).toHaveBeenCalledTimes(1); // DeleteCommand のみ
   });
 
   it("DynamoDB エラー時に 500 を返す", async () => {
-    vi.mocked(dynamo.send).mockRejectedValueOnce(new Error("DynamoDB error"));
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/listening-logs/delete.ts
+++ b/backend/src/listening-logs/delete.ts
@@ -1,7 +1,6 @@
-import { DeleteCommand, GetCommand } from "@aws-sdk/lib-dynamodb";
-import createError from "http-errors";
+import { DeleteCommand } from "@aws-sdk/lib-dynamodb";
 import { StatusCodes } from "http-status-codes";
-import { dynamo, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
+import { dynamo, getItemByIdAndUserId, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler } from "../utils/middleware";
 import { getIdParam } from "../utils/path-params";
 import { getUserId } from "../utils/auth";
@@ -10,13 +9,7 @@ import type { ListeningLog } from "../types";
 export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const userId = getUserId(event);
-
-  const result = await dynamo.send(
-    new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
-  );
-  const item = result.Item as ListeningLog | undefined;
-  if (!item || item.userId !== userId) throw new createError.NotFound("Listening log not found");
-
+  await getItemByIdAndUserId<ListeningLog>(TABLE_LISTENING_LOGS, id, userId);
   await dynamo.send(new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } }));
   return { statusCode: StatusCodes.NO_CONTENT, body: "" };
 });

--- a/backend/src/listening-logs/get.test.ts
+++ b/backend/src/listening-logs/get.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import createError from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ListeningLog } from "../types";
 
 import { handler } from "./get";
-import { dynamo } from "../utils/dynamodb";
+import * as dynamodb from "../utils/dynamodb";
 
 vi.mock("../utils/dynamodb", () => ({
-  dynamo: { send: vi.fn() },
+  getItemByIdAndUserId: vi.fn(),
   TABLE_LISTENING_LOGS: "test-listening-logs",
 }));
 
@@ -60,7 +61,9 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: undefined } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
@@ -70,20 +73,23 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("他ユーザーのアイテムにアクセスした場合は 404 を返す（存在を隠蔽）", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: testLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(makeEvent("abc-123", OTHER_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
   });
 
   it("userId が null のアイテム（未帰属データ）にアクセスした場合は 404 を返す", async () => {
-    const nullUserLog = { ...testLog, userId: null };
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: nullUserLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(
+      new createError.NotFound("Item not found")
+    );
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
   });
 
   it("正常取得して 200 を返す", async () => {
-    vi.mocked(dynamo.send).mockResolvedValueOnce({ Item: testLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(testLog);
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
 
@@ -93,7 +99,7 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("DynamoDB エラー時に 500 を返す", async () => {
-    vi.mocked(dynamo.send).mockRejectedValueOnce(new Error("DynamoDB error"));
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/listening-logs/get.ts
+++ b/backend/src/listening-logs/get.ts
@@ -1,7 +1,5 @@
-import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import createError from "http-errors";
 import { StatusCodes } from "http-status-codes";
-import { dynamo, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
+import { getItemByIdAndUserId, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler } from "../utils/middleware";
 import { getIdParam } from "../utils/path-params";
 import { getUserId } from "../utils/auth";
@@ -10,11 +8,6 @@ import type { ListeningLog } from "../types";
 export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const userId = getUserId(event);
-
-  const result = await dynamo.send(
-    new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
-  );
-  const item = result.Item as ListeningLog | undefined;
-  if (!item || item.userId !== userId) throw new createError.NotFound("Listening log not found");
+  const item = await getItemByIdAndUserId<ListeningLog>(TABLE_LISTENING_LOGS, id, userId);
   return { statusCode: StatusCodes.OK, body: item };
 });

--- a/backend/src/listening-logs/update.test.ts
+++ b/backend/src/listening-logs/update.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { Conflict } from "http-errors";
+import { Conflict, NotFound } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ListeningLog } from "../types";
 
@@ -7,8 +7,8 @@ import { handler } from "./update";
 import * as dynamodb from "../utils/dynamodb";
 
 vi.mock("../utils/dynamodb", () => ({
+  getItemByIdAndUserId: vi.fn(),
   updateItem: vi.fn(),
-  dynamo: { send: vi.fn() },
   TABLE_LISTENING_LOGS: "test-listening-logs",
 }));
 
@@ -163,7 +163,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("他ユーザーのアイテムを更新しようとした場合は 404 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), OTHER_USER_ID),
       mockContext,
@@ -174,8 +174,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("userId が null のアイテム（未帰属データ）を更新しようとした場合は 404 を返す", async () => {
-    const nullUserLog = { ...existingLog, userId: null };
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: nullUserLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
@@ -186,7 +185,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: undefined } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new NotFound("Item not found"));
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
@@ -196,7 +195,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("rating を含まない更新は rating のバリデーションをスキップする", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       isFavorite: true,
@@ -218,7 +217,7 @@ describe("PUT /listening-logs/:id (update)", () => {
       isFavorite: true,
       updatedAt: new Date().toISOString(),
     };
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce(updatedLog);
 
     const result = await handler(
@@ -236,7 +235,7 @@ describe("PUT /listening-logs/:id (update)", () => {
 
   it("updatedAt が更新されること", async () => {
     const now = new Date().toISOString();
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       updatedAt: now,
@@ -253,7 +252,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("id は上書きされない", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockResolvedValueOnce({
       ...existingLog,
       updatedAt: new Date().toISOString(),
@@ -269,7 +268,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockResolvedValueOnce({ Item: existingLog } as never);
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockResolvedValueOnce(existingLog);
     vi.mocked(dynamodb.updateItem).mockRejectedValueOnce(
       new Conflict("Item was updated by another request")
     );
@@ -283,7 +282,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("DynamoDB エラー時に 500 を返す", async () => {
-    vi.mocked(dynamodb.dynamo.send).mockRejectedValueOnce(new Error("DynamoDB error"));
+    vi.mocked(dynamodb.getItemByIdAndUserId).mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,

--- a/backend/src/listening-logs/update.ts
+++ b/backend/src/listening-logs/update.ts
@@ -1,7 +1,5 @@
-import { GetCommand } from "@aws-sdk/lib-dynamodb";
-import createError from "http-errors";
 import { StatusCodes } from "http-status-codes";
-import { dynamo, updateItem, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
+import { getItemByIdAndUserId, updateItem, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler, jsonBodyParser } from "../utils/middleware";
 import { parseRequestBody } from "../utils/parsing";
 import { updateListeningLogSchema } from "../utils/schemas";
@@ -13,15 +11,7 @@ export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const input = parseRequestBody(event.body as unknown, updateListeningLogSchema);
   const userId = getUserId(event);
-
-  const existing = await dynamo.send(
-    new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
-  );
-  const existingItem = existing.Item as ListeningLog | undefined;
-  if (!existingItem || existingItem.userId !== userId) {
-    throw new createError.NotFound("Listening log not found");
-  }
-
+  await getItemByIdAndUserId<ListeningLog>(TABLE_LISTENING_LOGS, id, userId);
   const updated = await updateItem<ListeningLog>(TABLE_LISTENING_LOGS, id, input);
   return { statusCode: StatusCodes.OK, body: updated };
 }).use(jsonBodyParser);

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -56,6 +56,17 @@ export async function scanAllItems<T>(tableName: string): Promise<T[]> {
   return items;
 }
 
+export async function getItemByIdAndUserId<T extends { userId: string }>(
+  tableName: string,
+  id: string,
+  userId: string
+): Promise<T> {
+  const result = await dynamo.send(new GetCommand({ TableName: tableName, Key: { id } }));
+  const item = result.Item as T | undefined;
+  if (!item || item.userId !== userId) throw new createError.NotFound("Item not found");
+  return item;
+}
+
 export async function updateItem<T extends { id: string; createdAt: string; updatedAt: string }>(
   tableName: string,
   id: string,


### PR DESCRIPTION
## 概要

`listening-logs` の `get` / `delete` / `update` の3エンドポイントで完全に重複していた「DynamoDB からアイテムを取得してユーザー権限を確認する」ロジックを、共通ユーティリティ関数 `getItemByIdAndUserId()` として抽出した。

## 変更内容

### 問題

以下のコードが3ファイルで重複していた。

```typescript
const result = await dynamo.send(
  new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
);
const item = result.Item as ListeningLog | undefined;
if (!item || item.userId !== userId) throw new createError.NotFound("Listening log not found");
```

### 対応

`backend/src/utils/dynamodb.ts` に汎用関数を追加し、3ファイルで共通利用するよう変更した。

```typescript
export async function getItemByIdAndUserId<T extends { userId: string }>(
  tableName: string,
  id: string,
  userId: string
): Promise<T> {
  const result = await dynamo.send(new GetCommand({ TableName: tableName, Key: { id } }));
  const item = result.Item as T | undefined;
  if (!item || item.userId !== userId) throw new createError.NotFound("Item not found");
  return item;
}
```

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/src/utils/dynamodb.ts` | `getItemByIdAndUserId()` を追加 |
| `backend/src/listening-logs/get.ts` | 共通関数を使用するよう変更（15行 → 8行） |
| `backend/src/listening-logs/delete.ts` | 共通関数を使用するよう変更（22行 → 13行） |
| `backend/src/listening-logs/update.ts` | 共通関数を使用するよう変更（27行 → 16行） |
| `backend/src/listening-logs/get.test.ts` | モックを `dynamo.send` から `getItemByIdAndUserId` に変更 |
| `backend/src/listening-logs/delete.test.ts` | 同上 |
| `backend/src/listening-logs/update.test.ts` | 同上 |

## テスト

- バックエンド: 214テスト すべてパス
- フロントエンド: 253テスト すべてパス