### PR TITLE
fix: レスポンシブデザインとトンマナの違和感を修正

### DIFF
--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -38,6 +38,11 @@ const emit = defineEmits<{
   gap: 1rem;
 }
 
+.piece-main {
+  flex: 1;
+  min-width: 0;
+}
+
 .piece-title {
   font-size: 1.1rem;
   font-weight: bold;
@@ -69,5 +74,17 @@ const emit = defineEmits<{
 
 .btn-detail:hover {
   background: #e0d8cc;
+}
+
+@media (max-width: 600px) {
+  .piece-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .piece-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
 }
 </style>

--- a/app/components/organisms/UserRegisterForm.vue
+++ b/app/components/organisms/UserRegisterForm.vue
@@ -37,7 +37,7 @@ function handleSubmit() {
           id="password"
           v-model="form.password"
           type="password"
-          placeholder="At least 8 characters"
+          placeholder="8文字以上で入力"
           required
         />
         <p class="password-requirements">

--- a/app/error.vue
+++ b/app/error.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+defineProps<{
+  error: { statusCode: number; statusMessage: string };
+}>();
+
+const handleError = () => clearError({ redirect: "/" });
+</script>
+
+<template>
+  <div class="error-page">
+    <header class="error-header">
+      <NuxtLink to="/" class="logo">
+        <img src="/logo.svg" alt="Nocturne" class="logo-img" />
+        <span class="logo-text">Nocturne</span>
+      </NuxtLink>
+    </header>
+    <main class="error-main">
+      <div class="error-content">
+        <p class="error-code">404</p>
+        <h1 class="error-title">ページが見つかりません</h1>
+        <p class="error-message">お探しのページは存在しないか、移動した可能性があります。</p>
+        <button class="btn-home" @click="handleError">ホームへ戻る</button>
+      </div>
+    </main>
+  </div>
+</template>
+
+<style scoped>
+.error-page {
+  min-height: 100vh;
+  background-color: #f5f0e8;
+  display: flex;
+  flex-direction: column;
+}
+
+.error-header {
+  background-color: #1e2d5a;
+  padding: 1rem 2rem;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  text-decoration: none;
+}
+
+.logo-img {
+  height: 32px;
+  width: auto;
+  filter: brightness(0) invert(1);
+}
+
+.logo-text {
+  font-size: 1.3rem;
+  font-weight: bold;
+  color: #fff;
+  letter-spacing: 0.08em;
+  font-style: italic;
+}
+
+.error-main {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+}
+
+.error-content {
+  text-align: center;
+}
+
+.error-code {
+  font-size: 6rem;
+  font-weight: bold;
+  color: #1e2d5a;
+  line-height: 1;
+  margin: 0 0 1rem;
+  font-style: italic;
+  font-family: Georgia, serif;
+}
+
+.error-title {
+  font-size: 1.5rem;
+  color: #1e2d5a;
+  margin: 0 0 1rem;
+}
+
+.error-message {
+  color: #666;
+  margin: 0 0 2rem;
+}
+
+.btn-home {
+  background-color: #1e2d5a;
+  color: #fff;
+  border: none;
+  padding: 0.75rem 2rem;
+  border-radius: 6px;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-home:hover {
+  background-color: #2a3f7e;
+}
+</style>

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -81,10 +81,30 @@ watch(
   text-decoration: none;
   font-size: 0.95rem;
   transition: color 0.2s;
+  white-space: nowrap;
 }
 
 .nav-links a:hover,
 .nav-links a.router-link-active {
+  color: #fff;
+}
+
+.auth-links {
+  list-style: none;
+  display: flex;
+  gap: 1.2rem;
+  margin-left: auto;
+}
+
+.auth-links a {
+  color: #9aa5b4;
+  text-decoration: none;
+  font-size: 0.95rem;
+  transition: color 0.2s;
+  white-space: nowrap;
+}
+
+.auth-links a:hover {
   color: #fff;
 }
 
@@ -111,5 +131,32 @@ watch(
   max-width: 1200px;
   margin: 0 auto;
   padding: 2rem;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding: 0.75rem 1rem;
+  }
+
+  .app-header nav {
+    gap: 1rem;
+    flex-wrap: nowrap;
+  }
+
+  .logo-text {
+    font-size: 1.1rem;
+  }
+
+  .nav-links {
+    gap: 0.75rem;
+  }
+
+  .auth-links {
+    gap: 0.75rem;
+  }
+
+  .app-main {
+    padding: 1rem;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary

- ナビゲーションの `auth-links`（新規登録・ログイン）にスタイルを追加し、ブラウザデフォルトの青リンク表示を解消
- モバイル(600px以下)でナビゲーションが崩れる問題を修正（`white-space: nowrap` 追加・メディアクエリ対応）
- `PieceItem` をモバイルで縦並びレイアウトに変更し、楽曲名が1文字ずつ折り返す問題を解消
- 新規登録フォームの英語プレースホルダー `"At least 8 characters"` を `"8文字以上で入力"` に日本語化
- カスタム `error.vue` を追加し、Nuxt デフォルトの白背景・英語 404 ページをアプリのデザインに統一

## Test plan

- [ ] デスクトップ表示でナビゲーションの「新規登録」「ログイン」がテーマカラーで表示されること
- [ ] モバイル(375px)でナビゲーションが1行に収まること
- [ ] モバイル(375px)の楽曲マスタページで楽曲名が正常に表示されること
- [ ] 新規登録フォームのパスワード欄に「8文字以上で入力」と表示されること
- [ ] 存在しないURLにアクセスするとアプリのデザインに合った404ページが表示されること
- [ ] `npm run test:frontend` が全通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エラーページを追加し、エラーハンドリングとホームへの戻る機能を実装しました。

* **スタイル**
  * モバイルデバイス向けのレスポンシブデザインを改善しました。
  * ナビゲーションとリンク配置のレイアウトを最適化しました。

* **その他の改善**
  * パスワードフィールドのプレースホルダーテキストを日本語に更新しました。
  * 全体的なUIの応答性と使いやすさを向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->