### PR TITLE
feat: youtube embed に rel=0・fs=0 を追加して関連動画と全画面ボタンを制限する

### DIFF
--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -57,13 +57,7 @@ onMounted(() => {
 
 <template>
   <div class="video-player">
-    <iframe
-      v-if="isYouTube"
-      :id="iframeId"
-      :src="embedUrl"
-      class="youtube-iframe"
-      allowfullscreen
-    />
+    <iframe v-if="isYouTube" :id="iframeId" :src="embedUrl" class="youtube-iframe" />
     <a
       v-else
       :href="videoUrl"

--- a/app/utils/video.test.ts
+++ b/app/utils/video.test.ts
@@ -39,13 +39,13 @@ describe("extractYouTubeVideoId", () => {
 describe("toYouTubeEmbedUrl", () => {
   it("youtube.com URL を embed URL に変換する", () => {
     expect(toYouTubeEmbedUrl("https://www.youtube.com/watch?v=abc123")).toBe(
-      "https://www.youtube.com/embed/abc123?enablejsapi=1"
+      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0"
     );
   });
 
   it("youtu.be URL を embed URL に変換する", () => {
     expect(toYouTubeEmbedUrl("https://youtu.be/abc123")).toBe(
-      "https://www.youtube.com/embed/abc123?enablejsapi=1"
+      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0"
     );
   });
 });

--- a/app/utils/video.ts
+++ b/app/utils/video.ts
@@ -15,5 +15,5 @@ export function extractYouTubeVideoId(url: string): string | null {
 export function toYouTubeEmbedUrl(url: string): string {
   const videoId = extractYouTubeVideoId(url);
   if (videoId === null) return url;
-  return `https://www.youtube.com/embed/${videoId}?enablejsapi=1`;
+  return `https://www.youtube.com/embed/${videoId}?enablejsapi=1&rel=0&fs=0`;
 }


### PR DESCRIPTION
- embed URLにrel=0を追加（関連動画を同一チャンネルのみに制限）
- embed URLにfs=0を追加（全画面ボタンを非表示）
- iframeのallowfullscreen属性を削除

Closes #235

https://claude.ai/code/session_01PxTwmAcy6QUCeKbwu5Tof8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * YouTubeビデオプレイヤーの埋め込み設定を最適化しました。関連動画の表示を無効化し、フルスクリーン機能を制限するパラメータを追加しました。

* **テスト**
  * 埋め込みURL変換機能のテスト期待値を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->