### PR TITLE
Add dev environment support with tag-based deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,11 +12,11 @@ on:
       environment:
         description: "デプロイ先の環境"
         required: true
-        default: "staging"
+        default: "stg"
         type: choice
         options:
           - dev
-          - staging
+          - stg
           - prod
 
 concurrency:
@@ -39,14 +39,14 @@ jobs:
 
       # ----------------------------------------
       # デプロイ先環境の決定
-      # push: mainブランチ → prod、stg*タグ → staging、dev*タグ → dev
+      # push: mainブランチ → prod、stg*タグ → stg、dev*タグ → dev
       # workflow_dispatch: 入力値をそのまま使用
       # ----------------------------------------
       - name: Determine stage name
         run: |
           if [ "${{ github.event_name }}" = "push" ]; then
             if [[ "${{ github.ref }}" == refs/tags/stg* ]]; then
-              echo "STAGE_NAME=staging" >> "$GITHUB_ENV"
+              echo "STAGE_NAME=stg" >> "$GITHUB_ENV"
             elif [[ "${{ github.ref }}" == refs/tags/dev* ]]; then
               echo "STAGE_NAME=dev" >> "$GITHUB_ENV"
             else

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -6,7 +6,7 @@ import { ClassicalMusicLakeStack, type StageName } from "../lib/classical-music-
 const app = new cdk.App();
 
 const rawStageName = process.env.STAGE_NAME ?? "prod";
-const validStages: StageName[] = ["dev", "staging", "prod"];
+const validStages: StageName[] = ["dev", "stg", "prod"];
 if (!validStages.includes(rawStageName as StageName)) {
   throw new Error(
     `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${validStages.join(", ")}`

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -15,7 +15,7 @@ import * as cognito from "aws-cdk-lib/aws-cognito";
 import type { Construct } from "constructs";
 import * as path from "path";
 
-export type StageName = "dev" | "staging" | "prod";
+export type StageName = "dev" | "stg" | "prod";
 
 export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
   stageName: StageName;
@@ -42,7 +42,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       tableName,
       partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      // prod は RETAIN、staging は DESTROY（スタック削除時にテーブルも削除）
+      // prod は RETAIN、stg/dev は DESTROY（スタック削除時にテーブルも削除）
       removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       // ポイントインタイムリカバリ（PITR）有効化（35日間のバックアップ自動保持）
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
@@ -337,7 +337,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // -------------------------
     const spaBucket = new s3.Bucket(this, "SpaBucket", {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      // prod は RETAIN（本番アセットの誤削除防止）、staging は DESTROY
+      // prod は RETAIN（本番アセットの誤削除防止）、stg/dev は DESTROY
       removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
       autoDeleteObjects: !isProd,
       // prod は S3 バージョニング有効（静的ファイルのロールバック用）

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -67,7 +67,7 @@ cdk deploy
 ### 緊急時：CDK スタックの確認
 
 ```bash
-# <stage> には staging または prod を指定
+# <stage> には dev, stg または prod を指定
 STAGE=<stage>
 STACK_NAME=$([ "$STAGE" = "prod" ] && echo "ClassicalMusicLakeStack" || echo "ClassicalMusicLakeStack-${STAGE}")
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -517,7 +517,7 @@ Authorization: Bearer {accessToken}
 #### バックエンド（Lambda）
 
 - `DYNAMO_TABLE_LISTENING_LOGS`: 視聴ログテーブル名（CDK が自動設定）
-- `CORS_ALLOW_ORIGIN`: 許可する CORS オリジン（CDK が CloudFront URL を自動設定。未設定時は `"*"` にフォールバックするが、本番・staging は CDK が必ず設定するため未設定にはならない）
+- `CORS_ALLOW_ORIGIN`: 許可する CORS オリジン（CDK が CloudFront URL を自動設定。未設定時は `"*"` にフォールバックするが、本番・stg は CDK が必ず設定するため未設定にはならない）
 
 #### CI/CD（GitHub Secrets）
 
@@ -540,19 +540,19 @@ Authorization: Bearer {accessToken}
 
 ### 6.1 環境構成
 
-| 環境      | スタック名                        | DynamoDB テーブル名                      | 削除ポリシー | 用途                                     |
-| --------- | --------------------------------- | ---------------------------------------- | ------------ | ---------------------------------------- |
-| `prod`    | `ClassicalMusicLakeStack`         | `classical-music-listening-logs`         | RETAIN       | 本番環境                                 |
-| `staging` | `ClassicalMusicLakeStack-staging` | `classical-music-listening-logs-staging` | DESTROY      | リリース前の検証環境                     |
-| `dev`     | `ClassicalMusicLakeStack-dev`     | `classical-music-listening-logs-dev`     | DESTROY      | 開発環境（ローカル環境からの接続も想定） |
+| 環境   | スタック名                    | DynamoDB テーブル名                  | 削除ポリシー | 用途                                     |
+| ------ | ----------------------------- | ------------------------------------ | ------------ | ---------------------------------------- |
+| `prod` | `ClassicalMusicLakeStack`     | `classical-music-listening-logs`     | RETAIN       | 本番環境                                 |
+| `stg`  | `ClassicalMusicLakeStack-stg` | `classical-music-listening-logs-stg` | DESTROY      | リリース前の検証環境                     |
+| `dev`  | `ClassicalMusicLakeStack-dev` | `classical-music-listening-logs-dev` | DESTROY      | 開発環境（ローカル環境からの接続も想定） |
 
 ### 6.2 デプロイフロー
 
 ```
 GitHub (main branch)         → prod 自動デプロイ
-GitHub (stg* タグ push)      → staging 自動デプロイ
+GitHub (stg* タグ push)      → stg 自動デプロイ
 GitHub (dev* タグ push)      → dev 自動デプロイ
-GitHub (workflow_dispatch)   → dev / staging / prod を手動選択
+GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
   → GitHub Actions
     → Nuxt ビルド (npm run generate)
     → CDK デプロイ (STAGE_NAME 環境変数で対象環境を指定)
@@ -565,9 +565,9 @@ GitHub (workflow_dispatch)   → dev / staging / prod を手動選択
 
 - **トリガー**:
   - `push to main` → prod 環境へ自動デプロイ
-  - `push stg* tag` → staging 環境へ自動デプロイ
+  - `push stg* tag` → stg 環境へ自動デプロイ
   - `push dev* tag` → dev 環境へ自動デプロイ
-  - `workflow_dispatch` → dev / staging / prod を選択してデプロイ
+  - `workflow_dispatch` → dev / stg / prod を選択してデプロイ
 - **Secrets**:
   - `AWS_ROLE_TO_ASSUME`
 


### PR DESCRIPTION
## 概要

開発環境（dev）のサポートを追加し、Git タグを使用した自動デプロイメント機能を実装しました。これにより、`main` ブランチへのプッシュ（prod）、`stg*` タグのプッシュ（staging）、`dev*` タグのプッシュ（dev）で自動的に対応する環境へデプロイされるようになります。

## 変更の種類

- [x] 新機能
- [x] ドキュメント

## 変更内容

- **GitHub Actions ワークフロー（`.github/workflows/deploy.yml`）**
  - `stg*` および `dev*` タグのプッシュをトリガーとして追加
  - `workflow_dispatch` の環境選択肢に `dev` を追加
  - 環境決定ロジックを改善：タグ名に基づいて自動的に対象環境を判定するステップを追加
    - `main` ブランチ → `prod`
    - `stg*` タグ → `staging`
    - `dev*` タグ → `dev`
    - `workflow_dispatch` → 入力値を使用

- **CDK 設定（`cdk/bin/app.ts` および `cdk/lib/classical-music-lake-stack.ts`）**
  - `StageName` 型に `"dev"` を追加
  - 有効なステージ一覧に `"dev"` を追加

- **ドキュメント（`docs/SPEC.md`）**
  - 環境構成テーブルに `dev` 環境の情報を追加
    - スタック名：`ClassicalMusicLakeStack-dev`
    - DynamoDB テーブル名：`classical-music-listening-logs-dev`
    - 削除ポリシー：`DESTROY`
    - 用途：開発環境（ローカル環境からの接続も想定）
  - デプロイフローを更新：タグベースのデプロイメント方式を記載
  - デプロイメント仕様を更新：新しいトリガー条件を記載

## テスト

- [x] 既存テストがすべて通ることを確認した
- GitHub Actions ワークフローの構文は有効です

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] `docs/SPEC.md` を更新した

https://claude.ai/code/session_0119iME28VmZK2iq91fq4iuV

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * dev および stg 環境へのデプロイを正式サポート。`dev*`/`stg*`タグでの自動デプロイと、手動デプロイ時の env 選択（dev/stg/prod）を追加。
  * デプロイ実行時のステージ判定ロジックを調整し、タグや手動選択に応じた環境設定を反映。

* **ドキュメント**
  * デプロイフロー、環境一覧、CORS 注記、運用手順を dev/stg を含む内容へ更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->