### PR TITLE
Add comprehensive unit and component tests across frontend and backend

### DIFF
--- a/app/components/atoms/ButtonDanger.test.ts
+++ b/app/components/atoms/ButtonDanger.test.ts
@@ -1,0 +1,38 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ButtonDanger from "./ButtonDanger.vue";
+
+describe("ButtonDanger", () => {
+  describe("表示", () => {
+    it("label が表示される", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { label: "削除" },
+      });
+      expect(wrapper.text()).toBe("削除");
+    });
+
+    it("btn-danger クラスが付いている", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { label: "削除" },
+      });
+      expect(wrapper.find("button.btn-danger").exists()).toBe(true);
+    });
+
+    it("type は button", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { label: "削除" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("button");
+    });
+  });
+
+  describe("イベント", () => {
+    it("クリック時に click イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { label: "削除" },
+      });
+      await wrapper.find("button").trigger("click");
+      expect(wrapper.emitted("click")).toBeDefined();
+      expect(wrapper.emitted("click")).toHaveLength(1);
+    });
+  });
+});

--- a/app/components/atoms/ButtonSecondary.test.ts
+++ b/app/components/atoms/ButtonSecondary.test.ts
@@ -1,0 +1,38 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ButtonSecondary from "./ButtonSecondary.vue";
+
+describe("ButtonSecondary", () => {
+  describe("表示", () => {
+    it("label が表示される", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { label: "戻る" },
+      });
+      expect(wrapper.text()).toBe("戻る");
+    });
+
+    it("btn-secondary クラスが付いている", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { label: "戻る" },
+      });
+      expect(wrapper.find("button.btn-secondary").exists()).toBe(true);
+    });
+
+    it("type は button", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { label: "戻る" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("button");
+    });
+  });
+
+  describe("イベント", () => {
+    it("クリック時に click イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { label: "戻る" },
+      });
+      await wrapper.find("button").trigger("click");
+      expect(wrapper.emitted("click")).toBeDefined();
+      expect(wrapper.emitted("click")).toHaveLength(1);
+    });
+  });
+});

--- a/app/components/atoms/FormGroup.test.ts
+++ b/app/components/atoms/FormGroup.test.ts
@@ -1,0 +1,56 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import FormGroup from "./FormGroup.vue";
+
+describe("FormGroup", () => {
+  describe("表示", () => {
+    it("label テキストが表示される", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "メールアドレス" },
+      });
+      expect(wrapper.find("label").text()).toContain("メールアドレス");
+    });
+
+    it("inputId が label の for 属性に反映される", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "メール", inputId: "email" },
+      });
+      expect(wrapper.find("label").attributes("for")).toBe("email");
+    });
+
+    it("スロットコンテンツが描画される", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "名前" },
+        slots: { default: '<input id="name" />' },
+      });
+      expect(wrapper.find("input#name").exists()).toBe(true);
+    });
+
+    it("required=true のとき RequiredMark が表示される", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "名前", required: true },
+      });
+      expect(wrapper.findComponent({ name: "RequiredMark" }).exists()).toBe(true);
+    });
+
+    it("required が未設定のとき RequiredMark が表示されない", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "名前" },
+      });
+      expect(wrapper.findComponent({ name: "RequiredMark" }).exists()).toBe(false);
+    });
+
+    it("errorMessage が設定されているとき ErrorMessage が表示される", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "名前", errorMessage: "必須項目です" },
+      });
+      expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+    });
+
+    it("errorMessage が未設定のとき ErrorMessage が表示されない", async () => {
+      const wrapper = await mountSuspended(FormGroup, {
+        props: { label: "名前" },
+      });
+      expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(false);
+    });
+  });
+});

--- a/app/components/organisms/ListeningLogDetail.test.ts
+++ b/app/components/organisms/ListeningLogDetail.test.ts
@@ -1,0 +1,49 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ListeningLogDetail from "./ListeningLogDetail.vue";
+import type { ListeningLog } from "~/types";
+
+const sampleLog: ListeningLog = {
+  id: "log-1",
+  userId: "user-1",
+  listenedAt: "2024-01-15T19:30:00.000Z",
+  composer: "ベートーヴェン",
+  piece: "交響曲第9番 ニ短調 Op.125",
+  rating: 5,
+  isFavorite: false,
+  memo: "カラヤン指揮、素晴らしい演奏",
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+};
+
+describe("ListeningLogDetail", () => {
+  describe("表示", () => {
+    it("曲名が表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogDetail, {
+        props: { log: sampleLog },
+      });
+      expect(wrapper.text()).toContain("交響曲第9番 ニ短調 Op.125");
+    });
+
+    it("作曲家が表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogDetail, {
+        props: { log: sampleLog },
+      });
+      expect(wrapper.text()).toContain("ベートーヴェン");
+    });
+
+    it("メモが表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogDetail, {
+        props: { log: sampleLog },
+      });
+      expect(wrapper.find(".memo").exists()).toBe(true);
+      expect(wrapper.text()).toContain("カラヤン指揮、素晴らしい演奏");
+    });
+
+    it("memo が未設定のとき感想・メモセクションが表示されない", async () => {
+      const wrapper = await mountSuspended(ListeningLogDetail, {
+        props: { log: { ...sampleLog, memo: undefined } },
+      });
+      expect(wrapper.find(".memo").exists()).toBe(false);
+    });
+  });
+});

--- a/app/components/organisms/ListeningLogList.test.ts
+++ b/app/components/organisms/ListeningLogList.test.ts
@@ -1,0 +1,88 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ListeningLogList from "./ListeningLogList.vue";
+import type { ListeningLog } from "~/types";
+
+const makeLogs = (): ListeningLog[] => [
+  {
+    id: "log-1",
+    userId: "user-1",
+    listenedAt: "2024-01-15T19:30:00.000Z",
+    composer: "ベートーヴェン",
+    piece: "交響曲第9番",
+    rating: 5,
+    isFavorite: false,
+    createdAt: "2024-01-15T20:00:00.000Z",
+    updatedAt: "2024-01-15T20:00:00.000Z",
+  },
+  {
+    id: "log-2",
+    userId: "user-1",
+    listenedAt: "2024-02-01T10:00:00.000Z",
+    composer: "モーツァルト",
+    piece: "魔笛",
+    rating: 4,
+    isFavorite: true,
+    createdAt: "2024-02-01T10:00:00.000Z",
+    updatedAt: "2024-02-01T10:00:00.000Z",
+  },
+];
+
+describe("ListeningLogList", () => {
+  describe("空の状態", () => {
+    it("logs が空のとき EmptyState が表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: [] },
+      });
+      expect(wrapper.findComponent({ name: "EmptyState" }).exists()).toBe(true);
+    });
+
+    it("logs が空のとき ul が表示されない", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: [] },
+      });
+      expect(wrapper.find("ul.log-list").exists()).toBe(false);
+    });
+  });
+
+  describe("リスト表示", () => {
+    it("logs があるとき ul が表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: makeLogs() },
+      });
+      expect(wrapper.find("ul.log-list").exists()).toBe(true);
+    });
+
+    it("logs があるとき EmptyState が表示されない", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: makeLogs() },
+      });
+      expect(wrapper.findComponent({ name: "EmptyState" }).exists()).toBe(false);
+    });
+
+    it("ログの件数分 ListeningLogItem が表示される", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: makeLogs() },
+      });
+      expect(wrapper.findAllComponents({ name: "ListeningLogItem" })).toHaveLength(2);
+    });
+  });
+
+  describe("イベント", () => {
+    it("削除ボタンをクリックすると delete イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: makeLogs() },
+      });
+      await wrapper.findAll(".btn-danger")[0].trigger("click");
+      expect(wrapper.emitted("delete")).toBeDefined();
+    });
+
+    it("1件目の削除ボタンで log-1 の ID が emit される", async () => {
+      const wrapper = await mountSuspended(ListeningLogList, {
+        props: { logs: makeLogs() },
+      });
+      await wrapper.findAll(".btn-danger")[0].trigger("click");
+      const emitted = wrapper.emitted("delete") as [string][];
+      expect(emitted[0][0]).toBe("log-1");
+    });
+  });
+});

--- a/app/components/organisms/LoginForm.test.ts
+++ b/app/components/organisms/LoginForm.test.ts
@@ -1,0 +1,93 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import LoginForm from "./LoginForm.vue";
+
+const defaultErrors = { email: "", password: "", general: "" };
+
+describe("LoginForm", () => {
+  describe("表示", () => {
+    it("フォームが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find("form").exists()).toBe(true);
+    });
+
+    it("メールアドレス入力欄が表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find('input[type="email"]').exists()).toBe(true);
+    });
+
+    it("パスワード入力欄が表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+    });
+
+    it("isLoading=false のとき「ログイン」ボタンが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find("button[type='submit']").text()).toBe("ログイン");
+    });
+
+    it("isLoading=true のとき「ログイン中...」ボタンが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: true, errors: defaultErrors },
+      });
+      expect(wrapper.find("button[type='submit']").text()).toBe("ログイン中...");
+    });
+
+    it("isLoading=true のとき送信ボタンが disabled になる", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: true, errors: defaultErrors },
+      });
+      expect(wrapper.find("button[type='submit']").attributes("disabled")).toBeDefined();
+    });
+
+    it("general エラーが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: {
+          isLoading: false,
+          errors: { ...defaultErrors, general: "ログインに失敗しました" },
+        },
+      });
+      expect(wrapper.text()).toContain("ログインに失敗しました");
+    });
+
+    it("新規登録リンクが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find('a[href="/auth/user-register"]').exists()).toBe(true);
+    });
+  });
+
+  describe("イベント", () => {
+    it("フォーム送信時に submit イベントが emit される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      const emailInput = wrapper.find('input[type="email"]');
+      const passwordInput = wrapper.find('input[type="password"]');
+      await emailInput.setValue("user@example.com");
+      await passwordInput.setValue("password123");
+      await wrapper.find("form").trigger("submit.prevent");
+      expect(wrapper.emitted("submit")).toBeDefined();
+    });
+
+    it("submit イベントにメールとパスワードが含まれる", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      await wrapper.find('input[type="email"]').setValue("user@example.com");
+      await wrapper.find('input[type="password"]').setValue("MyPassword1");
+      await wrapper.find("form").trigger("submit.prevent");
+      const emitted = wrapper.emitted("submit") as [string, string][];
+      expect(emitted[0][0]).toBe("user@example.com");
+      expect(emitted[0][1]).toBe("MyPassword1");
+    });
+  });
+});

--- a/app/components/organisms/PieceList.test.ts
+++ b/app/components/organisms/PieceList.test.ts
@@ -1,0 +1,96 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import PieceList from "./PieceList.vue";
+import type { Piece } from "~/types";
+
+const makePieces = (): Piece[] => [
+  {
+    id: "piece-1",
+    title: "交響曲第9番",
+    composer: "ベートーヴェン",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+  {
+    id: "piece-2",
+    title: "魔笛",
+    composer: "モーツァルト",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+];
+
+describe("PieceList", () => {
+  describe("エラー状態", () => {
+    it("error がある場合はエラーメッセージを表示する", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: [], error: new Error("fetch failed") },
+      });
+      expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+    });
+
+    it("error がある場合は EmptyState が表示されない", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: [], error: new Error("fetch failed") },
+      });
+      expect(wrapper.findComponent({ name: "EmptyState" }).exists()).toBe(false);
+    });
+  });
+
+  describe("空の状態", () => {
+    it("pieces が空のとき EmptyState が表示される", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: [], error: null },
+      });
+      expect(wrapper.findComponent({ name: "EmptyState" }).exists()).toBe(true);
+    });
+
+    it("pieces が空のとき ul が表示されない", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: [], error: null },
+      });
+      expect(wrapper.find("ul.piece-list").exists()).toBe(false);
+    });
+  });
+
+  describe("リスト表示", () => {
+    it("pieces があるとき ul が表示される", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      expect(wrapper.find("ul.piece-list").exists()).toBe(true);
+    });
+
+    it("pieces があるとき EmptyState が表示されない", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      expect(wrapper.findComponent({ name: "EmptyState" }).exists()).toBe(false);
+    });
+
+    it("楽曲の件数分 PieceItem が表示される", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      expect(wrapper.findAllComponents({ name: "PieceItem" })).toHaveLength(2);
+    });
+  });
+
+  describe("イベント", () => {
+    it("削除ボタンをクリックすると delete イベントが emit される", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      await wrapper.findAll(".btn-danger")[0].trigger("click");
+      expect(wrapper.emitted("delete")).toBeDefined();
+    });
+
+    it("1件目の削除で piece-1 の Piece が emit される", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      await wrapper.findAll(".btn-danger")[0].trigger("click");
+      const emitted = wrapper.emitted("delete") as [Piece][];
+      expect(emitted[0][0].id).toBe("piece-1");
+    });
+  });
+});

--- a/app/components/organisms/UserRegisterForm.test.ts
+++ b/app/components/organisms/UserRegisterForm.test.ts
@@ -1,0 +1,93 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import UserRegisterForm from "./UserRegisterForm.vue";
+
+const defaultErrors = { email: "", password: "" };
+
+describe("UserRegisterForm", () => {
+  describe("表示", () => {
+    it("フォームが表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find("form").exists()).toBe(true);
+    });
+
+    it("メールアドレス入力欄が表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find('input[type="email"]').exists()).toBe(true);
+    });
+
+    it("パスワード入力欄が表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find('input[type="password"]').exists()).toBe(true);
+    });
+
+    it("isLoading=false のとき「登録」ボタンが表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find("button[type='submit']").text()).toBe("登録");
+    });
+
+    it("isLoading=true のとき「登録中...」ボタンが表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: true, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find("button[type='submit']").text()).toBe("登録中...");
+    });
+
+    it("successMessage が設定されているとき表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: {
+          isLoading: false,
+          errors: defaultErrors,
+          successMessage: "登録が完了しました",
+        },
+      });
+      expect(wrapper.find(".success-message").exists()).toBe(true);
+      expect(wrapper.text()).toContain("登録が完了しました");
+    });
+
+    it("successMessage が空のとき成功メッセージが表示されない", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find(".success-message").exists()).toBe(false);
+    });
+
+    it("ログインリンクが表示される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      expect(wrapper.find('a[href="/auth/login"]').exists()).toBe(true);
+    });
+  });
+
+  describe("イベント", () => {
+    it("フォーム送信時に submit イベントが emit される", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      await wrapper.find('input[type="email"]').setValue("user@example.com");
+      await wrapper.find('input[type="password"]').setValue("SecurePass1");
+      await wrapper.find("form").trigger("submit.prevent");
+      expect(wrapper.emitted("submit")).toBeDefined();
+    });
+
+    it("submit イベントにメールとパスワードが含まれる", async () => {
+      const wrapper = await mountSuspended(UserRegisterForm, {
+        props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+      });
+      await wrapper.find('input[type="email"]').setValue("user@example.com");
+      await wrapper.find('input[type="password"]').setValue("SecurePass1");
+      await wrapper.find("form").trigger("submit.prevent");
+      const emitted = wrapper.emitted("submit") as [string, string][];
+      expect(emitted[0][0]).toBe("user@example.com");
+      expect(emitted[0][1]).toBe("SecurePass1");
+    });
+  });
+});

--- a/app/components/templates/HomeTemplate.test.ts
+++ b/app/components/templates/HomeTemplate.test.ts
@@ -1,0 +1,30 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import HomeTemplate from "./HomeTemplate.vue";
+
+const stubs = { FeaturedPiece: true };
+
+describe("HomeTemplate", () => {
+  it("Nocturne タイトルが表示される", async () => {
+    const wrapper = await mountSuspended(HomeTemplate, {
+      props: { pieces: [], loading: false },
+      global: { stubs },
+    });
+    expect(wrapper.text()).toContain("Nocturne");
+  });
+
+  it("鑑賞記録へのリンクが表示される", async () => {
+    const wrapper = await mountSuspended(HomeTemplate, {
+      props: { pieces: [], loading: false },
+      global: { stubs },
+    });
+    expect(wrapper.find('a[href="/listening-logs"]').exists()).toBe(true);
+  });
+
+  it("楽曲を探すリンクが表示される", async () => {
+    const wrapper = await mountSuspended(HomeTemplate, {
+      props: { pieces: [], loading: false },
+      global: { stubs },
+    });
+    expect(wrapper.find('a[href="/pieces"]').exists()).toBe(true);
+  });
+});

--- a/app/components/templates/ListeningLogEditTemplate.test.ts
+++ b/app/components/templates/ListeningLogEditTemplate.test.ts
@@ -1,0 +1,58 @@
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
+import ListeningLogEditTemplate from "./ListeningLogEditTemplate.vue";
+import type { ListeningLog } from "~/types";
+
+mockNuxtImport("usePieces", () =>
+  vi.fn().mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false) })
+);
+
+const sampleLog: ListeningLog = {
+  id: "log-1",
+  userId: "user-1",
+  listenedAt: "2024-01-15T19:30:00.000Z",
+  composer: "ベートーヴェン",
+  piece: "交響曲第9番",
+  rating: 5,
+  isFavorite: false,
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+};
+
+describe("ListeningLogEditTemplate", () => {
+  it("ページタイトルが表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditTemplate, {
+      props: { log: sampleLog, error: null },
+    });
+    expect(wrapper.text()).toContain("鑑賞記録を編集");
+  });
+
+  it("エラーがないとき ErrorMessage が表示されない", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditTemplate, {
+      props: { log: sampleLog, error: null },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(false);
+  });
+
+  it("エラーがあるとき ErrorMessage が表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditTemplate, {
+      props: { log: sampleLog, error: "更新に失敗しました" },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+  });
+
+  it("初期値が入力フィールドに反映される", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditTemplate, {
+      props: { log: sampleLog, error: null },
+    });
+    const composerInput = wrapper.find('input[placeholder="例: ベートーヴェン"]');
+    expect((composerInput.element as HTMLInputElement).value).toBe("ベートーヴェン");
+  });
+
+  it("フォーム送信時に submit イベントが emit される", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditTemplate, {
+      props: { log: sampleLog, error: null },
+    });
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/ListeningLogNewTemplate.test.ts
+++ b/app/components/templates/ListeningLogNewTemplate.test.ts
@@ -1,0 +1,44 @@
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
+import ListeningLogNewTemplate from "./ListeningLogNewTemplate.vue";
+
+mockNuxtImport("usePieces", () =>
+  vi.fn().mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false) })
+);
+
+describe("ListeningLogNewTemplate", () => {
+  it("ページタイトルが表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewTemplate, {
+      props: { error: null },
+    });
+    expect(wrapper.text()).toContain("鑑賞記録を追加");
+  });
+
+  it("エラーがないとき ErrorMessage が表示されない", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewTemplate, {
+      props: { error: null },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(false);
+  });
+
+  it("エラーがあるとき ErrorMessage が表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewTemplate, {
+      props: { error: "作成に失敗しました" },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+  });
+
+  it("ListeningLogForm が表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewTemplate, {
+      props: { error: null },
+    });
+    expect(wrapper.find("form.log-form").exists()).toBe(true);
+  });
+
+  it("フォーム送信時に submit イベントが emit される", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewTemplate, {
+      props: { error: null },
+    });
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/ListeningLogsTemplate.test.ts
+++ b/app/components/templates/ListeningLogsTemplate.test.ts
@@ -1,0 +1,48 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ListeningLogsTemplate from "./ListeningLogsTemplate.vue";
+import type { ListeningLog } from "~/types";
+
+const sampleLogs: ListeningLog[] = [
+  {
+    id: "log-1",
+    userId: "user-1",
+    listenedAt: "2024-01-15T19:30:00.000Z",
+    composer: "ベートーヴェン",
+    piece: "交響曲第9番",
+    rating: 5,
+    isFavorite: false,
+    createdAt: "2024-01-15T20:00:00.000Z",
+    updatedAt: "2024-01-15T20:00:00.000Z",
+  },
+];
+
+describe("ListeningLogsTemplate", () => {
+  it("ページヘッダーが表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogsTemplate, {
+      props: { logs: [] },
+    });
+    expect(wrapper.text()).toContain("鑑賞記録");
+  });
+
+  it("新規追加ボタンが表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogsTemplate, {
+      props: { logs: [] },
+    });
+    expect(wrapper.text()).toContain("新しい記録");
+  });
+
+  it("logs を渡すと ListeningLogList に伝達される", async () => {
+    const wrapper = await mountSuspended(ListeningLogsTemplate, {
+      props: { logs: sampleLogs },
+    });
+    expect(wrapper.findAllComponents({ name: "ListeningLogItem" })).toHaveLength(1);
+  });
+
+  it("delete イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(ListeningLogsTemplate, {
+      props: { logs: sampleLogs },
+    });
+    await wrapper.find(".btn-danger").trigger("click");
+    expect(wrapper.emitted("delete")).toBeDefined();
+  });
+});

--- a/app/components/templates/LoginTemplate.test.ts
+++ b/app/components/templates/LoginTemplate.test.ts
@@ -1,0 +1,23 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import LoginTemplate from "./LoginTemplate.vue";
+
+const defaultErrors = { email: "", password: "", general: "" };
+
+describe("LoginTemplate", () => {
+  it("LoginForm が表示される", async () => {
+    const wrapper = await mountSuspended(LoginTemplate, {
+      props: { isLoading: false, errors: defaultErrors },
+    });
+    expect(wrapper.find("form").exists()).toBe(true);
+  });
+
+  it("submit イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(LoginTemplate, {
+      props: { isLoading: false, errors: defaultErrors },
+    });
+    await wrapper.find('input[type="email"]').setValue("user@example.com");
+    await wrapper.find('input[type="password"]').setValue("pass");
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/PieceEditTemplate.test.ts
+++ b/app/components/templates/PieceEditTemplate.test.ts
@@ -1,0 +1,57 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import PieceEditTemplate from "./PieceEditTemplate.vue";
+import type { Piece } from "~/types";
+
+const samplePiece: Piece = {
+  id: "piece-1",
+  title: "交響曲第9番",
+  composer: "ベートーヴェン",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("PieceEditTemplate", () => {
+  it("ページタイトルが表示される", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: samplePiece, fetchError: null, errorMessage: "" },
+    });
+    expect(wrapper.text()).toContain("楽曲を編集");
+  });
+
+  it("fetchError がある場合はフェッチエラーメッセージが表示される", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: null, fetchError: new Error("fetch error"), errorMessage: "" },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+  });
+
+  it("fetchError がある場合は PieceForm が表示されない", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: null, fetchError: new Error("fetch error"), errorMessage: "" },
+    });
+    expect(wrapper.find("form.piece-form").exists()).toBe(false);
+  });
+
+  it("fetchError がない場合は PieceForm が表示される", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: samplePiece, fetchError: null, errorMessage: "" },
+    });
+    expect(wrapper.find("form.piece-form").exists()).toBe(true);
+  });
+
+  it("初期値が PieceForm に反映される", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: samplePiece, fetchError: null, errorMessage: "" },
+    });
+    const titleInput = wrapper.find('input[placeholder="例：交響曲第9番"]');
+    expect((titleInput.element as HTMLInputElement).value).toBe("交響曲第9番");
+  });
+
+  it("フォーム送信時に submit イベントが emit される", async () => {
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: { piece: samplePiece, fetchError: null, errorMessage: "" },
+    });
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/PieceNewTemplate.test.ts
+++ b/app/components/templates/PieceNewTemplate.test.ts
@@ -1,0 +1,40 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import PieceNewTemplate from "./PieceNewTemplate.vue";
+
+describe("PieceNewTemplate", () => {
+  it("ページタイトルが表示される", async () => {
+    const wrapper = await mountSuspended(PieceNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    expect(wrapper.text()).toContain("楽曲を追加");
+  });
+
+  it("エラーがないとき ErrorMessage が表示されない", async () => {
+    const wrapper = await mountSuspended(PieceNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(false);
+  });
+
+  it("エラーがあるとき ErrorMessage が表示される", async () => {
+    const wrapper = await mountSuspended(PieceNewTemplate, {
+      props: { errorMessage: "登録に失敗しました" },
+    });
+    expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
+  });
+
+  it("PieceForm が表示される", async () => {
+    const wrapper = await mountSuspended(PieceNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    expect(wrapper.find("form.piece-form").exists()).toBe(true);
+  });
+
+  it("フォーム送信時に submit イベントが emit される", async () => {
+    const wrapper = await mountSuspended(PieceNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/PiecesTemplate.test.ts
+++ b/app/components/templates/PiecesTemplate.test.ts
@@ -1,0 +1,44 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import PiecesTemplate from "./PiecesTemplate.vue";
+import type { Piece } from "~/types";
+
+const samplePieces: Piece[] = [
+  {
+    id: "piece-1",
+    title: "交響曲第9番",
+    composer: "ベートーヴェン",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+];
+
+describe("PiecesTemplate", () => {
+  it("ページヘッダーが表示される", async () => {
+    const wrapper = await mountSuspended(PiecesTemplate, {
+      props: { pieces: [], error: null },
+    });
+    expect(wrapper.text()).toContain("楽曲マスタ");
+  });
+
+  it("新規追加ボタンが表示される", async () => {
+    const wrapper = await mountSuspended(PiecesTemplate, {
+      props: { pieces: [], error: null },
+    });
+    expect(wrapper.text()).toContain("新しい楽曲");
+  });
+
+  it("pieces を渡すと PieceList に伝達される", async () => {
+    const wrapper = await mountSuspended(PiecesTemplate, {
+      props: { pieces: samplePieces, error: null },
+    });
+    expect(wrapper.findAllComponents({ name: "PieceItem" })).toHaveLength(1);
+  });
+
+  it("delete イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(PiecesTemplate, {
+      props: { pieces: samplePieces, error: null },
+    });
+    await wrapper.find(".btn-danger").trigger("click");
+    expect(wrapper.emitted("delete")).toBeDefined();
+  });
+});

--- a/app/components/templates/UserRegisterTemplate.test.ts
+++ b/app/components/templates/UserRegisterTemplate.test.ts
@@ -1,0 +1,34 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import UserRegisterTemplate from "./UserRegisterTemplate.vue";
+
+const defaultErrors = { email: "", password: "" };
+
+describe("UserRegisterTemplate", () => {
+  it("UserRegisterForm が表示される", async () => {
+    const wrapper = await mountSuspended(UserRegisterTemplate, {
+      props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+    });
+    expect(wrapper.find("form").exists()).toBe(true);
+  });
+
+  it("successMessage が渡されると表示される", async () => {
+    const wrapper = await mountSuspended(UserRegisterTemplate, {
+      props: {
+        isLoading: false,
+        errors: defaultErrors,
+        successMessage: "登録が完了しました",
+      },
+    });
+    expect(wrapper.find(".success-message").exists()).toBe(true);
+  });
+
+  it("submit イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(UserRegisterTemplate, {
+      props: { isLoading: false, errors: defaultErrors, successMessage: "" },
+    });
+    await wrapper.find('input[type="email"]').setValue("user@example.com");
+    await wrapper.find('input[type="password"]').setValue("SecurePass1");
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+});

--- a/app/components/templates/VerifyEmailTemplate.test.ts
+++ b/app/components/templates/VerifyEmailTemplate.test.ts
@@ -1,0 +1,43 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import VerifyEmailTemplate from "./VerifyEmailTemplate.vue";
+
+describe("VerifyEmailTemplate", () => {
+  it("VerifyEmailForm が表示される", async () => {
+    const wrapper = await mountSuspended(VerifyEmailTemplate, {
+      props: {
+        email: "user@example.com",
+        isLoading: false,
+        error: "",
+        infoMessage: "",
+      },
+    });
+    expect(wrapper.findComponent({ name: "VerifyEmailForm" }).exists()).toBe(true);
+  });
+
+  it("submit イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(VerifyEmailTemplate, {
+      props: {
+        email: "user@example.com",
+        isLoading: false,
+        error: "",
+        infoMessage: "",
+      },
+    });
+    await wrapper.find('input[type="text"]').setValue("123456");
+    await wrapper.find("form").trigger("submit.prevent");
+    expect(wrapper.emitted("submit")).toBeDefined();
+  });
+
+  it("resend イベントが上位に伝達される", async () => {
+    const wrapper = await mountSuspended(VerifyEmailTemplate, {
+      props: {
+        email: "user@example.com",
+        isLoading: false,
+        error: "",
+        infoMessage: "",
+      },
+    });
+    await wrapper.find(".resend-button").trigger("click");
+    expect(wrapper.emitted("resend")).toBeDefined();
+  });
+});

--- a/app/layouts/auth.test.ts
+++ b/app/layouts/auth.test.ts
@@ -1,0 +1,19 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import AuthLayout from "./auth.vue";
+
+describe("AuthLayout", () => {
+  it("スロットコンテンツが描画される", async () => {
+    const wrapper = await mountSuspended(AuthLayout, {
+      slots: { default: "<p class='test-content'>テストコンテンツ</p>" },
+    });
+    expect(wrapper.find("p.test-content").exists()).toBe(true);
+    expect(wrapper.find("p.test-content").text()).toBe("テストコンテンツ");
+  });
+
+  it("div でラップされている", async () => {
+    const wrapper = await mountSuspended(AuthLayout, {
+      slots: { default: "内容" },
+    });
+    expect(wrapper.find("div").exists()).toBe(true);
+  });
+});

--- a/app/pages/auth/user-register.test.ts
+++ b/app/pages/auth/user-register.test.ts
@@ -1,0 +1,73 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import UserRegisterPage from "./user-register.vue";
+
+const mockRegister = vi.fn();
+const mockValidateEmail = vi.fn();
+
+vi.mock("~/composables/useAuth", () => ({
+  useAuth: () => ({
+    register: mockRegister,
+    validateEmail: mockValidateEmail,
+  }),
+}));
+
+beforeEach(() => {
+  mockRegister.mockClear();
+  mockValidateEmail.mockClear();
+  sessionStorage.clear();
+});
+
+describe("UserRegisterPage", () => {
+  it("メールアドレスが無効な場合は register を呼ばない", async () => {
+    mockValidateEmail.mockReturnValue(false);
+
+    const wrapper = await mountSuspended(UserRegisterPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (email: string, password: string) => Promise<void>;
+    };
+    await vm.handleSubmit("invalid-email", "SecurePass1");
+
+    expect(mockRegister).not.toHaveBeenCalled();
+  });
+
+  it("登録成功時に pendingPassword を sessionStorage に保存する", async () => {
+    mockValidateEmail.mockReturnValue(true);
+    mockRegister.mockResolvedValue({ success: true });
+
+    const wrapper = await mountSuspended(UserRegisterPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (email: string, password: string) => Promise<void>;
+    };
+    await vm.handleSubmit("user@example.com", "SecurePass1");
+
+    expect(sessionStorage.getItem("pendingPassword")).toBe("SecurePass1");
+  });
+
+  it("登録成功時に verify-email ページへリダイレクトする", async () => {
+    mockValidateEmail.mockReturnValue(true);
+    mockRegister.mockResolvedValue({ success: true });
+
+    const wrapper = await mountSuspended(UserRegisterPage);
+    const pushSpy = vi.spyOn(wrapper.vm.$router, "push");
+    const vm = wrapper.vm as {
+      handleSubmit: (email: string, password: string) => Promise<void>;
+    };
+    await vm.handleSubmit("user@example.com", "SecurePass1");
+
+    expect(pushSpy).toHaveBeenCalledWith(expect.objectContaining({ path: "/auth/verify-email" }));
+  });
+
+  it("登録失敗時（already含む）はメールエラーを表示する", async () => {
+    mockValidateEmail.mockReturnValue(true);
+    mockRegister.mockResolvedValue({ success: false, error: "Email already registered" });
+
+    const wrapper = await mountSuspended(UserRegisterPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (email: string, password: string) => Promise<void>;
+      errors: { email: string; password: string };
+    };
+    await vm.handleSubmit("user@example.com", "SecurePass1");
+
+    expect(vm.errors.email).toBe("このメールアドレスは既に登録されています");
+  });
+});

--- a/app/pages/auth/verify-email.test.ts
+++ b/app/pages/auth/verify-email.test.ts
@@ -1,0 +1,90 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import VerifyEmailPage from "./verify-email.vue";
+
+const mockVerifyEmail = vi.fn();
+const mockResendVerificationCode = vi.fn();
+const mockLogin = vi.fn();
+
+vi.mock("~/composables/useAuth", () => ({
+  useAuth: () => ({
+    verifyEmail: mockVerifyEmail,
+    resendVerificationCode: mockResendVerificationCode,
+    login: mockLogin,
+  }),
+}));
+
+beforeEach(() => {
+  mockVerifyEmail.mockClear();
+  mockResendVerificationCode.mockClear();
+  mockLogin.mockClear();
+  sessionStorage.clear();
+  history.replaceState({ email: "user@example.com" }, "");
+  sessionStorage.setItem("pendingPassword", "SecurePass1");
+});
+
+describe("VerifyEmailPage", () => {
+  it("認証成功・ログイン成功後に / へリダイレクトする", async () => {
+    mockVerifyEmail.mockResolvedValue({ success: true });
+    mockLogin.mockResolvedValue({ success: true });
+
+    const wrapper = await mountSuspended(VerifyEmailPage);
+    const pushSpy = vi.spyOn(wrapper.vm.$router, "push");
+    const vm = wrapper.vm as { handleSubmit: (code: string) => Promise<void> };
+    await vm.handleSubmit("123456");
+
+    expect(pushSpy).toHaveBeenCalledWith("/");
+  });
+
+  it("認証失敗時はエラーメッセージを設定する", async () => {
+    mockVerifyEmail.mockResolvedValue({ success: false, error: "コードが間違っています" });
+
+    const wrapper = await mountSuspended(VerifyEmailPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (code: string) => Promise<void>;
+      error: string;
+    };
+    await vm.handleSubmit("000000");
+
+    expect(vm.error).toBe("コードが間違っています");
+  });
+
+  it("認証成功後にログイン失敗した場合はエラーメッセージを設定する", async () => {
+    mockVerifyEmail.mockResolvedValue({ success: true });
+    mockLogin.mockResolvedValue({ success: false });
+
+    const wrapper = await mountSuspended(VerifyEmailPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (code: string) => Promise<void>;
+      error: string;
+    };
+    await vm.handleSubmit("123456");
+
+    expect(vm.error).toContain("ログインに失敗しました");
+  });
+
+  it("再送信成功時に infoMessage を設定する", async () => {
+    mockResendVerificationCode.mockResolvedValue({ success: true });
+
+    const wrapper = await mountSuspended(VerifyEmailPage);
+    const vm = wrapper.vm as {
+      handleResend: () => Promise<void>;
+      infoMessage: string;
+    };
+    await vm.handleResend();
+
+    expect(vm.infoMessage).toContain("再送しました");
+  });
+
+  it("再送信失敗時にエラーメッセージを設定する", async () => {
+    mockResendVerificationCode.mockResolvedValue({ success: false, error: "再送信に失敗" });
+
+    const wrapper = await mountSuspended(VerifyEmailPage);
+    const vm = wrapper.vm as {
+      handleResend: () => Promise<void>;
+      error: string;
+    };
+    await vm.handleResend();
+
+    expect(vm.error).toBe("再送信に失敗");
+  });
+});

--- a/app/pages/listening-logs/[id]/edit.test.ts
+++ b/app/pages/listening-logs/[id]/edit.test.ts
@@ -1,0 +1,70 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import ListeningLogEditPage from "./edit.vue";
+import type { ListeningLog, UpdateListeningLogInput } from "~/types";
+
+const mockUpdate = vi.fn();
+
+const sampleLog: ListeningLog = {
+  id: "log-1",
+  userId: "user-1",
+  listenedAt: "2024-01-15T19:30:00.000Z",
+  composer: "ベートーヴェン",
+  piece: "交響曲第9番",
+  rating: 5,
+  isFavorite: false,
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+};
+
+vi.mock("~/composables/useListeningLogs", () => ({
+  useListeningLogs: () => ({
+    data: [],
+    error: null,
+    pending: false,
+    refresh: vi.fn(),
+    create: vi.fn(),
+    update: mockUpdate,
+    deleteLog: vi.fn(),
+  }),
+  useListeningLog: () => ({ data: sampleLog, error: null }),
+}));
+
+vi.mock("~/composables/usePieces", () => ({
+  usePieces: () => ({ data: [], error: null, pending: false }),
+  usePiece: () => ({ data: null, error: null }),
+}));
+
+beforeEach(() => {
+  mockUpdate.mockClear();
+});
+
+describe("ListeningLogEditPage", () => {
+  it("ListeningLogEditTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogEditPage);
+    expect(wrapper.find("form.log-form").exists()).toBe(true);
+  });
+
+  it("更新成功時に update が呼ばれる", async () => {
+    mockUpdate.mockResolvedValue({ ...sampleLog, rating: 4 });
+    const wrapper = await mountSuspended(ListeningLogEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdateListeningLogInput) => Promise<void>;
+    };
+    await vm.handleSubmit({ rating: 4 });
+    await flushPromises();
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it("更新失敗時にエラーメッセージを設定する", async () => {
+    mockUpdate.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(ListeningLogEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdateListeningLogInput) => Promise<void>;
+      error: string | null;
+    };
+    await vm.handleSubmit({ rating: 4 });
+    await flushPromises();
+    expect(vm.error).not.toBeNull();
+  });
+});

--- a/app/pages/listening-logs/new.test.ts
+++ b/app/pages/listening-logs/new.test.ts
@@ -1,0 +1,66 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import ListeningLogNewPage from "./new.vue";
+import type { CreateListeningLogInput } from "~/types";
+
+const mockCreate = vi.fn();
+
+vi.mock("~/composables/useListeningLogs", () => ({
+  useListeningLogs: () => ({
+    data: [],
+    error: null,
+    pending: false,
+    refresh: vi.fn(),
+    create: mockCreate,
+    update: vi.fn(),
+    deleteLog: vi.fn(),
+  }),
+  useListeningLog: () => ({ data: null, error: null }),
+}));
+
+vi.mock("~/composables/usePieces", () => ({
+  usePieces: () => ({ data: [], error: null, pending: false }),
+  usePiece: () => ({ data: null, error: null }),
+}));
+
+beforeEach(() => {
+  mockCreate.mockClear();
+});
+
+const validInput: CreateListeningLogInput = {
+  listenedAt: "2024-01-15T19:30:00.000Z",
+  composer: "ベートーヴェン",
+  piece: "交響曲第9番",
+  rating: 5,
+  isFavorite: false,
+};
+
+describe("ListeningLogNewPage", () => {
+  it("ListeningLogNewTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(ListeningLogNewPage);
+    expect(wrapper.find("form.log-form").exists()).toBe(true);
+  });
+
+  it("作成成功時に create が呼ばれる", async () => {
+    mockCreate.mockResolvedValue({ id: "log-new" });
+    const wrapper = await mountSuspended(ListeningLogNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreateListeningLogInput) => Promise<void>;
+    };
+    await vm.handleSubmit(validInput);
+    await flushPromises();
+    expect(mockCreate).toHaveBeenCalledWith(validInput);
+  });
+
+  it("作成失敗時にエラーメッセージを設定する", async () => {
+    mockCreate.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(ListeningLogNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreateListeningLogInput) => Promise<void>;
+      error: string | null;
+    };
+    await vm.handleSubmit(validInput);
+    await flushPromises();
+    expect(vm.error).not.toBeNull();
+  });
+});

--- a/app/pages/pieces/[id]/edit.test.ts
+++ b/app/pages/pieces/[id]/edit.test.ts
@@ -1,0 +1,59 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import PieceEditPage from "./edit.vue";
+import type { Piece, UpdatePieceInput } from "~/types";
+
+const mockUpdatePiece = vi.fn();
+
+const samplePiece: Piece = {
+  id: "piece-1",
+  title: "交響曲第9番",
+  composer: "ベートーヴェン",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+vi.mock("~/composables/usePieces", () => ({
+  usePieces: () => ({
+    data: ref([]),
+    error: ref(null),
+    refresh: vi.fn(),
+    createPiece: vi.fn(),
+    updatePiece: mockUpdatePiece,
+  }),
+  usePiece: () => ({ data: ref(samplePiece), error: ref(null) }),
+}));
+
+beforeEach(() => {
+  mockUpdatePiece.mockClear();
+});
+
+describe("PieceEditPage", () => {
+  it("PieceEditTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(PieceEditPage);
+    expect(wrapper.find("form.piece-form").exists()).toBe(true);
+  });
+
+  it("更新成功時に updatePiece が呼ばれる", async () => {
+    mockUpdatePiece.mockResolvedValue({ ...samplePiece, title: "更新後" });
+    const wrapper = await mountSuspended(PieceEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdatePieceInput) => Promise<void>;
+    };
+    await vm.handleSubmit({ title: "更新後" });
+    await flushPromises();
+    expect(mockUpdatePiece).toHaveBeenCalled();
+  });
+
+  it("更新失敗時にエラーメッセージを設定する", async () => {
+    mockUpdatePiece.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(PieceEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdatePieceInput) => Promise<void>;
+      errorMessage: string;
+    };
+    await vm.handleSubmit({ title: "更新後" });
+    await flushPromises();
+    expect(vm.errorMessage).toContain("失敗");
+  });
+});

--- a/app/pages/pieces/[id]/index.test.ts
+++ b/app/pages/pieces/[id]/index.test.ts
@@ -1,0 +1,63 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import PieceDetailPage from "./index.vue";
+import type { Piece, Rating } from "~/types";
+
+const mockCreate = vi.fn();
+
+const samplePiece: Piece = {
+  id: "piece-1",
+  title: "交響曲第9番",
+  composer: "ベートーヴェン",
+  videoUrl: "https://www.youtube.com/watch?v=abc123",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+vi.mock("~/composables/usePieces", () => ({
+  usePieces: vi.fn(),
+  usePiece: () => ({ data: ref(samplePiece), error: ref(null) }),
+}));
+
+vi.mock("~/composables/useListeningLogs", () => ({
+  useListeningLogs: () => ({
+    data: ref([]),
+    error: ref(null),
+    pending: ref(false),
+    refresh: vi.fn(),
+    create: mockCreate,
+    update: vi.fn(),
+    deleteLog: vi.fn(),
+  }),
+  useListeningLog: () => ({ data: ref(null), error: ref(null) }),
+}));
+
+beforeEach(() => {
+  mockCreate.mockClear();
+});
+
+describe("PieceDetailPage", () => {
+  it("PieceDetailTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(PieceDetailPage);
+    expect(wrapper.findComponent({ name: "PieceDetailTemplate" }).exists()).toBe(true);
+  });
+
+  it("handleSave が呼ばれると create が実行される", async () => {
+    mockCreate.mockResolvedValue({ id: "log-new" });
+    const wrapper = await mountSuspended(PieceDetailPage);
+    const vm = wrapper.vm as {
+      handleSave: (values: { rating: Rating; isFavorite: boolean; memo: string }) => Promise<void>;
+    };
+    await vm.handleSave({ rating: 5, isFavorite: true, memo: "最高" });
+    await flushPromises();
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        composer: "ベートーヴェン",
+        piece: "交響曲第9番",
+        rating: 5,
+        isFavorite: true,
+        memo: "最高",
+      })
+    );
+  });
+});

--- a/app/pages/pieces/index.test.ts
+++ b/app/pages/pieces/index.test.ts
@@ -1,0 +1,71 @@
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import PiecesPage from "./index.vue";
+import type { Piece } from "~/types";
+
+const { samplePieces, mockRefresh } = vi.hoisted(() => {
+  const samplePieces: Piece[] = [
+    {
+      id: "piece-1",
+      title: "交響曲第9番",
+      composer: "ベートーヴェン",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+  ];
+  return { samplePieces, mockRefresh: vi.fn() };
+});
+
+mockNuxtImport("useFetch", () =>
+  vi.fn().mockReturnValue({
+    data: samplePieces,
+    error: null,
+    refresh: mockRefresh,
+  })
+);
+
+const mockFetch = vi.fn();
+
+beforeEach(() => {
+  mockRefresh.mockClear();
+  mockFetch.mockClear();
+  vi.stubGlobal("$fetch", mockFetch);
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => true)
+  );
+  vi.stubGlobal("alert", vi.fn());
+});
+
+describe("PiecesPage", () => {
+  it("楽曲一覧が表示される", async () => {
+    const wrapper = await mountSuspended(PiecesPage);
+    expect(wrapper.findAllComponents({ name: "PieceItem" })).toHaveLength(1);
+  });
+
+  it("削除確認で OK を選ぶと $fetch が呼ばれる", async () => {
+    mockFetch.mockResolvedValue(undefined);
+    const wrapper = await mountSuspended(PiecesPage);
+    await wrapper.find(".btn-danger").trigger("click");
+    await flushPromises();
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("削除後に refresh が呼ばれる", async () => {
+    mockFetch.mockResolvedValue(undefined);
+    const wrapper = await mountSuspended(PiecesPage);
+    await wrapper.find(".btn-danger").trigger("click");
+    await flushPromises();
+    expect(mockRefresh).toHaveBeenCalled();
+  });
+
+  it("削除キャンセル時は $fetch が呼ばれない", async () => {
+    vi.stubGlobal(
+      "confirm",
+      vi.fn(() => false)
+    );
+    const wrapper = await mountSuspended(PiecesPage);
+    await wrapper.find(".btn-danger").trigger("click");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/pages/pieces/new.test.ts
+++ b/app/pages/pieces/new.test.ts
@@ -1,0 +1,54 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import PieceNewPage from "./new.vue";
+import type { CreatePieceInput } from "~/types";
+
+const mockCreatePiece = vi.fn();
+
+vi.mock("~/composables/usePieces", () => ({
+  usePieces: () => ({
+    data: ref([]),
+    error: ref(null),
+    refresh: vi.fn(),
+    createPiece: mockCreatePiece,
+    updatePiece: vi.fn(),
+  }),
+  usePiece: () => ({ data: ref(null), error: ref(null) }),
+}));
+
+beforeEach(() => {
+  mockCreatePiece.mockClear();
+});
+
+describe("PieceNewPage", () => {
+  it("PieceNewTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(PieceNewPage);
+    expect(wrapper.find("form.piece-form").exists()).toBe(true);
+  });
+
+  it("登録成功時に createPiece が呼ばれる", async () => {
+    mockCreatePiece.mockResolvedValue({ id: "new-1" });
+    const wrapper = await mountSuspended(PieceNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreatePieceInput) => Promise<void>;
+    };
+    await vm.handleSubmit({ title: "交響曲第9番", composer: "ベートーヴェン" });
+    await flushPromises();
+    expect(mockCreatePiece).toHaveBeenCalledWith({
+      title: "交響曲第9番",
+      composer: "ベートーヴェン",
+    });
+  });
+
+  it("登録失敗時にエラーメッセージを設定する", async () => {
+    mockCreatePiece.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(PieceNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreatePieceInput) => Promise<void>;
+      errorMessage: string;
+    };
+    await vm.handleSubmit({ title: "交響曲第9番", composer: "ベートーヴェン" });
+    await flushPromises();
+    expect(vm.errorMessage).toContain("失敗");
+  });
+});

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import type { APIGatewayProxyEvent } from "aws-lambda";
+import { getUserId } from "./auth";
+
+const makeEvent = (authorizer: unknown): APIGatewayProxyEvent =>
+  ({
+    requestContext: { authorizer },
+  }) as unknown as APIGatewayProxyEvent;
+
+describe("getUserId", () => {
+  it("authorizer が null の場合は 401 を投げる", () => {
+    expect(() => getUserId(makeEvent(null))).toThrow("User not authenticated");
+  });
+
+  it("authorizer が undefined の場合は 401 を投げる", () => {
+    expect(() => getUserId(makeEvent(undefined))).toThrow("User not authenticated");
+  });
+
+  it("claims.sub が空文字の場合は 401 を投げる", () => {
+    expect(() => getUserId(makeEvent({ claims: { sub: "" } }))).toThrow("User not authenticated");
+  });
+
+  it("claims.sub が undefined の場合は 401 を投げる", () => {
+    expect(() => getUserId(makeEvent({ claims: {} }))).toThrow("User not authenticated");
+  });
+
+  it("有効な sub がある場合はその値を返す", () => {
+    const result = getUserId(makeEvent({ claims: { sub: "user-abc-123" } }));
+    expect(result).toBe("user-abc-123");
+  });
+});

--- a/backend/src/utils/dynamodb.test.ts
+++ b/backend/src/utils/dynamodb.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+
+import { queryItemsByUserId, scanAllItems, updateItem } from "./dynamodb";
+
+const { mockSend } = vi.hoisted(() => ({
+  mockSend: vi.fn(),
+}));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  // eslint-disable-next-line @typescript-eslint/no-extraneous-class
+  DynamoDBClient: class DynamoDBClient {},
+  ConditionalCheckFailedException: class ConditionalCheckFailedException extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = "ConditionalCheckFailedException";
+    }
+  },
+}));
+
+vi.mock("@aws-sdk/lib-dynamodb", () => ({
+  DynamoDBDocumentClient: {
+    from: vi.fn().mockReturnValue({ send: mockSend }),
+  },
+  GetCommand: class GetCommand {
+    constructor(public input: unknown) {}
+  },
+  PutCommand: class PutCommand {
+    constructor(public input: unknown) {}
+  },
+  QueryCommand: class QueryCommand {
+    constructor(public input: unknown) {}
+  },
+  ScanCommand: class ScanCommand {
+    constructor(public input: unknown) {}
+  },
+}));
+
+type TestItem = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  name: string;
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("queryItemsByUserId", () => {
+  it("ページネーションなしで全アイテムを返す", async () => {
+    const items = [{ id: "1", userId: "user-1" }];
+    mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+    const result = await queryItemsByUserId<{ id: string; userId: string }>("test-table", "user-1");
+
+    expect(result).toEqual(items);
+  });
+
+  it("ページネーションが必要な場合に複数ページを取得する", async () => {
+    const page1 = [{ id: "1" }];
+    const page2 = [{ id: "2" }];
+    mockSend
+      .mockResolvedValueOnce({ Items: page1, LastEvaluatedKey: { id: "1" } })
+      .mockResolvedValueOnce({ Items: page2, LastEvaluatedKey: undefined });
+
+    const result = await queryItemsByUserId<{ id: string }>("test-table", "user-1");
+
+    expect(result).toEqual([...page1, ...page2]);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("Items が undefined の場合は空配列を返す", async () => {
+    mockSend.mockResolvedValueOnce({ Items: undefined, LastEvaluatedKey: undefined });
+
+    const result = await queryItemsByUserId("test-table", "user-1");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("scanAllItems", () => {
+  it("ページネーションなしで全アイテムを返す", async () => {
+    const items = [{ id: "1" }, { id: "2" }];
+    mockSend.mockResolvedValueOnce({ Items: items, LastEvaluatedKey: undefined });
+
+    const result = await scanAllItems<{ id: string }>("test-table");
+
+    expect(result).toEqual(items);
+  });
+
+  it("ページネーションが必要な場合に複数ページを取得する", async () => {
+    const page1 = [{ id: "1" }];
+    const page2 = [{ id: "2" }];
+    mockSend
+      .mockResolvedValueOnce({ Items: page1, LastEvaluatedKey: { id: "1" } })
+      .mockResolvedValueOnce({ Items: page2, LastEvaluatedKey: undefined });
+
+    const result = await scanAllItems<{ id: string }>("test-table");
+
+    expect(result).toEqual([...page1, ...page2]);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+  });
+
+  it("Items が undefined の場合は空配列を返す", async () => {
+    mockSend.mockResolvedValueOnce({ Items: undefined, LastEvaluatedKey: undefined });
+
+    const result = await scanAllItems("test-table");
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("updateItem", () => {
+  const existing: TestItem = {
+    id: "item-1",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+    name: "original",
+  };
+
+  it("アイテムが存在しない場合は 404 を投げる", async () => {
+    mockSend.mockResolvedValueOnce({ Item: undefined });
+
+    await expect(updateItem("test-table", "item-1", { name: "updated" })).rejects.toThrow(
+      "Item not found"
+    );
+  });
+
+  it("正常に更新されたアイテムを返す", async () => {
+    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
+
+    const result = await updateItem<TestItem>("test-table", "item-1", { name: "updated" });
+
+    expect(result.name).toBe("updated");
+    expect(result.id).toBe("item-1");
+    expect(result.createdAt).toBe(existing.createdAt);
+    expect(result.updatedAt).not.toBe(existing.updatedAt);
+  });
+
+  it("updatedAt が更新される", async () => {
+    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
+
+    const result = await updateItem<TestItem>("test-table", "item-1", {});
+
+    expect(result.updatedAt).not.toBe(existing.updatedAt);
+  });
+
+  it("id と createdAt は変更されない", async () => {
+    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
+
+    const result = await updateItem<TestItem>("test-table", "item-1", {
+      id: "different-id",
+      createdAt: "2099-01-01T00:00:00.000Z",
+    } as Partial<TestItem>);
+
+    expect(result.id).toBe("item-1");
+    expect(result.createdAt).toBe(existing.createdAt);
+  });
+
+  it("ConditionalCheckFailedException が発生した場合は 409 を投げる", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: existing })
+      .mockRejectedValueOnce(new ConditionalCheckFailedException("Condition failed"));
+
+    await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
+      "Item was updated by another request"
+    );
+  });
+
+  it("その他のエラーはそのまま再スローされる", async () => {
+    mockSend
+      .mockResolvedValueOnce({ Item: existing })
+      .mockRejectedValueOnce(new Error("DynamoDB connection error"));
+
+    await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
+      "DynamoDB connection error"
+    );
+  });
+});

--- a/backend/src/utils/response.test.ts
+++ b/backend/src/utils/response.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from "vitest";
+import { ok, badRequest, tooManyRequests, internalError } from "./response";
+
+describe("response helpers", () => {
+  describe("ok", () => {
+    it("200 ステータスコードを返す", () => {
+      expect(ok({ message: "success" }).statusCode).toBe(200);
+    });
+
+    it("ボディをそのまま返す", () => {
+      const body = { id: "abc", name: "test" };
+      expect(ok(body).body).toEqual(body);
+    });
+  });
+
+  describe("badRequest", () => {
+    it("400 ステータスコードを返す", () => {
+      expect(badRequest("ValidationError", "invalid input").statusCode).toBe(400);
+    });
+
+    it("error フィールドが設定される", () => {
+      expect(badRequest("ValidationError", "invalid input").body.error).toBe("ValidationError");
+    });
+
+    it("message フィールドが設定される", () => {
+      expect(badRequest("ValidationError", "invalid input").body.message).toBe("invalid input");
+    });
+  });
+
+  describe("tooManyRequests", () => {
+    it("429 ステータスコードを返す", () => {
+      expect(tooManyRequests().statusCode).toBe(429);
+    });
+
+    it("error フィールドは TooManyRequests", () => {
+      expect(tooManyRequests().body.error).toBe("TooManyRequests");
+    });
+
+    it("デフォルトメッセージを返す", () => {
+      expect(tooManyRequests().body.message).toBe("Too many attempts. Please try again later.");
+    });
+
+    it("カスタムメッセージを渡せる", () => {
+      expect(tooManyRequests("カスタムメッセージ").body.message).toBe("カスタムメッセージ");
+    });
+  });
+
+  describe("internalError", () => {
+    it("500 ステータスコードを返す", () => {
+      expect(internalError().statusCode).toBe(500);
+    });
+
+    it("message が Internal server error である", () => {
+      expect(internalError().body.message).toBe("Internal server error");
+    });
+  });
+});

--- a/backend/src/utils/schemas.test.ts
+++ b/backend/src/utils/schemas.test.ts
@@ -1,0 +1,278 @@
+import { describe, it, expect } from "vitest";
+import {
+  createListeningLogSchema,
+  updateListeningLogSchema,
+  createPieceSchema,
+  updatePieceSchema,
+  registerSchema,
+  loginSchema,
+  verifyEmailSchema,
+  resendVerificationCodeSchema,
+} from "./schemas";
+
+const validLog = {
+  listenedAt: "2024-01-15T19:30:00.000Z",
+  composer: "ベートーヴェン",
+  piece: "交響曲第9番",
+  rating: 5,
+  isFavorite: true,
+  memo: "素晴らしい",
+};
+
+describe("createListeningLogSchema", () => {
+  it("有効なデータをパースできる", () => {
+    const result = createListeningLogSchema.safeParse(validLog);
+    expect(result.success).toBe(true);
+  });
+
+  it("memo は省略可能", () => {
+    const { memo: _memo, ...withoutMemo } = validLog;
+    const result = createListeningLogSchema.safeParse(withoutMemo);
+    expect(result.success).toBe(true);
+  });
+
+  it("listenedAt が ISO 8601 形式でない場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, listenedAt: "2024-01-15" });
+    expect(result.success).toBe(false);
+  });
+
+  it("composer が空文字の場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, composer: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("composer が空白のみの場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, composer: "   " });
+    expect(result.success).toBe(false);
+  });
+
+  it("composer が 100 文字を超える場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({
+      ...validLog,
+      composer: "a".repeat(101),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("piece が空文字の場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, piece: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("piece が 200 文字を超える場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({
+      ...validLog,
+      piece: "a".repeat(201),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rating が 0 の場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, rating: 0 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rating が 6 の場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, rating: 6 });
+    expect(result.success).toBe(false);
+  });
+
+  it("rating が小数の場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, rating: 2.5 });
+    expect(result.success).toBe(false);
+  });
+
+  it("memo が 1000 文字を超える場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, memo: "a".repeat(1001) });
+    expect(result.success).toBe(false);
+  });
+
+  it("isFavorite が boolean でない場合はエラー", () => {
+    const result = createListeningLogSchema.safeParse({ ...validLog, isFavorite: "true" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updateListeningLogSchema", () => {
+  it("すべてのフィールドが省略可能", () => {
+    const result = updateListeningLogSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("rating だけ更新できる", () => {
+    const result = updateListeningLogSchema.safeParse({ rating: 3 });
+    expect(result.success).toBe(true);
+  });
+
+  it("rating が範囲外の場合はエラー", () => {
+    const result = updateListeningLogSchema.safeParse({ rating: 6 });
+    expect(result.success).toBe(false);
+  });
+});
+
+const validPiece = {
+  title: "交響曲第9番",
+  composer: "ベートーヴェン",
+};
+
+describe("createPieceSchema", () => {
+  it("有効なデータをパースできる", () => {
+    const result = createPieceSchema.safeParse(validPiece);
+    expect(result.success).toBe(true);
+  });
+
+  it("videoUrl は省略可能", () => {
+    const result = createPieceSchema.safeParse(validPiece);
+    expect(result.success).toBe(true);
+  });
+
+  it("有効な videoUrl を受け付ける", () => {
+    const result = createPieceSchema.safeParse({
+      ...validPiece,
+      videoUrl: "https://www.youtube.com/watch?v=abc123",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("title が空文字の場合はエラー", () => {
+    const result = createPieceSchema.safeParse({ ...validPiece, title: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("title が 200 文字を超える場合はエラー", () => {
+    const result = createPieceSchema.safeParse({ ...validPiece, title: "a".repeat(201) });
+    expect(result.success).toBe(false);
+  });
+
+  it("composer が空文字の場合はエラー", () => {
+    const result = createPieceSchema.safeParse({ ...validPiece, composer: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("composer が 100 文字を超える場合はエラー", () => {
+    const result = createPieceSchema.safeParse({ ...validPiece, composer: "a".repeat(101) });
+    expect(result.success).toBe(false);
+  });
+
+  it("videoUrl が無効な URL の場合はエラー", () => {
+    const result = createPieceSchema.safeParse({ ...validPiece, videoUrl: "not-a-url" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("updatePieceSchema", () => {
+  it("すべてのフィールドが省略可能", () => {
+    const result = updatePieceSchema.safeParse({});
+    expect(result.success).toBe(true);
+  });
+
+  it("videoUrl に空文字を渡すと削除フラグとして受け付ける", () => {
+    const result = updatePieceSchema.safeParse({ videoUrl: "" });
+    expect(result.success).toBe(true);
+  });
+
+  it("videoUrl に有効な URL を渡せる", () => {
+    const result = updatePieceSchema.safeParse({
+      videoUrl: "https://www.youtube.com/watch?v=abc",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("title が空白のみの場合はエラー", () => {
+    const result = updatePieceSchema.safeParse({ title: "   " });
+    expect(result.success).toBe(false);
+  });
+});
+
+const validAuth = {
+  email: "user@example.com",
+  password: "SecurePass1",
+};
+
+describe("registerSchema", () => {
+  it("有効なデータをパースできる", () => {
+    const result = registerSchema.safeParse(validAuth);
+    expect(result.success).toBe(true);
+  });
+
+  it("email が無効な場合はエラー", () => {
+    const result = registerSchema.safeParse({ ...validAuth, email: "not-an-email" });
+    expect(result.success).toBe(false);
+  });
+
+  it("password が 8 文字未満の場合はエラー", () => {
+    const result = registerSchema.safeParse({ ...validAuth, password: "Abc1234" });
+    expect(result.success).toBe(false);
+  });
+
+  it("password に大文字が含まれない場合はエラー", () => {
+    const result = registerSchema.safeParse({ ...validAuth, password: "secure1pass" });
+    expect(result.success).toBe(false);
+  });
+
+  it("password に小文字が含まれない場合はエラー", () => {
+    const result = registerSchema.safeParse({ ...validAuth, password: "SECURE1PASS" });
+    expect(result.success).toBe(false);
+  });
+
+  it("password に数字が含まれない場合はエラー", () => {
+    const result = registerSchema.safeParse({ ...validAuth, password: "SecurePass" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("loginSchema", () => {
+  it("有効なデータをパースできる", () => {
+    const result = loginSchema.safeParse(validAuth);
+    expect(result.success).toBe(true);
+  });
+
+  it("password に複雑さルールは適用されない（1文字以上であればOK）", () => {
+    const result = loginSchema.safeParse({ email: "user@example.com", password: "simple" });
+    expect(result.success).toBe(true);
+  });
+
+  it("password が空文字の場合はエラー", () => {
+    const result = loginSchema.safeParse({ ...validAuth, password: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("email が未設定の場合はエラー", () => {
+    const result = loginSchema.safeParse({ password: "pass123" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("verifyEmailSchema", () => {
+  it("有効なデータをパースできる", () => {
+    const result = verifyEmailSchema.safeParse({ email: "user@example.com", code: "123456" });
+    expect(result.success).toBe(true);
+  });
+
+  it("code が空文字の場合はエラー", () => {
+    const result = verifyEmailSchema.safeParse({ email: "user@example.com", code: "" });
+    expect(result.success).toBe(false);
+  });
+
+  it("email が無効な場合はエラー", () => {
+    const result = verifyEmailSchema.safeParse({ email: "invalid", code: "123456" });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("resendVerificationCodeSchema", () => {
+  it("有効なメールアドレスをパースできる", () => {
+    const result = resendVerificationCodeSchema.safeParse({ email: "user@example.com" });
+    expect(result.success).toBe(true);
+  });
+
+  it("email が無効な場合はエラー", () => {
+    const result = resendVerificationCodeSchema.safeParse({ email: "not-an-email" });
+    expect(result.success).toBe(false);
+  });
+
+  it("email が未設定の場合はエラー", () => {
+    const result = resendVerificationCodeSchema.safeParse({});
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

フロントエンド（Nuxt/Vue）とバックエンド（Node.js）全体にわたる包括的なユニットテストとコンポーネントテストを追加しました。スキーマ検証、API ユーティリティ、認証、ページ、テンプレート、コンポーネントなど、アプリケーションの主要な部分をカバーしています。

## 変更の種類

- [x] テスト

## 変更内容

### バックエンド
- **スキーマ検証テスト** (`backend/src/utils/schemas.test.ts`)
  - `createListeningLogSchema`: 鑑賞記録作成スキーマの入力値検証（日時形式、文字列長、レーティング範囲など）
  - `updateListeningLogSchema`: 鑑賞記録更新スキーマの部分更新検証
  - `createPieceSchema`: 楽曲作成スキーマの検証（タイトル、作曲家、動画URL）
  - `updatePieceSchema`: 楽曲更新スキーマの検証
  - `registerSchema`, `loginSchema`: 認証スキーマの検証（メール形式、パスワード強度）
  - `verifyEmailSchema`, `resendVerificationCodeSchema`: メール検証スキーマの検証

- **DynamoDB ユーティリティテスト** (`backend/src/utils/dynamodb.test.ts`)
  - `queryItemsByUserId`: ページネーション対応のクエリ機能
  - `scanAllItems`: テーブル全体スキャン機能
  - `updateItem`: アイテム更新と存在確認

- **レスポンスヘルパーテスト** (`backend/src/utils/response.test.ts`)
  - `ok`, `badRequest`, `tooManyRequests`, `internalError` の HTTP レスポンス生成

- **認証ユーティリティテスト** (`backend/src/utils/auth.test.ts`)
  - `getUserId`: Lambda イベントからのユーザー ID 抽出と認証検証

### フロントエンド

#### ページテスト
- `app/pages/auth/user-register.test.ts`: ユーザー登録ページ
- `app/pages/auth/verify-email.test.ts`: メール検証ページ
- `app/pages/listening-logs/new.test.ts`: 鑑賞記録作成ページ
- `app/pages/listening-logs/[id]/edit.test.ts`: 鑑賞記録編集ページ
- `app/pages/pieces/index.test.ts`: 楽曲一覧ページ
- `app/pages/pieces/new.test.ts`: 楽曲作成ページ
- `app/pages/pieces/[id]/index.test.ts`: 楽曲詳細ページ
- `app/pages/pieces/[id]/edit.test.ts`: 楽曲編集ページ

#### テンプレートコンポーネントテスト
- `app/components/templates/HomeTemplate.test.ts`
- `app/components/templates/LoginTemplate.test.ts`
- `app/components/templates/UserRegisterTemplate.test.ts`
- `app/components/templates/VerifyEmailTemplate.test.ts`
- `app/components/templates/ListeningLogsTemplate.test.ts`
- `app/components/templates/ListeningLogNewTemplate.test.ts`
- `app/components/templates/ListeningLogEditTemplate.test.ts`
- `app/components/templates/

https://claude.ai/code/session_01FwhWdioes3r7Rqu21oeekP