### PR TITLE
perf: デプロイワークフローの npm インストールを高速化

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,6 +36,11 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "24"
+          cache: "npm"
+          cache-dependency-path: |
+            package-lock.json
+            backend/package-lock.json
+            cdk/package-lock.json
 
       # ----------------------------------------
       # デプロイ先環境の決定
@@ -61,7 +66,7 @@ jobs:
       # (CDK が esbuild でバンドルする際に node_modules が必要)
       # ----------------------------------------
       - name: Install backend dependencies
-        run: npm install
+        run: npm ci
         working-directory: backend
 
       # ----------------------------------------
@@ -69,7 +74,7 @@ jobs:
       # (API URL 取得のためにフロントエンドビルドより前に実行)
       # ----------------------------------------
       - name: Install CDK dependencies
-        run: npm install
+        run: npm ci
         working-directory: cdk
 
       # ----------------------------------------
@@ -126,7 +131,7 @@ jobs:
       # フロントエンド: Nuxt SPA ビルド
       # ----------------------------------------
       - name: Install frontend dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build frontend
         run: npm run generate


### PR DESCRIPTION
## Summary
- `npm install` を `npm ci` に変更（lock ファイルから直接インストールするため高速・冪等）
- `actions/setup-node` に `cache: "npm"` と `cache-dependency-path` を追加
  - backend / cdk / frontend の 3 箇所すべてが `~/.npm` キャッシュの恩恵を受ける

## Test plan
- [ ] CI のデプロイワークフローが正常に動作することを確認
- [ ] キャッシュヒット時にインストール時間が短縮されることを確認

Closes #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイメント パイプラインの最適化により、ビルド時間を短縮し、より安定した依存関係管理を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->