### PR TITLE
ci: main マージ → stg、Release 発行 → prod に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - main
     tags:
-      - "stg*"
       - "dev*"
+  release:
+    types:
+      - published
   workflow_dispatch:
     inputs:
       environment:
@@ -44,18 +46,19 @@ jobs:
 
       # ----------------------------------------
       # デプロイ先環境の決定
-      # push: mainブランチ → prod、stg*タグ → stg、dev*タグ → dev
+      # push: mainブランチ → stg、dev*タグ → dev
+      # release: published → prod
       # workflow_dispatch: 入力値をそのまま使用
       # ----------------------------------------
       - name: Determine stage name
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            if [[ "${{ github.ref }}" == refs/tags/stg* ]]; then
-              echo "STAGE_NAME=stg" >> "$GITHUB_ENV"
-            elif [[ "${{ github.ref }}" == refs/tags/dev* ]]; then
+          if [ "${{ github.event_name }}" = "release" ]; then
+            echo "STAGE_NAME=prod" >> "$GITHUB_ENV"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            if [[ "${{ github.ref }}" == refs/tags/dev* ]]; then
               echo "STAGE_NAME=dev" >> "$GITHUB_ENV"
             else
-              echo "STAGE_NAME=prod" >> "$GITHUB_ENV"
+              echo "STAGE_NAME=stg" >> "$GITHUB_ENV"
             fi
           else
             echo "STAGE_NAME=${{ github.event.inputs.environment }}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- `main` ブランチへの push → stg デプロイに変更
- GitHub Release 発行（`release: published`）→ prod デプロイに変更
- `stg*` タグトリガーを廃止

## Test plan
- [ ] main への PR マージ後、stg デプロイが走ることを確認
- [ ] GitHub Release 発行後、prod デプロイが走ることを確認
- [ ] `workflow_dispatch` での手動デプロイが引き続き動作することを確認

closes #263

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **チョア**
  * デプロイメント ワークフロー設定を更新しました。リリース イベント発行時に本番環境への自動デプロイが行われるようになりました。
  * 開発環境およびステージング環境のデプロイメント ロジックが改善され、環境選択処理がより正確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->