### PR TITLE
feat: add claude auto-fix workflow for CI failures

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -2,7 +2,7 @@ name: Claude Auto Fix
 
 on:
   workflow_run:
-    workflows: ["Test"]
+    workflows: ["Test", "Security", "Deploy"]
     types: [completed]
 
 jobs:
@@ -30,7 +30,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: |
-            CIワークフロー「Test」がプルリクエストのブランチ「${{ github.event.workflow_run.head_branch }}」で失敗しました。
+            CIワークフロー「${{ github.event.workflow_run.name }}」がプルリクエストのブランチ「${{ github.event.workflow_run.head_branch }}」で失敗しました。
             Run ID: ${{ github.event.workflow_run.id }}
 
             以下の手順で修正してください:
@@ -67,7 +67,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: |
-            CIワークフロー「Test」がmainブランチで失敗しました。
+            CIワークフロー「${{ github.event.workflow_run.name }}」がmainブランチで失敗しました。
             Run ID: ${{ github.event.workflow_run.id }}
 
             以下の手順で修正してください:


### PR DESCRIPTION
PR上のCI失敗時は同じブランチに修正をプッシュし、
mainブランチのCI失敗時は修正ブランチを切ってPRを作成する。

https://claude.ai/code/session_012cEkErTrihaxn2LGxBv1qu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CIの失敗を検出して自動で修正案を作成・適用するワークフローを追加しました。失敗が発生したプルリクやmainへのプッシュに対して、それぞれ修正をコミット／ブランチ＆プルリクで提案します。自動コミットやプルリクのタイトルは日本語を使用します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->