### PR TITLE
chore: change Dependabot update schedule from weekly to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
 
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
 
@@ -20,7 +20,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"
 
@@ -28,6 +28,6 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     labels:
       - "dependencies"


### PR DESCRIPTION
## 概要

Dependabot の依存関係更新スケジュールを週次から日次に変更しました。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [x] その他（設定変更）

## 変更内容

- `.github/dependabot.yml` の全ての `schedule.interval` を `"weekly"` から `"daily"` に変更
  - フロントエンド (npm)
  - バックエンド (Lambda/npm)
  - インフラ (CDK/npm)
  - GitHub Actions

## テスト

- [x] N/A（設定ファイルの変更のため、テスト不要）

## チェックリスト

- [x] コーディング規約に従っている
- [x] 実装を含まない変更のため、ドキュメント更新不要

https://claude.ai/code/session_01M6b1j4ao5nVsqL1NVWKye1