### PR TITLE
chore: dependabot を weekly+グループ化に変更し patch 自動マージを追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,30 +4,46 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
 
   # バックエンド (Lambda)
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
 
   # インフラ (CDK)
   - package-ecosystem: "npm"
     directory: "/cdk"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     labels:
       - "dependencies"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  auto-merge:
+    name: Auto Merge (Dependabot patch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+
+    if: github.actor == 'dependabot[bot]'
+
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
daily で大量のPRが来ていたため weekly に変更。patch 更新はグループ化して
1つのPRにまとめ、自動 approve + auto-merge するワークフローを追加。

https://claude.ai/code/session_013VPXjihiB6PhB4iaCZ5VfQ