### PR TITLE
fix: HomeTemplate のヒーロー全幅表示を viewport-width 方式に変更

### DIFF
--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -120,7 +120,9 @@ defineProps<{
 
 <style scoped>
 .home {
-  margin: -2rem -2rem 0;
+  width: 100vw;
+  margin-left: calc(-50vw + 50%);
+  margin-top: -2rem;
   padding-bottom: 4rem;
   overflow-x: hidden;
 }
@@ -327,7 +329,7 @@ defineProps<{
 
 @media (max-width: 600px) {
   .home {
-    margin: -1rem -1rem 0;
+    margin-top: -1rem;
   }
 
   .hero {


### PR DESCRIPTION
## Summary

- `HomeTemplate.vue` のヒーローセクション全幅表示を、負のマージンハックから標準的な CSS 手法に変更
- `margin: -2rem -2rem 0` → `width: 100vw; margin-left: calc(-50vw + 50%); margin-top: -2rem`
- モバイルのメディアクエリも同様に `margin-top: -1rem` のみに変更

## 背景（Issue #255）

外枠の `.app-main` が `padding: 2rem` を持っており、ホームページのヒーローセクションを全幅表示する際に「視覚上のギャップはあるが、CSSの構造上は内側の要素に隙間がない（外枠が隙間を作っている）」状態になっていた。

Playwright MCP がこのギャップを修正できなかったのは、ギャップの原因が外側のコンテナにあるためで、内側の要素を直接編集しても解決しない構造だった。

## 変更内容

| Before | After |
|--------|-------|
| `margin: -2rem -2rem 0` | `width: 100vw; margin-left: calc(-50vw + 50%); margin-top: -2rem` |

`width: 100vw + margin-left: calc(-50vw + 50%)` は、センタリングされたコンテナからブレイクアウトするための標準的な CSS 手法。左右の拡張が親のパディング値に依存しないため、より堅牢。

## Test plan

- [ ] ホームページでヒーローセクションが全幅で表示されることを確認
- [ ] モバイル（600px以下）でも正常に表示されることを確認
- [ ] 他のページに影響がないことを確認

Closes #255

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル修正**
  * ホームテンプレートのコンテナレイアウトスタイリングを更新しました。水平マージン処理を改善し、デスクトップおよびモバイル表示のレスポンシブ対応を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->