### PR TITLE
docs: mark refresh token as implemented in login design doc

### DIFF
--- a/docs/features/003-user-authentication/003-3-user-login/design.md
+++ b/docs/features/003-user-authentication/003-3-user-login/design.md
@@ -158,7 +158,6 @@ Content-Type: application/json
 - HTTPS のみ（本番環境）
 - トークン有効期限（60 分）
 - Rate Limiting（ログイン: 5 req/min）
-- リフレッシュトークンの自動更新（将来フェーズ）
 
 ### 実装しない
 
@@ -172,7 +171,7 @@ Content-Type: application/json
 | **認証フロー**       | USER_PASSWORD_AUTH        | シンプル、Cognito 標準                                                                             |
 | **トークン保存**     | Secure Cookie（HttpOnly） | XSS によるトークン窃取を防止。refresh token は HttpOnly Secure Cookie、access token は短寿命で管理 |
 | **エラーメッセージ** | 汎用化                    | セキュリティ（ユーザー存在有無の推測防止）                                                         |
-| **Refresh Token**    | 実装しない（初期版）      | MVP スコープ削減。トークン有効期限 60 分で対応                                                     |
+| **Refresh Token**    | 実装済み（PR #301, #305） | アクセストークン期限切れ時に自動更新。`POST /auth/refresh` で取得し localStorage に保存            |
 
 ## レビュー結果
 


### PR DESCRIPTION
## Summary

- issue #289 はすでに PR #301・#305 で実装済みのため、設計書の「残課題」表記を修正
- `リフレッシュトークンの自動更新（将来フェーズ）` を実装予定から削除
- Refresh Token のトレードオフ行を「実装しない（初期版）」→「実装済み（PR #301, #305）」に更新

## Test plan

- [ ] design.md に「将来フェーズ」「実装しない（初期版）」の誤った表記が残っていないこと

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アクセストークンの自動更新機能が実装されました。トークンの有効期限切れ時に自動的に更新されるようになります。

* **ドキュメント**
  * ユーザー認証フロー設計に関するドキュメントを更新し、自動更新機能の実装を反映させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->