### PR TITLE
feat: Google OAuth 認証を追加 (closes #286)

### DIFF
--- a/app/components/organisms/LoginForm.test.ts
+++ b/app/components/organisms/LoginForm.test.ts
@@ -63,6 +63,13 @@ describe("LoginForm", () => {
       });
       expect(wrapper.find('a[href="/auth/user-register"]').exists()).toBe(true);
     });
+
+    it("Googleでログインボタンが表示される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      expect(wrapper.find(".btn-google-login").exists()).toBe(true);
+    });
   });
 
   describe("イベント", () => {
@@ -88,6 +95,14 @@ describe("LoginForm", () => {
       const emitted = wrapper.emitted("submit") as [string, string][];
       expect(emitted[0][0]).toBe("user@example.com");
       expect(emitted[0][1]).toBe("MyPassword1");
+    });
+
+    it("Googleでログインボタンをクリックすると googleLogin イベントが emit される", async () => {
+      const wrapper = await mountSuspended(LoginForm, {
+        props: { isLoading: false, errors: defaultErrors },
+      });
+      await wrapper.find(".btn-google-login").trigger("click");
+      expect(wrapper.emitted("googleLogin")).toBeDefined();
     });
   });
 });

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -6,6 +6,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   submit: [email: string, password: string];
+  googleLogin: [];
 }>();
 
 const form = reactive({
@@ -48,6 +49,14 @@ function handleSubmit() {
       </ButtonPrimary>
     </form>
 
+    <div class="divider">
+      <span>または</span>
+    </div>
+
+    <button type="button" class="btn-google-login" @click="emit('googleLogin')">
+      Google でログイン
+    </button>
+
     <div class="register-link">
       <p>
         アカウントをお持ちでない方は
@@ -77,5 +86,36 @@ form {
 
 .register-link a:hover {
   text-decoration: underline;
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: #7a5c38;
+  gap: 0.5rem;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid #d4c5b0;
+}
+
+.btn-google-login {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border: 1px solid #d4c5b0;
+  border-radius: 4px;
+  background-color: #ffffff;
+  color: #2d2d50;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+.btn-google-login:hover {
+  background-color: #f0ebe3;
 }
 </style>

--- a/app/components/templates/LoginTemplate.vue
+++ b/app/components/templates/LoginTemplate.vue
@@ -6,6 +6,7 @@ defineProps<{
 
 const emit = defineEmits<{
   submit: [email: string, password: string];
+  googleLogin: [];
 }>();
 </script>
 
@@ -15,6 +16,7 @@ const emit = defineEmits<{
       :is-loading="isLoading"
       :errors="errors"
       @submit="(email, password) => emit('submit', email, password)"
+      @google-login="emit('googleLogin')"
     />
   </div>
 </template>

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -15,12 +15,20 @@ vi.mock("./useApiBase", () => ({
   useApiBase: () => "https://api.example.com",
 }));
 
+vi.mock("./useCognitoConfig", () => ({
+  useCognitoConfig: () => ({
+    domain: "test.auth.ap-northeast-1.amazoncognito.com",
+    clientId: "test-client-id",
+  }),
+}));
+
 vi.mock("#app", () => ({
   useRouter: () => ({ push: mockRouterPush }),
 }));
 
 beforeEach(() => {
   vi.stubGlobal("fetch", mockFetch);
+  vi.stubGlobal("location", { href: "", origin: "https://app.example.com" });
   mockFetch.mockClear();
   mockRouterPush.mockClear();
   localStorage.clear();
@@ -569,6 +577,61 @@ describe("useAuth", () => {
 
       expect(result.success).toBe(false);
       expect(result.errorType).toBe("general");
+    });
+  });
+
+  describe("loginWithGoogle", () => {
+    it("Cognito Hosted UI の Google OAuth URL へリダイレクトする", () => {
+      const { loginWithGoogle } = useAuth();
+      loginWithGoogle();
+
+      expect(window.location.href).toContain(
+        "test.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
+      );
+      expect(window.location.href).toContain("identity_provider=Google");
+      expect(window.location.href).toContain("response_type=code");
+      expect(window.location.href).toContain("client_id=test-client-id");
+      expect(window.location.href).toContain("%2Fauth%2Fcallback");
+    });
+  });
+
+  describe("handleOAuthCallback", () => {
+    it("認可コードでトークンエンドポイントを呼び出してトークンを保存する", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          access_token: "access-token",
+          id_token: "id-token",
+          refresh_token: "refresh-token",
+          expires_in: 3600,
+        }),
+      });
+
+      const { handleOAuthCallback } = useAuth();
+      await handleOAuthCallback("test-code");
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "https://test.auth.ap-northeast-1.amazoncognito.com/oauth2/token",
+        expect.objectContaining({ method: "POST" })
+      );
+      expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe("access-token");
+      expect(localStorage.getItem(ID_TOKEN_KEY)).toBe("id-token");
+      expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe("refresh-token");
+      expect(localStorage.getItem(TOKEN_EXPIRES_AT_KEY)).not.toBeNull();
+    });
+
+    it("トークン取得失敗時にエラーをスローする", async () => {
+      mockFetch.mockResolvedValue({ ok: false });
+
+      const { handleOAuthCallback } = useAuth();
+      await expect(handleOAuthCallback("bad-code")).rejects.toThrow();
+    });
+
+    it("ネットワークエラー時にエラーをスローする", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      const { handleOAuthCallback } = useAuth();
+      await expect(handleOAuthCallback("code")).rejects.toThrow();
     });
   });
 

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "#app";
 import { useApiBase } from "./useApiBase";
+import { useCognitoConfig } from "./useCognitoConfig";
 
 export const ACCESS_TOKEN_KEY = "accessToken";
 export const ID_TOKEN_KEY = "idToken";
@@ -64,6 +65,7 @@ export interface LoginResult {
 export const useAuth = () => {
   const apiBase = useApiBase();
   const router = useRouter();
+  const { domain: cognitoDomain, clientId: cognitoClientId } = useCognitoConfig();
 
   const validateEmail = (email: string): boolean => {
     if (email === "" || email.trim() === "") {
@@ -387,6 +389,41 @@ export const useAuth = () => {
     router.push("/auth/login");
   };
 
+  const loginWithGoogle = (): void => {
+    const redirectUri = `${window.location.origin}/auth/callback`;
+    const url = new URL(`https://${cognitoDomain}/oauth2/authorize`);
+    url.searchParams.set("identity_provider", "Google");
+    url.searchParams.set("redirect_uri", redirectUri);
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("client_id", cognitoClientId);
+    url.searchParams.set("scope", "email openid profile");
+    window.location.href = url.toString();
+  };
+
+  const handleOAuthCallback = async (code: string): Promise<void> => {
+    const redirectUri = `${window.location.origin}/auth/callback`;
+    const body = new URLSearchParams({
+      grant_type: "authorization_code",
+      client_id: cognitoClientId,
+      code,
+      redirect_uri: redirectUri,
+    });
+
+    const response = await fetch(`https://${cognitoDomain}/oauth2/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+    });
+
+    if (!response.ok) {
+      throw new Error("Token exchange failed");
+    }
+
+    const data = await response.json();
+    localStorage.setItem(REFRESH_TOKEN_KEY, data.refresh_token);
+    saveSessionTokens(data.access_token, data.id_token, data.expires_in);
+  };
+
   return {
     validateEmail,
     validatePassword,
@@ -400,5 +437,7 @@ export const useAuth = () => {
     refreshTokens,
     clearTokens,
     logout,
+    loginWithGoogle,
+    handleOAuthCallback,
   };
 };

--- a/app/composables/useCognitoConfig.ts
+++ b/app/composables/useCognitoConfig.ts
@@ -1,0 +1,7 @@
+export function useCognitoConfig() {
+  const config = useRuntimeConfig();
+  return {
+    domain: config.public.cognitoDomain as string,
+    clientId: config.public.cognitoClientId as string,
+  };
+}

--- a/app/pages/auth/callback.test.ts
+++ b/app/pages/auth/callback.test.ts
@@ -1,0 +1,80 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import CallbackPage from "./callback.vue";
+
+const mockHandleOAuthCallback = vi.fn();
+
+vi.mock("~/composables/useAuth", () => ({
+  useAuth: () => ({
+    handleOAuthCallback: mockHandleOAuthCallback,
+  }),
+}));
+
+beforeEach(() => {
+  mockHandleOAuthCallback.mockClear();
+});
+
+describe("CallbackPage", () => {
+  describe("code がある場合", () => {
+    it("handleOAuthCallback を code 付きで呼び出す", async () => {
+      mockHandleOAuthCallback.mockResolvedValue(undefined);
+
+      await mountSuspended(CallbackPage, {
+        route: "/auth/callback?code=test-auth-code",
+      });
+
+      expect(mockHandleOAuthCallback).toHaveBeenCalledWith("test-auth-code");
+    });
+
+    it("成功時に / へリダイレクトする", async () => {
+      // handleOAuthCallback を pending にして spy セットアップ後に解決させる
+      let resolveCallback!: () => void;
+      mockHandleOAuthCallback.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveCallback = resolve;
+        })
+      );
+
+      const wrapper = await mountSuspended(CallbackPage, {
+        route: "/auth/callback?code=test-auth-code",
+      });
+      const pushSpy = vi.spyOn(wrapper.vm.$router, "push");
+
+      resolveCallback();
+      await wrapper.vm.$nextTick();
+
+      expect(pushSpy).toHaveBeenCalledWith("/");
+    });
+
+    it("handleOAuthCallback が失敗したときエラーメッセージを表示する", async () => {
+      mockHandleOAuthCallback.mockRejectedValue(new Error("Token exchange failed"));
+
+      const wrapper = await mountSuspended(CallbackPage, {
+        route: "/auth/callback?code=bad-code",
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain("ログインに失敗しました");
+    });
+  });
+
+  describe("code がない場合", () => {
+    it("エラーメッセージを表示する", async () => {
+      const wrapper = await mountSuspended(CallbackPage, {
+        route: "/auth/callback",
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain("ログインに失敗しました");
+    });
+
+    it("handleOAuthCallback を呼び出さない", async () => {
+      await mountSuspended(CallbackPage, {
+        route: "/auth/callback",
+      });
+
+      expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+definePageMeta({ layout: "auth" });
+
+const route = useRoute();
+const router = useRouter();
+const { handleOAuthCallback } = useAuth();
+
+const error = ref<string | null>(null);
+
+onMounted(async () => {
+  const code = route.query.code as string | undefined;
+  if (code === undefined || code === "") {
+    error.value = "ログインに失敗しました。もう一度お試しください。";
+    return;
+  }
+  try {
+    await handleOAuthCallback(code);
+    await router.push("/");
+  } catch {
+    error.value = "ログインに失敗しました。もう一度お試しください。";
+  }
+});
+</script>
+
+<template>
+  <div class="callback-page">
+    <p v-if="error !== null" class="error-message">{{ error }}</p>
+    <p v-else class="loading-message">ログイン処理中...</p>
+  </div>
+</template>
+
+<style scoped>
+.callback-page {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background-color: #f8f4ed;
+}
+
+.error-message {
+  color: #c0392b;
+  font-size: 1rem;
+}
+
+.loading-message {
+  color: #7a5c38;
+  font-size: 1rem;
+}
+</style>

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 definePageMeta({ layout: "auth" });
 
-const { login } = useAuth();
+const { login, loginWithGoogle } = useAuth();
 const router = useRouter();
 
 const errors = reactive({
@@ -42,5 +42,10 @@ async function handleSubmit(email: string, password: string) {
 </script>
 
 <template>
-  <LoginTemplate :is-loading="isLoading" :errors="errors" @submit="handleSubmit" />
+  <LoginTemplate
+    :is-loading="isLoading"
+    :errors="errors"
+    @submit="handleSubmit"
+    @google-login="loginWithGoogle"
+  />
 </template>

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -105,24 +105,177 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       signInCaseSensitive: false,
     });
 
+    // -------------------------
+    // S3 + CloudFront (SPA ホスティング)
+    // App Client の callback URL に CloudFront ドメインが必要なため先に作成する
+    // -------------------------
+    const spaBucket = new s3.Bucket(this, "SpaBucket", {
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      // prod は RETAIN（本番アセットの誤削除防止）、stg/dev は DESTROY
+      removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+      autoDeleteObjects: !isProd,
+      // prod は S3 バージョニング有効（静的ファイルのロールバック用）
+      versioned: isProd,
+    });
+
+    // セキュリティヘッダポリシー（SPA 用: X-Frame-Options: DENY）
+    const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      "SecurityHeadersPolicy",
+      {
+        securityHeadersBehavior: {
+          strictTransportSecurity: {
+            accessControlMaxAge: cdk.Duration.days(365),
+            includeSubdomains: true,
+            override: true,
+          },
+          contentTypeOptions: { override: true },
+          frameOptions: {
+            frameOption: cloudfront.HeadersFrameOption.DENY,
+            override: true,
+          },
+          xssProtection: { protection: true, modeBlock: true, override: true },
+          referrerPolicy: {
+            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+        },
+      }
+    );
+
+    // Storybook 用セキュリティヘッダポリシー（X-Frame-Options を除外: iframe プレビューに必要）
+    const storybookHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+      this,
+      "StorybookHeadersPolicy",
+      {
+        securityHeadersBehavior: {
+          strictTransportSecurity: {
+            accessControlMaxAge: cdk.Duration.days(365),
+            includeSubdomains: true,
+            override: true,
+          },
+          contentTypeOptions: { override: true },
+          contentSecurityPolicy: {
+            contentSecurityPolicy: "frame-ancestors 'self';",
+            override: true,
+          },
+          xssProtection: { protection: true, modeBlock: true, override: true },
+          referrerPolicy: {
+            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+            override: true,
+          },
+        },
+      }
+    );
+
+    const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
+      defaultBehavior: {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        responseHeadersPolicy: securityHeadersPolicy,
+      },
+      // index.html はキャッシュしない（SPA デプロイ後に即反映させるため）
+      additionalBehaviors: {
+        "/index.html": {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          responseHeadersPolicy: securityHeadersPolicy,
+        },
+      },
+      defaultRootObject: "index.html",
+      errorResponses: [
+        // SPA のクライアントサイドルーティング対応
+        // ttl を 0 にして index.html の古いキャッシュが返らないようにする
+        {
+          httpStatus: 403,
+          responseHttpStatus: 200,
+          responsePagePath: "/index.html",
+          ttl: cdk.Duration.seconds(0),
+        },
+        {
+          httpStatus: 404,
+          responseHttpStatus: 200,
+          responsePagePath: "/index.html",
+          ttl: cdk.Duration.seconds(0),
+        },
+      ],
+    });
+
+    // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
+    this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
+    // dev 環境のみローカル開発用に localhost を許可（NOTE: 3000だとなぜか起動できない）
+    this.corsAllowOrigins =
+      stageName === "dev"
+        ? [this.corsAllowOrigin, "http://localhost:3010"]
+        : [this.corsAllowOrigin];
+
+    // -------------------------
+    // Google Identity Provider
+    // GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET 環境変数が設定されている場合のみ作成
+    // -------------------------
+    const googleClientId = process.env.GOOGLE_CLIENT_ID ?? "";
+    const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET ?? "";
+    const hasGoogleCredentials = googleClientId !== "" && googleClientSecret !== "";
+
+    let googleIdP: cognito.UserPoolIdentityProviderGoogle | undefined;
+    if (hasGoogleCredentials) {
+      googleIdP = new cognito.UserPoolIdentityProviderGoogle(this, "GoogleProvider", {
+        userPool,
+        clientId: googleClientId,
+        clientSecretValue: cdk.SecretValue.unsafePlainText(googleClientSecret),
+        scopes: ["email", "profile", "openid"],
+        attributeMapping: {
+          email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+          givenName: cognito.ProviderAttribute.GOOGLE_GIVEN_NAME,
+          familyName: cognito.ProviderAttribute.GOOGLE_FAMILY_NAME,
+        },
+      });
+    }
+
     // App Client: フロントエンド用
+    const callbackUrls = [`https://${distribution.distributionDomainName}/auth/callback`];
+    const logoutUrls = [`https://${distribution.distributionDomainName}/auth/login`];
+    if (stageName === "dev") {
+      callbackUrls.push("http://localhost:3010/auth/callback");
+      logoutUrls.push("http://localhost:3010/auth/login");
+    }
+
     const appClient = userPool.addClient("FrontendClient", {
       authFlows: {
         userPassword: true,
         custom: true,
       },
+      supportedIdentityProviders: [
+        cognito.UserPoolClientIdentityProvider.COGNITO,
+        ...(hasGoogleCredentials ? [cognito.UserPoolClientIdentityProvider.GOOGLE] : []),
+      ],
       oAuth: {
         flows: {
           authorizationCodeGrant: true,
         },
         scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
-        callbackUrls: ["https://classical-music-lake.example.com/auth/callback"],
-        logoutUrls: ["https://classical-music-lake.example.com/login"],
+        callbackUrls,
+        logoutUrls,
       },
       accessTokenValidity: cdk.Duration.minutes(60),
       idTokenValidity: cdk.Duration.minutes(60),
       refreshTokenValidity: cdk.Duration.days(30),
       preventUserExistenceErrors: true,
+    });
+
+    // Google IdP が存在する場合、App Client との依存関係を明示
+    if (googleIdP !== undefined) {
+      appClient.node.addDependency(googleIdP);
+    }
+
+    // Cognito Hosted UI ドメイン（Google OAuth のリダイレクト先として必要）
+    const cognitoDomainPrefix = isProd
+      ? "classical-music-lake"
+      : `classical-music-lake-${stageName}`;
+    userPool.addDomain("CognitoDomain", {
+      cognitoDomain: { domainPrefix: cognitoDomainPrefix },
     });
 
     const commonEnv: Record<string, string> = {
@@ -345,110 +498,6 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const authRefreshResource = authResource.addResource("refresh");
     authRefreshResource.addMethod("POST", integ(authRefresh));
 
-    // -------------------------
-    // S3 + CloudFront (SPA ホスティング)
-    // -------------------------
-    const spaBucket = new s3.Bucket(this, "SpaBucket", {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      // prod は RETAIN（本番アセットの誤削除防止）、stg/dev は DESTROY
-      removalPolicy: isProd ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
-      autoDeleteObjects: !isProd,
-      // prod は S3 バージョニング有効（静的ファイルのロールバック用）
-      versioned: isProd,
-    });
-
-    // セキュリティヘッダポリシー（SPA 用: X-Frame-Options: DENY）
-    const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
-      this,
-      "SecurityHeadersPolicy",
-      {
-        securityHeadersBehavior: {
-          strictTransportSecurity: {
-            accessControlMaxAge: cdk.Duration.days(365),
-            includeSubdomains: true,
-            override: true,
-          },
-          contentTypeOptions: { override: true },
-          frameOptions: {
-            frameOption: cloudfront.HeadersFrameOption.DENY,
-            override: true,
-          },
-          xssProtection: { protection: true, modeBlock: true, override: true },
-          referrerPolicy: {
-            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            override: true,
-          },
-        },
-      }
-    );
-
-    // Storybook 用セキュリティヘッダポリシー（X-Frame-Options を除外: iframe プレビューに必要）
-    const storybookHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
-      this,
-      "StorybookHeadersPolicy",
-      {
-        securityHeadersBehavior: {
-          strictTransportSecurity: {
-            accessControlMaxAge: cdk.Duration.days(365),
-            includeSubdomains: true,
-            override: true,
-          },
-          contentTypeOptions: { override: true },
-          contentSecurityPolicy: {
-            contentSecurityPolicy: "frame-ancestors 'self';",
-            override: true,
-          },
-          xssProtection: { protection: true, modeBlock: true, override: true },
-          referrerPolicy: {
-            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            override: true,
-          },
-        },
-      }
-    );
-
-    const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
-      defaultBehavior: {
-        origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
-        responseHeadersPolicy: securityHeadersPolicy,
-      },
-      // index.html はキャッシュしない（SPA デプロイ後に即反映させるため）
-      additionalBehaviors: {
-        "/index.html": {
-          origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
-          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-          responseHeadersPolicy: securityHeadersPolicy,
-        },
-      },
-      defaultRootObject: "index.html",
-      errorResponses: [
-        // SPA のクライアントサイドルーティング対応
-        // ttl を 0 にして index.html の古いキャッシュが返らないようにする
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.seconds(0),
-        },
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.seconds(0),
-        },
-      ],
-    });
-
-    // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
-    this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
-    // dev 環境のみローカル開発用に localhost を許可（NOTE: 3000だとなぜか起動できない）
-    this.corsAllowOrigins =
-      stageName === "dev"
-        ? [this.corsAllowOrigin, "http://localhost:3010"]
-        : [this.corsAllowOrigin];
     [
       listeningLogsList,
       listeningLogsGet,
@@ -652,6 +701,11 @@ function handler(event) {
     new cdk.CfnOutput(this, "CognitoUserPoolArn", {
       value: userPool.userPoolArn,
       description: "Cognito User Pool ARN",
+    });
+
+    new cdk.CfnOutput(this, "CognitoDomainName", {
+      value: `${cognitoDomainPrefix}.auth.${this.region}.amazoncognito.com`,
+      description: "Cognito Hosted UI Domain (NUXT_PUBLIC_COGNITO_DOMAIN に設定)",
     });
   }
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -51,12 +51,13 @@
 
 #### フロントエンド Composables
 
-| Composable         | 役割                                                                                |
-| ------------------ | ----------------------------------------------------------------------------------- |
-| `useApiBase`       | API Gateway のベース URL を返す                                                     |
-| `useAuth`          | 認証処理（register・login・logout・isAuthenticated・refreshTokens・isTokenExpired） |
-| `usePieces`        | 曲一覧を取得する                                                                    |
-| `useRatingDisplay` | 評価値（0〜5）を星文字列に変換する (`ratingStars`)                                  |
+| Composable         | 役割                                                                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| `useApiBase`       | API Gateway のベース URL を返す                                                                                           |
+| `useCognitoConfig` | Cognito Hosted UI のドメインとクライアント ID を返す                                                                      |
+| `useAuth`          | 認証処理（register・login・logout・isAuthenticated・refreshTokens・isTokenExpired・loginWithGoogle・handleOAuthCallback） |
+| `usePieces`        | 曲一覧を取得する                                                                                                          |
+| `useRatingDisplay` | 評価値（0〜5）を星文字列に変換する (`ratingStars`)                                                                        |
 
 #### フロントエンド レイアウト
 
@@ -315,6 +316,17 @@ Content-Type: application/json
 - 既に確認済み: `400 Bad Request` `{ "error": "UserAlreadyConfirmed", "message": "..." }`
 - ユーザー不存在: `400 Bad Request` `{ "error": "UserNotFound", "message": "..." }`
 - リクエスト過多: `429 Too Many Requests`
+
+#### `GET /auth/callback`（Cognito Hosted UI コールバック）
+
+Cognito Hosted UI からのリダイレクトを受け取り、認可コードをトークンと交換する（フロントエンド処理）
+
+**フロー**
+
+1. Cognito Hosted UI が Google 認証後に `/auth/callback?code=...` へリダイレクト
+2. フロントエンドが `useCognitoConfig` で取得した Cognito ドメインのトークンエンドポイントへ認可コードを送信
+3. 成功時: アクセストークン・IDトークン・リフレッシュトークンを localStorage に保存してトップへ遷移
+4. 失敗時: エラーメッセージを表示
 
 #### `POST /auth/refresh`
 
@@ -794,25 +806,26 @@ cdk deploy
 
 ## 10. 変更履歴
 
-| 日付       | バージョン | 変更内容                                                                                                                                                                                                  |
-| ---------- | ---------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 2026-04-03 | 1.7.2      | CORS オリジン制限の強化: prod・stg 環境では CloudFront URL のみ許可、dev 環境のみ localhost:3010 を追加許可するよう変更                                                                                   |
-| 2026-04-02 | 1.7.1      | カテゴリの値を `shared/constants.ts` に一元管理し、フロント・バックエンドから re-export。型・Zodスキーマ・フォーム選択肢を導出するよう統一                                                                |
-| 2026-03-31 | 1.7.0      | トークンリフレッシュ機能追加（`POST /auth/refresh` エンドポイント新設、ログイン時に `refreshToken`・有効期限を保存、auth ミドルウェアで期限切れ時に自動リフレッシュ、401 時にリフレッシュ試行後リトライ） |
-| 2026-03-28 | 1.6.1      | コード品質改善: truthy/falsy 依存を全廃し明示的な null/undefined 比較に統一。`@typescript-eslint/strict-boolean-expressions` および `vitest/no-restricted-matchers` ESLint ルールを追加し再発を防止       |
-| 2026-03-26 | 1.6.0      | `ListeningLogForm` に楽曲選択時の動画プレビュー機能を追加（`videoUrl` ありの曲を選択すると `VideoPlayer` をインライン表示）                                                                               |
-| 2026-03-25 | 1.5.0      | 楽曲詳細ページ（`/pieces/[id]`）追加、`VideoPlayer`・`QuickLogForm`・`PieceDetailTemplate` 新設、動画再生起点のクイックログ記録フローを実装                                                               |
-| 2026-03-23 | 1.3.3      | `useFetch` の `onResponseError` で 401 時に `handleAuthError` を呼び出し、ログイン画面へリダイレクトするよう修正（`useListeningLogs.list`、`useListeningLog`）                                            |
-| 2026-03-22 | 1.3.2      | ヘッダーナビゲーション改善（未ログイン時: 新規登録・ログインリンク表示、ログイン済み時: ログアウトボタン表示・認証リンク非表示）                                                                          |
-| 2026-03-21 | 1.3.1      | ログアウト機能追加（useAuth: logout/isAuthenticated、auth ミドルウェア、ナビバーボタン）                                                                                                                  |
-| 2026-03-25 | 1.4.0      | `Piece` に `videoUrl` フィールドを追加（任意・URL形式バリデーション）、楽曲フォームに動画 URL 入力欄を追加                                                                                                |
-| 2026-03-21 | 1.3.0      | AWS Cognito ユーザー登録機能を追加（`POST /auth/register`、`useAuth` composable）                                                                                                                         |
-| 2026-03-17 | 1.2.5      | CDK CORS 設定を DRY 化（`addCors` ヘルパー）、型定義ファイルの管理方針コメントを整備                                                                                                                      |
-| 2026-03-17 | 1.2.4      | Create入力の実体バリデーション強化（空白のみ禁止・最大文字数制限）                                                                                                                                        |
-| 2026-03-16 | 1.2.3      | Zod を導入しリクエストボディのパース処理にバリデーションを統合                                                                                                                                            |
-| 2026-03-15 | 1.2.2      | `listening-logs/list.ts` を DynamoDB ページネーション対応に統一                                                                                                                                           |
-| 2026-03-15 | 1.2.1      | バックエンドの JSON パース処理を `utils/parsing.ts` に共通化                                                                                                                                              |
-| 2026-03-11 | 1.2.0      | TOPページに管理者向けリンクセクション（楽曲マスタ導線）を追加                                                                                                                                             |
-| 2026-03-07 | 1.1.0      | performer・conductor フィールド削除、DELETE レスポンス 204 に修正                                                                                                                                         |
-| 2026-03-02 | 1.0.1      | Node.js 24.x対応                                                                                                                                                                                          |
-| 2026-03-02 | 1.0.0      | 初版作成                                                                                                                                                                                                  |
+| 日付       | バージョン | 変更内容                                                                                                                                                                                                                       |
+| ---------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2026-04-03 | 1.8.0      | Google OAuth 認証を追加（Cognito Hosted UI 経由。`POST /auth/callback` フロー、`loginWithGoogle`・`handleOAuthCallback` を `useAuth` に追加、`useCognitoConfig` 新設、CDK に Google Identity Provider・Cognito Domain を追加） |
+| 2026-04-03 | 1.7.2      | CORS オリジン制限の強化: prod・stg 環境では CloudFront URL のみ許可、dev 環境のみ localhost:3010 を追加許可するよう変更                                                                                                        |
+| 2026-04-02 | 1.7.1      | カテゴリの値を `shared/constants.ts` に一元管理し、フロント・バックエンドから re-export。型・Zodスキーマ・フォーム選択肢を導出するよう統一                                                                                     |
+| 2026-03-31 | 1.7.0      | トークンリフレッシュ機能追加（`POST /auth/refresh` エンドポイント新設、ログイン時に `refreshToken`・有効期限を保存、auth ミドルウェアで期限切れ時に自動リフレッシュ、401 時にリフレッシュ試行後リトライ）                      |
+| 2026-03-28 | 1.6.1      | コード品質改善: truthy/falsy 依存を全廃し明示的な null/undefined 比較に統一。`@typescript-eslint/strict-boolean-expressions` および `vitest/no-restricted-matchers` ESLint ルールを追加し再発を防止                            |
+| 2026-03-26 | 1.6.0      | `ListeningLogForm` に楽曲選択時の動画プレビュー機能を追加（`videoUrl` ありの曲を選択すると `VideoPlayer` をインライン表示）                                                                                                    |
+| 2026-03-25 | 1.5.0      | 楽曲詳細ページ（`/pieces/[id]`）追加、`VideoPlayer`・`QuickLogForm`・`PieceDetailTemplate` 新設、動画再生起点のクイックログ記録フローを実装                                                                                    |
+| 2026-03-23 | 1.3.3      | `useFetch` の `onResponseError` で 401 時に `handleAuthError` を呼び出し、ログイン画面へリダイレクトするよう修正（`useListeningLogs.list`、`useListeningLog`）                                                                 |
+| 2026-03-22 | 1.3.2      | ヘッダーナビゲーション改善（未ログイン時: 新規登録・ログインリンク表示、ログイン済み時: ログアウトボタン表示・認証リンク非表示）                                                                                               |
+| 2026-03-21 | 1.3.1      | ログアウト機能追加（useAuth: logout/isAuthenticated、auth ミドルウェア、ナビバーボタン）                                                                                                                                       |
+| 2026-03-25 | 1.4.0      | `Piece` に `videoUrl` フィールドを追加（任意・URL形式バリデーション）、楽曲フォームに動画 URL 入力欄を追加                                                                                                                     |
+| 2026-03-21 | 1.3.0      | AWS Cognito ユーザー登録機能を追加（`POST /auth/register`、`useAuth` composable）                                                                                                                                              |
+| 2026-03-17 | 1.2.5      | CDK CORS 設定を DRY 化（`addCors` ヘルパー）、型定義ファイルの管理方針コメントを整備                                                                                                                                           |
+| 2026-03-17 | 1.2.4      | Create入力の実体バリデーション強化（空白のみ禁止・最大文字数制限）                                                                                                                                                             |
+| 2026-03-16 | 1.2.3      | Zod を導入しリクエストボディのパース処理にバリデーションを統合                                                                                                                                                                 |
+| 2026-03-15 | 1.2.2      | `listening-logs/list.ts` を DynamoDB ページネーション対応に統一                                                                                                                                                                |
+| 2026-03-15 | 1.2.1      | バックエンドの JSON パース処理を `utils/parsing.ts` に共通化                                                                                                                                                                   |
+| 2026-03-11 | 1.2.0      | TOPページに管理者向けリンクセクション（楽曲マスタ導線）を追加                                                                                                                                                                  |
+| 2026-03-07 | 1.1.0      | performer・conductor フィールド削除、DELETE レスポンス 204 に修正                                                                                                                                                              |
+| 2026-03-02 | 1.0.1      | Node.js 24.x対応                                                                                                                                                                                                               |
+| 2026-03-02 | 1.0.0      | 初版作成                                                                                                                                                                                                                       |

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -15,6 +15,8 @@ export default defineNuxtConfig({
   runtimeConfig: {
     public: {
       apiBaseUrl: "", // NUXT_PUBLIC_API_BASE_URL 環境変数で上書き可能
+      cognitoDomain: "", // NUXT_PUBLIC_COGNITO_DOMAIN 環境変数で上書き可能
+      cognitoClientId: "", // NUXT_PUBLIC_COGNITO_CLIENT_ID 環境変数で上書き可能
     },
   },
   test: {


### PR DESCRIPTION
## Summary

- Cognito Hosted UI 経由の Google サインインフローを実装（issue #286）
- `useCognitoConfig` composable を新設し、ドメイン・クライアント ID を管理
- `useAuth` に `loginWithGoogle` / `handleOAuthCallback` を追加
- ログインページに「Google でログイン」ボタンを追加
- `/auth/callback` ページを新設（認可コードをトークンと交換して localStorage に保存）
- CDK: S3/CloudFront を App Client より先に作成する構成に変更し、実際の callback URL を設定
- CDK: `UserPoolIdentityProviderGoogle` と Cognito Hosted UI ドメインを追加（`GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` 環境変数で制御）

## デプロイ前に必要な設定

| 項目 | 説明 |
|---|---|
| Google Cloud Console | OAuth 2.0 クライアント ID/シークレットを取得し、リダイレクト URI に `https://{cognitoDomain}/oauth2/idpresponse` を登録 |
| GitHub Secrets | `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を追加 |
| フロントエンド環境変数 | `NUXT_PUBLIC_COGNITO_DOMAIN` / `NUXT_PUBLIC_COGNITO_CLIENT_ID`（CDK Output の `CognitoDomainName` / `CognitoClientId` を設定） |

## Test plan

- [ ] ログインページに「Google でログイン」ボタンが表示される
- [ ] ボタンクリックで Cognito Hosted UI（Google OAuth）へリダイレクトする
- [ ] Google 認証後に `/auth/callback` へ戻り、トークンが localStorage に保存される
- [ ] 認証成功後にトップページへ遷移する
- [ ] `GOOGLE_CLIENT_ID` 未設定時はメール/パスワードログインのみ機能する（Google ボタンは引き続き表示されるが Cognito に IdP が未設定のためエラー）
- [ ] フロントエンドテスト: `npm run test:frontend`（438件 PASS）

🤖 Generated with [Claude Code](https://claude.ai/claude-code)