### PR TITLE
fix: deploy時にGoogle OAuth認証情報をCDKへ渡すよう修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -206,3 +206,5 @@ jobs:
         working-directory: cdk
         env:
           STAGE_NAME: ${{ env.STAGE_NAME }}
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}


### PR DESCRIPTION
## Summary

- CDKデプロイステップに `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` を環境変数として渡すよう修正
- これらが未設定の場合、CDKスタックがGoogle IdPを作成せず、CognitoのApp ClientにGoogleが追加されないため「Login option is not available」エラーが発生していた

## 原因

`cdk/lib/classical-music-lake-stack.ts` では以下のように、環境変数が設定されている場合のみGoogle IdPを作成する実装になっている：

\`\`\`typescript
const hasGoogleCredentials = googleClientId !== "" && googleClientSecret !== "";
if (hasGoogleCredentials) {
  // Google IdP を作成・App Clientに追加
}
\`\`\`

しかし `.github/workflows/deploy.yml` のCDK Deployステップにこれらのシークレットが渡されていなかった。

## 必要な対応

GitHubリポジトリの Settings → Secrets and variables → Actions に以下を登録すること：
- `GOOGLE_CLIENT_ID`
- `GOOGLE_CLIENT_SECRET`

## Test plan

- [ ] `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` をGitHub Secretsに登録する
- [ ] デプロイ後、CognitoコンソールでApp ClientにGoogleが追加されていることを確認
- [ ] Googleログインボタンをクリックして「Login option is not available」エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)