### PR TITLE
feat: pre-signupトリガーでGoogleアカウントと既存ユーザーを自動リンク

### DIFF
--- a/backend/src/auth/pre-signup.ts
+++ b/backend/src/auth/pre-signup.ts
@@ -1,0 +1,63 @@
+import {
+  AdminLinkProviderForUserCommand,
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+import type { PreSignUpTriggerHandler } from "aws-lambda";
+
+const cognito = new CognitoIdentityProviderClient({});
+
+export const handler: PreSignUpTriggerHandler = async (event) => {
+  // 外部プロバイダー（Google等）経由のサインアップ以外はスキップ
+  if (event.triggerSource !== "PreSignUp_ExternalProvider") {
+    return event;
+  }
+
+  const email = event.request.userAttributes.email;
+  if (email === undefined || email === "") {
+    return event;
+  }
+
+  const userPoolId = event.userPoolId;
+
+  // 同じメールアドレスを持つ既存の確認済みユーザーを検索
+  const listResult = await cognito.send(
+    new ListUsersCommand({
+      UserPoolId: userPoolId,
+      Filter: `email = "${email}"`,
+      Limit: 1,
+    })
+  );
+
+  const existingUser = (listResult.Users ?? []).find(
+    (u) => u.UserStatus === "CONFIRMED" && u.Username !== undefined
+  );
+
+  if (existingUser === undefined || existingUser.Username === undefined) {
+    return event;
+  }
+
+  // userName は "Google_<providerUserId>" の形式
+  const underscoreIndex = event.userName.indexOf("_");
+  const providerName = event.userName.substring(0, underscoreIndex); // "Google"
+  const providerUserId = event.userName.substring(underscoreIndex + 1);
+
+  // 既存の Cognito ユーザーに外部アカウントをリンク
+  await cognito.send(
+    new AdminLinkProviderForUserCommand({
+      UserPoolId: userPoolId,
+      DestinationUser: {
+        ProviderName: "Cognito",
+        ProviderAttributeName: "Username",
+        ProviderAttributeValue: existingUser.Username,
+      },
+      SourceUser: {
+        ProviderName: providerName,
+        ProviderAttributeName: "Cognito_Subject",
+        ProviderAttributeValue: providerUserId,
+      },
+    })
+  );
+
+  return event;
+};

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -337,6 +337,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const authVerifyEmail = fn("AuthVerifyEmail", "auth/verify-email.ts");
     const authResendCode = fn("AuthResendCode", "auth/resend-verification-code.ts");
     const authRefresh = fn("AuthRefresh", "auth/refresh.ts");
+    const authPreSignUp = fn("AuthPreSignUp", "auth/pre-signup.ts");
+
+    // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
+    // いる場合に自動でアカウントリンクを行う
+    userPool.addTrigger(cognito.UserPoolOperation.PRE_SIGN_UP, authPreSignUp);
 
     // -------------------------
     // Cognito 権限付与
@@ -380,6 +385,14 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       resources: [userPool.userPoolArn],
     });
     authRefresh.addToRolePolicy(cognitoRefreshPolicy);
+
+    // auth/pre-signup: ListUsers + AdminLinkProviderForUser を実行
+    const cognitoPreSignUpPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ["cognito-idp:ListUsers", "cognito-idp:AdminLinkProviderForUser"],
+      resources: [userPool.userPoolArn],
+    });
+    authPreSignUp.addToRolePolicy(cognitoPreSignUpPolicy);
 
     // -------------------------
     // DynamoDB 権限付与
@@ -630,6 +643,7 @@ function handler(event) {
       authVerifyEmail,
       authResendCode,
       authRefresh,
+      authPreSignUp,
     ];
 
     // Lambda エラー監視：各関数ごとにアラーム作成


### PR DESCRIPTION
## Summary

- Cognito PreSignUp Lambdaトリガーを追加
- Googleでログイン時に同じメールアドレスの確認済みユーザーが存在する場合、`AdminLinkProviderForUser` で自動リンク
- リンク後はメール/パスワード・Googleどちらの方法でも同一アカウント（同一 `userId`）でログイン可能

## 動作フロー

```
メール/パスワードで登録済みユーザーが初めてGoogleでログイン
  → PreSignUp トリガー発火
  → ListUsers で同じメールの確認済みユーザーを検索
  → 発見: AdminLinkProviderForUser でリンク
  → 以降は同一アカウントとして扱われる（視聴ログ等も共有）
```

## Test plan

- [ ] メール/パスワードで登録済みのアカウントと同じメールのGoogleアカウントでログインし、同一ユーザーとして認識されることを確認
- [ ] 新規Googleアカウント（未登録メール）でログインし、新規ユーザーとして作成されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)