### PR TITLE
fix: pre-signupトリガーのIAMポリシーで循環依存を解消

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -387,10 +387,12 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     authRefresh.addToRolePolicy(cognitoRefreshPolicy);
 
     // auth/pre-signup: ListUsers + AdminLinkProviderForUser を実行
+    // NOTE: userPool.userPoolArn を使うと CognitoUserPool ↔ AuthPreSignUp の循環依存が
+    // 発生するため、リソースを "*" にして依存関係を断ち切る
     const cognitoPreSignUpPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       actions: ["cognito-idp:ListUsers", "cognito-idp:AdminLinkProviderForUser"],
-      resources: [userPool.userPoolArn],
+      resources: ["*"],
     });
     authPreSignUp.addToRolePolicy(cognitoPreSignUpPolicy);
 


### PR DESCRIPTION
## Summary

- `authPreSignUp` LambdaのIAMポリシーリソースを `userPool.userPoolArn` から `"*"` に変更

## 原因

```
CognitoUserPool → AuthPreSignUp Lambda（トリガー設定）
AuthPreSignUp IAM Policy → CognitoUserPool.Arn（リソース参照）
```

この循環参照により CloudFormation が `ValidationError: Circular dependency between resources` を返しデプロイが失敗していた。

## 対処

IAM ポリシーのリソースを `"*"` にすることで循環依存を断ち切る。
この Lambda は Cognito サービスからのみ呼び出されるため、セキュリティ上の影響は軽微。

## Test plan

- [ ] デプロイが正常に完了することを確認
- [ ] Googleログインで既存メールアドレスのユーザーにリンクされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)