### PR TITLE
fix: callbackページでCognitoのerrorパラメーターを処理してエラー詳細を表示

### DIFF
--- a/app/pages/auth/callback.test.ts
+++ b/app/pages/auth/callback.test.ts
@@ -58,6 +58,37 @@ describe("CallbackPage", () => {
     });
   });
 
+  describe("Cognito がエラーを返した場合", () => {
+    it("error_description をエラーメッセージに含めて表示する", async () => {
+      const wrapper = await mountSuspended(CallbackPage, {
+        route: "/auth/callback?error=access_denied&error_description=Login+option+is+not+available",
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain("ログインに失敗しました");
+      expect(wrapper.text()).toContain("Login option is not available");
+    });
+
+    it("error_description がない場合は汎用メッセージを表示する", async () => {
+      const wrapper = await mountSuspended(CallbackPage, {
+        route: "/auth/callback?error=access_denied",
+      });
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.text()).toContain("ログインに失敗しました");
+    });
+
+    it("handleOAuthCallback を呼び出さない", async () => {
+      await mountSuspended(CallbackPage, {
+        route: "/auth/callback?error=access_denied&error_description=some+error",
+      });
+
+      expect(mockHandleOAuthCallback).not.toHaveBeenCalled();
+    });
+  });
+
   describe("code がない場合", () => {
     it("エラーメッセージを表示する", async () => {
       const wrapper = await mountSuspended(CallbackPage, {

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -8,6 +8,17 @@ const { handleOAuthCallback } = useAuth();
 const error = ref<string | null>(null);
 
 onMounted(async () => {
+  // Cognito がエラー時に ?error=...&error_description=... を付けてリダイレクトする
+  const cognitoError = route.query.error as string | undefined;
+  if (cognitoError !== undefined && cognitoError !== "") {
+    const description = route.query.error_description as string | undefined;
+    error.value =
+      description !== undefined && description !== ""
+        ? `ログインに失敗しました: ${description}`
+        : "ログインに失敗しました。もう一度お試しください。";
+    return;
+  }
+
   const code = route.query.code as string | undefined;
   if (code === undefined || code === "") {
     error.value = "ログインに失敗しました。もう一度お試しください。";


### PR DESCRIPTION
## Summary

- `/auth/callback` で Cognito が返す `?error=...&error_description=...` を処理し、エラー詳細をユーザーに表示するよう改善

## 背景

Playwright MCP で Google ログインフローを調査した結果、Cognito がエラー時に `?error=access_denied&error_description=Login+option+is+not+available` 等のパラメーターを付けてコールバック URL にリダイレクトすることを確認。

修正前は `code` パラメーターの有無しか確認しておらず、Cognito のエラーパラメーターは無視されて汎用メッセージ「ログインに失敗しました。もう一度お試しください。」のみ表示されていた。

## Test plan

- [ ] Google 認証でエラーが発生した場合（例: IdP 未設定時）にエラー詳細が表示されることを確認
- [ ] 正常な Google ログインフローが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)