### PR TITLE
Update SonarQube badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Classical Music Lake
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=konabe_classical-music-lake&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=konabe_classical-music-lake)
+[![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=konabe_classical-music-lake)
 [![Known Vulnerabilities](https://snyk.io/test/github/konabe/classical-music-lake/badge.svg)](https://snyk.io/test/github/konabe/classical-music-lake)
 
 クラシック音楽の鑑賞体験を記録・管理するWebアプリケーション。


### PR DESCRIPTION
## 概要

README.mdのSonarQube Cloud バッジを更新しました。Quality Gate Statusバッジから、SonarQube Cloudの公式バッジに変更しています。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [ ] リファクタリング
- [x] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- SonarQube CloudのバッジURLを`https://sonarcloud.io/api/project_badges/measure?project=konabe_classical-music-lake&metric=alert_status`から`https://sonarcloud.io/images/project_badges/sonarcloud-light.svg`に変更
- バッジのalt textを「Quality Gate Status」から「SonarQube Cloud」に更新
- バッジのリンク先は変わらず`https://sonarcloud.io/summary/new_code?id=konabe_classical-music-lake`のままです

## テスト

- [x] ドキュメント変更のため、テストは不要です

## チェックリスト

- [x] コーディング規約に従っている（ドキュメント変更のため該当なし）

https://claude.ai/code/session_01HNNhQYD1vVdEsQK1eULkaV