### PR TITLE
Add Stryker mutation testing badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![SonarQube Cloud](https://sonarcloud.io/images/project_badges/sonarcloud-light.svg)](https://sonarcloud.io/summary/new_code?id=konabe_classical-music-lake)
 [![Known Vulnerabilities](https://snyk.io/test/github/konabe/classical-music-lake/badge.svg)](https://snyk.io/test/github/konabe/classical-music-lake)
 [![codecov](https://codecov.io/gh/konabe/classical-music-lake/graph/badge.svg?token=Q5QFLF326W)](https://codecov.io/gh/konabe/classical-music-lake)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2Fkonabe%2Fclassical-music-lake%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/konabe/classical-music-lake/main)
 
 クラシック音楽の鑑賞体験を記録・管理するWebアプリケーション。
 


### PR DESCRIPTION
## 概要

README.mdにStryker mutation testingのバッジを追加しました。プロジェクトの品質指標をより可視化するためのものです。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [x] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- README.mdの既存バッジセクション（SonarQube Cloud、Snyk、codecov）にStryker mutation testingバッジを追加
- バッジはプロジェクトのmainブランチのmutation testingダッシュボードにリンク

## テスト

- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約（CLAUDE.md）に従っている
- [x] 実装を含む変更の場合、`docs/SPEC.md` を更新した（ドキュメント変更のみ）

https://claude.ai/code/session_01SyEqKTqGdNX1QaCFvjFQJn