### PR TITLE
Enable Bash tool with unrestricted directory access in Claude settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -61,7 +61,8 @@
       "mcp__figma__generate_figma_design",
       "mcp__figma__get_code_connect_suggestions",
       "WebSearch",
-      "WebFetch(domain:www.npmjs.com)"
+      "WebFetch(domain:www.npmjs.com)",
+      "Bash(cd:*)"
     ],
     "ask": ["Bash(git push:*)"]
   },


### PR DESCRIPTION
## 概要

Claude設定ファイルのツール許可リストに `Bash(cd:*)` を追加し、Bashツールで任意のディレクトリへのアクセスを許可するように変更しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- `.claude/settings.json` の `tools` セクションに `"Bash(cd:*)"` を追加
- これにより、Bashツールで `cd` コマンドを使用して任意のディレクトリに移動できるようになります

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] 実装を含む変更ではないため、`docs/SPEC.md` の更新は不要

https://claude.ai/code/session_012BUpQ676GCcq3FsG2EAg8Q