### PR TITLE
fix: sonarqube指摘対応

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
       pull-requests: write
 
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
 
     steps:
       - name: Dependabot metadata

--- a/app/components/molecules/ConcertLogItem.vue
+++ b/app/components/molecules/ConcertLogItem.vue
@@ -12,7 +12,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <li class="log-item">
+  <div class="log-item">
     <div class="log-main">
       <div class="log-title">
         {{ concertLog.venue }}
@@ -31,7 +31,7 @@ const emit = defineEmits<{
     <div class="log-actions">
       <ButtonSecondary label="詳細" @click="emit('detail')" />
     </div>
-  </li>
+  </div>
 </template>
 
 <style scoped>

--- a/app/components/molecules/ListeningLogItem.vue
+++ b/app/components/molecules/ListeningLogItem.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <li class="log-item">
+  <div class="log-item">
     <div class="log-main">
       <div class="log-title">
         <FavoriteIndicator :is-favorite="listeningLog.isFavorite" />
@@ -34,7 +34,7 @@ const emit = defineEmits<{
       <ButtonSecondary label="編集" @click="emit('edit')" />
       <ButtonDanger label="削除" @click="emit('delete')" />
     </div>
-  </li>
+  </div>
 </template>
 
 <style scoped>

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -13,7 +13,7 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <li class="piece-item">
+  <div class="piece-item">
     <div class="piece-main">
       <div class="piece-title">{{ piece.title }}</div>
       <div class="piece-composer">{{ piece.composer }}</div>
@@ -26,7 +26,7 @@ const emit = defineEmits<{
       <ButtonSecondary label="編集" @click="emit('edit')" />
       <ButtonDanger label="削除" @click="emit('delete')" />
     </div>
-  </li>
+  </div>
 </template>
 
 <style scoped>

--- a/app/components/organisms/ConcertLogList.vue
+++ b/app/components/organisms/ConcertLogList.vue
@@ -15,12 +15,9 @@ const router = useRouter();
     >
 
     <ul v-else class="log-list">
-      <ConcertLogItem
-        v-for="log in logs"
-        :key="log.id"
-        :concert-log="log"
-        @detail="router.push(`/concert-logs/${log.id}`)"
-      />
+      <li v-for="log in logs" :key="log.id">
+        <ConcertLogItem :concert-log="log" @detail="router.push(`/concert-logs/${log.id}`)" />
+      </li>
     </ul>
   </div>
 </template>

--- a/app/components/organisms/ListeningLogList.vue
+++ b/app/components/organisms/ListeningLogList.vue
@@ -19,13 +19,13 @@ const router = useRouter();
     >
 
     <ul v-else class="log-list">
-      <ListeningLogItem
-        v-for="log in logs"
-        :key="log.id"
-        :listening-log="log"
-        @edit="router.push(`/listening-logs/${log.id}/edit`)"
-        @delete="emit('delete', log.id)"
-      />
+      <li v-for="log in logs" :key="log.id">
+        <ListeningLogItem
+          :listening-log="log"
+          @edit="router.push(`/listening-logs/${log.id}/edit`)"
+          @delete="emit('delete', log.id)"
+        />
+      </li>
     </ul>
   </div>
 </template>

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -25,14 +25,14 @@ const router = useRouter();
     >
 
     <ul v-else class="piece-list">
-      <PieceItem
-        v-for="piece in pieces"
-        :key="piece.id"
-        :piece="piece"
-        @detail="router.push(`/pieces/${piece.id}`)"
-        @edit="router.push(`/pieces/${piece.id}/edit`)"
-        @delete="emit('delete', piece)"
-      />
+      <li v-for="piece in pieces" :key="piece.id">
+        <PieceItem
+          :piece="piece"
+          @detail="router.push(`/pieces/${piece.id}`)"
+          @edit="router.push(`/pieces/${piece.id}/edit`)"
+          @delete="emit('delete', piece)"
+        />
+      </li>
     </ul>
   </div>
 </template>


### PR DESCRIPTION
## Summary
- **ワークフローセキュリティ**: `dependabot-auto-merge.yml` で `github.actor` の代わりに `github.event.pull_request.user.login` を使用し、`pull_request_target` イベントでの偽装リスクを排除
- **HTML構造修正**: Item コンポーネント（PieceItem, ListeningLogItem, ConcertLogItem）のルート要素を `<li>` から `<div>` に変更し、親の List コンポーネント側で `<li>` ラッパーを追加。`<ul>` > `<li>` の親子関係が同一ファイル内で完結するように修正

## Test plan
- [x] フロントエンドテスト全パス (72 files, 474 tests)
- [x] バックエンドテスト全パス (29 files, 366 tests)
- [x] lint-staged (ESLint, Prettier, Stylelint) パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)