### PR TITLE
Add cache invalidation to data mutation operations

### DIFF
--- a/app/composables/useConcertLogs.ts
+++ b/app/composables/useConcertLogs.ts
@@ -87,6 +87,7 @@ export const useConcertLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
     return response.json();
   };
 
@@ -99,6 +100,7 @@ export const useConcertLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
     return response.json();
   };
 
@@ -109,6 +111,7 @@ export const useConcertLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
   };
 
   return { ...list, create, update, deleteLog };

--- a/app/composables/useListeningLogs.ts
+++ b/app/composables/useListeningLogs.ts
@@ -87,6 +87,7 @@ export const useListeningLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
     return response.json();
   };
 
@@ -99,6 +100,7 @@ export const useListeningLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
     return response.json();
   };
 
@@ -109,6 +111,7 @@ export const useListeningLogs = () => {
     if (!response.ok) {
       return throwResponseError(response);
     }
+    clearNuxtData();
   };
 
   return { ...list, create, update, deleteLog };

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -4,11 +4,17 @@ export const usePieces = () => {
   const apiBase = useApiBase();
   const list = useFetch<Piece[]>(`${apiBase}/pieces`);
 
-  const createPiece = (input: CreatePieceInput) =>
-    $fetch<Piece>(`${apiBase}/pieces`, { method: "POST", body: input });
+  const createPiece = async (input: CreatePieceInput) => {
+    const result = await $fetch<Piece>(`${apiBase}/pieces`, { method: "POST", body: input });
+    clearNuxtData();
+    return result;
+  };
 
-  const updatePiece = (id: string, input: UpdatePieceInput) =>
-    $fetch<Piece>(`${apiBase}/pieces/${id}`, { method: "PUT", body: input });
+  const updatePiece = async (id: string, input: UpdatePieceInput) => {
+    const result = await $fetch<Piece>(`${apiBase}/pieces/${id}`, { method: "PUT", body: input });
+    clearNuxtData();
+    return result;
+  };
 
   return { ...list, createPiece, updatePiece };
 };


### PR DESCRIPTION
## 概要

データ変更操作（作成・更新・削除）後にNuxtのデータキャッシュをクリアするよう修正しました。これにより、API呼び出し後に最新のデータが確実に取得されるようになります。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- **usePieces.ts**: `createPiece` と `updatePiece` を async 関数に変更し、API呼び出し後に `clearNuxtData()` を呼び出すように修正
- **useConcertLogs.ts**: `create`、`update`、`deleteLog` メソッド内で API呼び出し後に `clearNuxtData()` を呼び出すように修正
- **useListeningLogs.ts**: `create`、`update`、`deleteLog` メソッド内で API呼び出し後に `clearNuxtData()` を呼び出すように修正

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [ ] 実装を含む変更の場合、`docs/SPEC.md` を更新した（ドキュメント更新不要）

https://claude.ai/code/session_01DanEvKs2bSA86fzrgAK3dS