### PR TITLE
chore: add pnpm-lock.yaml to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,6 +6,7 @@ node_modules/
 backend/node_modules/
 cdk/node_modules/
 package-lock.json
+pnpm-lock.yaml
 .claude/
 # release-please が自動生成するため除外
 CHANGELOG.md


### PR DESCRIPTION
## Summary
- `pnpm-lock.yaml` を `.prettierignore` に追加
- Dependabot PR のロックファイル更新が prettier チェックを通過するようになる

## Test plan
- [ ] Lint & Format CI が通過することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)