### PR TITLE
fix: disable noUncheckedSideEffectImports in CDK tsconfig for TypeScript 6

### DIFF
--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -11,7 +11,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"]
+    "types": ["node"],
+    "noUncheckedSideEffectImports": false
   },
   "include": ["bin/**/*", "lib/**/*"],
   "exclude": ["node_modules", "dist", "cdk.out"]


### PR DESCRIPTION
## Summary

TypeScript 6.0 で `noUncheckedSideEffectImports` がデフォルト `true` になったことで、CDK の `bin/app.ts` にある `import 'source-map-support/register'` が型定義なしとして `TS2882` エラーになっていた問題を修正します。

**エラー内容:**
```
error TS2882: Cannot find module or type declarations for side-effect import of 'source-map-support/register'.
```

**対応:** `cdk/tsconfig.json` に `"noUncheckedSideEffectImports": false` を追加して TypeScript 5 と同じ挙動に戻す。

## Test plan
- [ ] Deploy CI が通過すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)