### PR TITLE
refactor: エラーハンドリングパターンをバックエンド・フロントエンドで統一

### DIFF
--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -620,18 +620,20 @@ describe("useAuth", () => {
       expect(localStorage.getItem(TOKEN_EXPIRES_AT_KEY)).not.toBeNull();
     });
 
-    it("トークン取得失敗時にエラーをスローする", async () => {
+    it("トークン取得失敗時に success: false を返す", async () => {
       mockFetch.mockResolvedValue({ ok: false });
 
       const { handleOAuthCallback } = useAuth();
-      await expect(handleOAuthCallback("bad-code")).rejects.toThrow();
+      const result = await handleOAuthCallback("bad-code");
+      expect(result.success).toBe(false);
     });
 
-    it("ネットワークエラー時にエラーをスローする", async () => {
+    it("ネットワークエラー時に success: false を返す", async () => {
       mockFetch.mockRejectedValue(new Error("Network error"));
 
       const { handleOAuthCallback } = useAuth();
-      await expect(handleOAuthCallback("code")).rejects.toThrow();
+      const result = await handleOAuthCallback("code");
+      expect(result.success).toBe(false);
     });
   });
 

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -400,7 +400,9 @@ export const useAuth = () => {
     window.location.href = url.toString();
   };
 
-  const handleOAuthCallback = async (code: string): Promise<void> => {
+  const handleOAuthCallback = async (
+    code: string
+  ): Promise<{ success: boolean; error?: string }> => {
     const redirectUri = `${window.location.origin}/auth/callback`;
     const body = new URLSearchParams({
       grant_type: "authorization_code",
@@ -409,19 +411,24 @@ export const useAuth = () => {
       redirect_uri: redirectUri,
     });
 
-    const response = await fetch(`https://${cognitoDomain}/oauth2/token`, {
-      method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
-      body: body.toString(),
-    });
+    try {
+      const response = await fetch(`https://${cognitoDomain}/oauth2/token`, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: body.toString(),
+      });
 
-    if (!response.ok) {
-      throw new Error("Token exchange failed");
+      if (!response.ok) {
+        return { success: false, error: "Token exchange failed" };
+      }
+
+      const data = await response.json();
+      localStorage.setItem(REFRESH_TOKEN_KEY, data.refresh_token);
+      saveSessionTokens(data.access_token, data.id_token, data.expires_in);
+      return { success: true };
+    } catch {
+      return { success: false, error: "Network error" };
     }
-
-    const data = await response.json();
-    localStorage.setItem(REFRESH_TOKEN_KEY, data.refresh_token);
-    saveSessionTokens(data.access_token, data.id_token, data.expires_in);
   };
 
   return {

--- a/app/pages/auth/callback.test.ts
+++ b/app/pages/auth/callback.test.ts
@@ -16,7 +16,7 @@ beforeEach(() => {
 describe("CallbackPage", () => {
   describe("code がある場合", () => {
     it("handleOAuthCallback を code 付きで呼び出す", async () => {
-      mockHandleOAuthCallback.mockResolvedValue(undefined);
+      mockHandleOAuthCallback.mockResolvedValue({ success: true });
 
       await mountSuspended(CallbackPage, {
         route: "/auth/callback?code=test-auth-code",
@@ -27,9 +27,9 @@ describe("CallbackPage", () => {
 
     it("成功時に / へリダイレクトする", async () => {
       // handleOAuthCallback を pending にして spy セットアップ後に解決させる
-      let resolveCallback!: () => void;
+      let resolveCallback!: (value: { success: boolean }) => void;
       mockHandleOAuthCallback.mockReturnValue(
-        new Promise<void>((resolve) => {
+        new Promise<{ success: boolean }>((resolve) => {
           resolveCallback = resolve;
         })
       );
@@ -39,14 +39,17 @@ describe("CallbackPage", () => {
       });
       const pushSpy = vi.spyOn(wrapper.vm.$router, "push");
 
-      resolveCallback();
+      resolveCallback({ success: true });
       await wrapper.vm.$nextTick();
 
       expect(pushSpy).toHaveBeenCalledWith("/");
     });
 
     it("handleOAuthCallback が失敗したときエラーメッセージを表示する", async () => {
-      mockHandleOAuthCallback.mockRejectedValue(new Error("Token exchange failed"));
+      mockHandleOAuthCallback.mockResolvedValue({
+        success: false,
+        error: "Token exchange failed",
+      });
 
       const wrapper = await mountSuspended(CallbackPage, {
         route: "/auth/callback?code=bad-code",

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -24,10 +24,10 @@ onMounted(async () => {
     error.value = "ログインに失敗しました。もう一度お試しください。";
     return;
   }
-  try {
-    await handleOAuthCallback(code);
+  const result = await handleOAuthCallback(code);
+  if (result.success) {
     await router.push("/");
-  } catch {
+  } else {
     error.value = "ログインに失敗しました。もう一度お試しください。";
   }
 });

--- a/backend/src/auth/login.ts
+++ b/backend/src/auth/login.ts
@@ -2,12 +2,12 @@ import {
   CognitoIdentityProviderClient,
   InitiateAuthCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
-import { StatusCodes } from "http-status-codes";
 
 import { createHandler, jsonBodyParser } from "../utils/middleware";
 import { parseRequestBody } from "../utils/parsing";
 import { loginSchema } from "../utils/schemas";
 import { getEnv } from "../utils/env";
+import { ok, unauthorized, forbidden, tooManyRequests } from "../utils/response";
 import type { CognitoError } from "../types";
 
 const cognito = new CognitoIdentityProviderClient({});
@@ -30,16 +30,13 @@ export const handler = createHandler(async (event) => {
 
     const authResult = response.AuthenticationResult;
 
-    return {
-      statusCode: StatusCodes.OK,
-      body: {
-        accessToken: authResult?.AccessToken,
-        idToken: authResult?.IdToken,
-        refreshToken: authResult?.RefreshToken,
-        tokenType: authResult?.TokenType ?? "Bearer",
-        expiresIn: authResult?.ExpiresIn,
-      },
-    };
+    return ok({
+      accessToken: authResult?.AccessToken,
+      idToken: authResult?.IdToken,
+      refreshToken: authResult?.RefreshToken,
+      tokenType: authResult?.TokenType ?? "Bearer",
+      expiresIn: authResult?.ExpiresIn,
+    });
   } catch (error) {
     const cognitoError = error as CognitoError;
 
@@ -47,33 +44,18 @@ export const handler = createHandler(async (event) => {
       cognitoError.name === "NotAuthorizedException" ||
       cognitoError.name === "UserNotFoundException"
     ) {
-      return {
-        statusCode: StatusCodes.UNAUTHORIZED,
-        body: {
-          error: "InvalidCredentials",
-          message: "Email or password is incorrect.",
-        },
-      };
+      return unauthorized("InvalidCredentials", "Email or password is incorrect.");
     }
 
     if (cognitoError.name === "UserNotConfirmedException") {
-      return {
-        statusCode: StatusCodes.FORBIDDEN,
-        body: {
-          error: "UserNotConfirmed",
-          message: "User account is not confirmed. Please verify your email.",
-        },
-      };
+      return forbidden(
+        "UserNotConfirmed",
+        "User account is not confirmed. Please verify your email."
+      );
     }
 
     if (cognitoError.name === "TooManyRequestsException") {
-      return {
-        statusCode: StatusCodes.TOO_MANY_REQUESTS,
-        body: {
-          error: "TooManyRequests",
-          message: "Too many login attempts. Please try again later.",
-        },
-      };
+      return tooManyRequests("Too many login attempts. Please try again later.");
     }
 
     throw error;

--- a/backend/src/auth/refresh.ts
+++ b/backend/src/auth/refresh.ts
@@ -2,12 +2,12 @@ import {
   CognitoIdentityProviderClient,
   InitiateAuthCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
-import { StatusCodes } from "http-status-codes";
 
 import { createHandler, jsonBodyParser } from "../utils/middleware";
 import { parseRequestBody } from "../utils/parsing";
 import { refreshTokenSchema } from "../utils/schemas";
 import { getEnv } from "../utils/env";
+import { ok, unauthorized, tooManyRequests } from "../utils/response";
 import type { CognitoError } from "../types";
 
 const cognito = new CognitoIdentityProviderClient({});
@@ -29,36 +29,24 @@ export const handler = createHandler(async (event) => {
 
     const authResult = response.AuthenticationResult;
 
-    return {
-      statusCode: StatusCodes.OK,
-      body: {
-        accessToken: authResult?.AccessToken,
-        idToken: authResult?.IdToken,
-        tokenType: authResult?.TokenType ?? "Bearer",
-        expiresIn: authResult?.ExpiresIn,
-      },
-    };
+    return ok({
+      accessToken: authResult?.AccessToken,
+      idToken: authResult?.IdToken,
+      tokenType: authResult?.TokenType ?? "Bearer",
+      expiresIn: authResult?.ExpiresIn,
+    });
   } catch (error) {
     const cognitoError = error as CognitoError;
 
     if (cognitoError.name === "NotAuthorizedException") {
-      return {
-        statusCode: StatusCodes.UNAUTHORIZED,
-        body: {
-          error: "InvalidRefreshToken",
-          message: "Refresh token is invalid or expired. Please login again.",
-        },
-      };
+      return unauthorized(
+        "InvalidRefreshToken",
+        "Refresh token is invalid or expired. Please login again."
+      );
     }
 
     if (cognitoError.name === "TooManyRequestsException") {
-      return {
-        statusCode: StatusCodes.TOO_MANY_REQUESTS,
-        body: {
-          error: "TooManyRequests",
-          message: "Too many requests. Please try again later.",
-        },
-      };
+      return tooManyRequests("Too many requests. Please try again later.");
     }
 
     throw error;

--- a/backend/src/auth/register.ts
+++ b/backend/src/auth/register.ts
@@ -2,12 +2,12 @@ import {
   CognitoIdentityProviderClient,
   SignUpCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
-import { StatusCodes } from "http-status-codes";
 
 import { createHandler, jsonBodyParser } from "../utils/middleware";
 import { parseRequestBody } from "../utils/parsing";
 import { registerSchema } from "../utils/schemas";
 import { getEnv } from "../utils/env";
+import { created, badRequest, tooManyRequests } from "../utils/response";
 import type { CognitoError } from "../types";
 
 const cognito = new CognitoIdentityProviderClient({});
@@ -31,44 +31,25 @@ export const handler = createHandler(async (event) => {
       })
     );
 
-    return {
-      statusCode: StatusCodes.CREATED,
-      body: {
-        message: "User created successfully. Please check your email to verify your account.",
-      },
-    };
+    return created({
+      message: "User created successfully. Please check your email to verify your account.",
+    });
   } catch (error) {
     const cognitoError = error as CognitoError;
 
     if (cognitoError.name === "UsernameExistsException") {
-      return {
-        statusCode: StatusCodes.BAD_REQUEST,
-        body: {
-          error: "UserExists",
-          message: "An account with the given email already exists.",
-        },
-      };
+      return badRequest("UserExists", "An account with the given email already exists.");
     }
 
     if (cognitoError.name === "InvalidPasswordException") {
-      return {
-        statusCode: StatusCodes.BAD_REQUEST,
-        body: {
-          error: "InvalidPassword",
-          message:
-            "Password does not meet the requirements. Password must be at least 8 characters long and contain uppercase, lowercase, and numeric characters.",
-        },
-      };
+      return badRequest(
+        "InvalidPassword",
+        "Password does not meet the requirements. Password must be at least 8 characters long and contain uppercase, lowercase, and numeric characters."
+      );
     }
 
     if (cognitoError.name === "TooManyRequestsException") {
-      return {
-        statusCode: StatusCodes.TOO_MANY_REQUESTS,
-        body: {
-          error: "TooManyRequests",
-          message: "Too many registration attempts. Please try again later.",
-        },
-      };
+      return tooManyRequests("Too many registration attempts. Please try again later.");
     }
 
     throw error;

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -5,8 +5,23 @@ export const ok = (body: Record<string, unknown>) => ({
   body,
 });
 
+export const created = (body: Record<string, unknown>) => ({
+  statusCode: StatusCodes.CREATED,
+  body,
+});
+
 export const badRequest = (error: string, message: string) => ({
   statusCode: StatusCodes.BAD_REQUEST,
+  body: { error, message },
+});
+
+export const unauthorized = (error: string, message: string) => ({
+  statusCode: StatusCodes.UNAUTHORIZED,
+  body: { error, message },
+});
+
+export const forbidden = (error: string, message: string) => ({
+  statusCode: StatusCodes.FORBIDDEN,
   body: { error, message },
 });
 

--- a/docs/projects/REARCHITECTING_20260411.md
+++ b/docs/projects/REARCHITECTING_20260411.md
@@ -1,0 +1,69 @@
+# リアーキテクチャリング チェックリスト
+
+## 🔴 優先度: 高
+
+### Composable の HTTP ロジック統一
+
+`useListeningLogs.ts` と `useConcertLogs.ts` で以下の関数が一字一句同じで重複（合計約270行）。
+違いはエンドポイント名（`listening-logs` vs `concert-logs`）のみ。
+
+| 重複関数             | 行数    |
+| -------------------- | ------- |
+| `getAuthHeaders`     | 5–8行   |
+| `handleAuthError`    | 10–28行 |
+| `throwResponseError` | 30–35行 |
+| `authenticatedFetch` | 41–68行 |
+
+**追加で判明した問題点:**
+
+- **二重リトライのリスク** — 401エラー時に `useFetch` の `onResponseError` と `authenticatedFetch` 内の401チェックが両方発火する可能性がある。`useAuth` 側の `refreshInFlight` で多重実行は防いでいるが、リトライ自体は2経路から起きうる
+- **ネットワークエラーの未処理** — `create` / `update` / `deleteLog` で `fetch` 例外・`response.json()` パースエラーが未キャッチのままコンポーネントに伝播する
+- **型安全性の欠如** — `response.json()` の戻り値が `any` のままキャストのみで返却（`useAuth.ts` では厳密に検証しているのに不統一）
+- **テスタビリティ** — `useApiBase()` / `useRouter()` / `useAuth()` / グローバル `fetch` を直接呼び出しているためモック注入不可。ユニットテストが書けず統合テストのみ対応可能
+
+**改善方針:** `useAuthenticatedApi()` を新設し、リトライ制御・エラー正規化・型検証を集約する。`useListeningLogs` / `useConcertLogs` はエンドポイント名を渡して呼ぶだけにする。
+
+- [x] `useListeningLogs` と `useConcertLogs` に完全複製されている `authenticatedFetch()` / `handleAuthError()` / `getAuthHeaders()` を `useAuthenticatedApi` に抽出
+- [x] `useAuthenticatedApi` 内でリトライ経路を一本化し、二重リトライを排除（`useFetch` と `authenticatedFetch` は GET/mutations で経路が分離されており衝突しないことをコメントで明示）
+- [x] ネットワークエラー・JSONパースエラーを `useAuthenticatedApi` 内で正規化してハンドリング（`doFetch` でネットワーク例外を正規化、`parseJsonResponse<T>` でJSONパースエラーをキャッチ）
+- [x] `response.json()` の戻り値に型検証を追加（`parseJsonResponse<T>` を導入し `create`・`update` の戻り値を型付き取得に統一）
+- [x] `fetch` のテスタビリティ（既存の `vi.stubGlobal("fetch", ...)` パターンで対応済み。構造的変更不要と判断）
+
+---
+
+## 🟡 優先度: 中
+
+### エラーハンドリングの統一
+
+- [x] バックエンドでエラー形式が3種類混在（直接返却 / ヘルパー関数 / middleware）— すべてのLambdaで `response.ok()` / `response.badRequest()` ヘルパーを使用に統一（`created` / `unauthorized` / `forbidden` を `response.ts` に追加し `auth/register.ts` / `auth/login.ts` / `auth/refresh.ts` を更新）
+- [x] フロントエンドで戻り値 vs 例外スローの2パターン混在 — `{ success, error?, errorType? }` に統一（`handleOAuthCallback` を `Promise<{ success: boolean; error?: string }>` に変更）
+
+### バリデーションロジックの一元化
+
+- [ ] パスワードバリデーションが `useAuth.ts` と `backend/src/utils/schemas.ts` で二重定義 — `shared/` に移動
+- [ ] フロントエンドに `isValidRating()` 相当がない — 共有バリデーション関数として `shared/validators.ts` に集約
+
+### `useAuth` の責務分離
+
+- [ ] トークン管理（localStorage操作）を `useTokenStorage()` に分離
+- [ ] Google OAuth 処理を `useOAuth()` に分離
+- [ ] バリデーション関数を `shared/` に移動
+
+### ConcertLogForm のロジック分離
+
+- [ ] ピース追加・削除・並び替え・初期化ロジックを `usePieceSelector()` composable に抽出（現在 `ConcertLogForm.vue` に直書き）
+
+---
+
+## 🟢 優先度: 低
+
+### コンポーネント設計の整理
+
+- [ ] `ListeningLogItem` と `ConcertLogItem` のスタイルが類似 — 共通の `ItemCard` 基盤コンポーネントを検討
+- [ ] `usePieces()` が複数コンポーネントで個別呼び出し — Pinia 導入によるマスタデータの一元管理を検討
+
+### アーキテクチャ全般
+
+- [ ] 依存方向の確認 — composable の依存グラフを整理し、循環依存がないか検証
+- [ ] テスタビリティ確認 — 各 composable が単体でテスト可能か（依存注入できるか）
+- [ ] 型定義ファイルの整理 — フロントエンドの型定義が `app/types/index.ts` に集約されているか確認


### PR DESCRIPTION
## Summary

- **バックエンド**: `auth/register.ts` / `auth/login.ts` / `auth/refresh.ts` が直接 `{ statusCode, body }` を返していた箇所を `response.ts` のヘルパー関数に統一。不足していた `created` / `unauthorized` / `forbidden` を `response.ts` に追加
- **フロントエンド**: `useAuth.handleOAuthCallback` が失敗時に例外をスローするパターンだったのを、他の useAuth 関数と同様の `{ success: boolean; error?: string }` 戻り値パターンに統一。`callback.vue` の try/catch を結果チェックに変更

## Test plan

- [x] `pnpm run test:backend` — 29 files, 372 tests passed
- [x] `pnpm run test:frontend` — 73 files, 503 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)