### PR TITLE
fix: sonarqube S7735 否定条件を正条件に書き換え

### DIFF
--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -17,9 +17,9 @@ const { data: pieces, pending: piecesPending } = usePieces();
 const form = reactive({
   title: props.initialValues?.title ?? "",
   concertDate:
-    props.initialValues?.concertDate !== undefined
-      ? toDatetimeLocal(props.initialValues.concertDate)
-      : nowAsDatetimeLocal(),
+    props.initialValues?.concertDate === undefined
+      ? nowAsDatetimeLocal()
+      : toDatetimeLocal(props.initialValues.concertDate),
   venue: props.initialValues?.venue ?? "",
   conductor: props.initialValues?.conductor ?? "",
   orchestra: props.initialValues?.orchestra ?? "",
@@ -71,9 +71,9 @@ function handleSubmit() {
     title: form.title,
     concertDate: new Date(form.concertDate).toISOString(),
     venue: form.venue,
-    conductor: form.conductor !== "" ? form.conductor : undefined,
-    orchestra: form.orchestra !== "" ? form.orchestra : undefined,
-    soloist: form.soloist !== "" ? form.soloist : undefined,
+    conductor: form.conductor === "" ? undefined : form.conductor,
+    orchestra: form.orchestra === "" ? undefined : form.orchestra,
+    soloist: form.soloist === "" ? undefined : form.soloist,
     pieceIds: selectedPieces.value.map((p) => p.id),
   };
   emit("submit", input);

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -15,9 +15,9 @@ const { data: pieces, pending: piecesPending } = usePieces();
 
 const form = reactive<CreateListeningLogInput>({
   listenedAt:
-    props.initialValues?.listenedAt !== undefined
-      ? toDatetimeLocal(props.initialValues.listenedAt)
-      : nowAsDatetimeLocal(),
+    props.initialValues?.listenedAt === undefined
+      ? nowAsDatetimeLocal()
+      : toDatetimeLocal(props.initialValues.listenedAt),
   composer: props.initialValues?.composer ?? "",
   piece: props.initialValues?.piece ?? "",
   rating: props.initialValues?.rating ?? 3,

--- a/app/composables/useAuthenticatedApi.ts
+++ b/app/composables/useAuthenticatedApi.ts
@@ -6,7 +6,7 @@ export const useAuthenticatedApi = () => {
 
   const getAuthHeaders = (): Record<string, string> => {
     const token = localStorage.getItem(ID_TOKEN_KEY);
-    return token !== null ? { Authorization: `Bearer ${token}` } : {};
+    return token === null ? {} : { Authorization: `Bearer ${token}` };
   };
 
   const handleAuthError = async (status: number): Promise<boolean> => {

--- a/backend/src/concert-logs/delete.test.ts
+++ b/backend/src/concert-logs/delete.test.ts
@@ -23,12 +23,12 @@ function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
     httpMethod: "DELETE",
     isBase64Encoded: false,
     path: `/concert-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/concert-logs/get.test.ts
+++ b/backend/src/concert-logs/get.test.ts
@@ -24,12 +24,12 @@ function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
     httpMethod: "GET",
     isBase64Encoded: false,
     path: `/concert-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/concert-logs/update.test.ts
+++ b/backend/src/concert-logs/update.test.ts
@@ -20,18 +20,18 @@ const OTHER_USER_ID = "cognito-sub-other-user";
 
 function makeEvent(id?: string, body?: string | null, userId?: string): APIGatewayProxyEvent {
   return {
-    body: body !== undefined ? body : null,
+    body: body === undefined ? null : body,
     headers: {},
     multiValueHeaders: {},
     httpMethod: "PUT",
     isBase64Encoded: false,
     path: `/concert-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/listening-logs/delete.test.ts
+++ b/backend/src/listening-logs/delete.test.ts
@@ -23,12 +23,12 @@ function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
     httpMethod: "DELETE",
     isBase64Encoded: false,
     path: `/listening-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/listening-logs/get.test.ts
+++ b/backend/src/listening-logs/get.test.ts
@@ -24,12 +24,12 @@ function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
     httpMethod: "GET",
     isBase64Encoded: false,
     path: `/listening-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/listening-logs/integration.test.ts
+++ b/backend/src/listening-logs/integration.test.ts
@@ -49,12 +49,12 @@ function makeEvent(options: {
     httpMethod: options.method,
     isBase64Encoded: false,
     path: options.path,
-    pathParameters: options.id !== undefined ? { id: options.id } : null,
+    pathParameters: options.id === undefined ? null : { id: options.id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: options.userId !== undefined ? { claims: { sub: options.userId } } : undefined,
+      authorizer: options.userId === undefined ? undefined : { claims: { sub: options.userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/listening-logs/update.test.ts
+++ b/backend/src/listening-logs/update.test.ts
@@ -20,18 +20,18 @@ const OTHER_USER_ID = "cognito-sub-other-user";
 
 function makeEvent(id?: string, body?: string | null, userId?: string): APIGatewayProxyEvent {
   return {
-    body: body !== undefined ? body : null,
+    body: body === undefined ? null : body,
     headers: {},
     multiValueHeaders: {},
     httpMethod: "PUT",
     isBase64Encoded: false,
     path: `/listening-logs/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
     requestContext: {
-      authorizer: userId !== undefined ? { claims: { sub: userId } } : undefined,
+      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
     } as APIGatewayProxyEvent["requestContext"],
     resource: "",
   };

--- a/backend/src/pieces/delete.test.ts
+++ b/backend/src/pieces/delete.test.ts
@@ -21,7 +21,7 @@ function makeEvent(id: string | null): APIGatewayProxyEvent {
     httpMethod: "DELETE",
     isBase64Encoded: false,
     path: `/pieces/${id ?? ""}`,
-    pathParameters: id !== null ? { id } : null,
+    pathParameters: id === null ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,

--- a/backend/src/pieces/get.test.ts
+++ b/backend/src/pieces/get.test.ts
@@ -21,7 +21,7 @@ function makeEvent(id?: string): APIGatewayProxyEvent {
     httpMethod: "GET",
     isBase64Encoded: false,
     path: `/pieces/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,

--- a/backend/src/pieces/update.test.ts
+++ b/backend/src/pieces/update.test.ts
@@ -20,13 +20,13 @@ const mockCallback = { signal: new AbortController().signal };
 
 function makeEvent(id?: string, body?: string | null): APIGatewayProxyEvent {
   return {
-    body: body !== undefined ? body : null,
+    body: body === undefined ? null : body,
     headers: {},
     multiValueHeaders: {},
     httpMethod: "PUT",
     isBase64Encoded: false,
     path: `/pieces/${id ?? ""}`,
-    pathParameters: id !== undefined ? { id } : null,
+    pathParameters: id === undefined ? null : { id },
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,


### PR DESCRIPTION
## Summary

- SonarQube ルール `typescript:S7735`（Unexpected negated condition）に該当する21箇所を修正
- テスト `makeEvent` ヘルパーの `!== undefined` / `!== null` 条件を正条件（`===`）に反転してブランチを入れ替え
- フロントエンドの composable・フォームコンポーネントも同様に修正

## 変更ファイル

| ファイル | 修正内容 |
|---|---|
| `app/composables/useAuthenticatedApi.ts` | `token !== null ?` → `token === null ?` |
| `app/components/organisms/ConcertLogForm.vue` | `!== undefined` / `!== ""` 条件を反転 |
| `app/components/organisms/ListeningLogForm.vue` | `!== undefined` 条件を反転 |
| `backend/src/concert-logs/*.test.ts` | `makeEvent` の `!== undefined` 条件を反転 |
| `backend/src/listening-logs/*.test.ts` | `makeEvent` の `!== undefined` 条件を反転 |
| `backend/src/pieces/*.test.ts` | `makeEvent` の `!== undefined` / `!== null` 条件を反転 |

## Test plan

- [x] `pnpm run test:backend` — 372 tests passed
- [x] `pnpm run test:frontend` — 503 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)