### PR TITLE
fix: sonarqube S7764 window を globalThis に書き換え

### DIFF
--- a/app/components/templates/ConcertLogDetailTemplate.test.ts
+++ b/app/components/templates/ConcertLogDetailTemplate.test.ts
@@ -86,7 +86,7 @@ describe("ConcertLogDetailTemplate", () => {
         global: { components: { ButtonSecondary, ButtonDanger } },
       });
       await wrapper.find(".btn-danger").trigger("click");
-      expect(window.confirm).toHaveBeenCalledWith("このコンサート記録を削除しますか？");
+      expect(globalThis.confirm).toHaveBeenCalledWith("このコンサート記録を削除しますか？");
     });
 
     it("confirm で OK を選択すると deleteLog が呼ばれる", async () => {

--- a/app/components/templates/ListeningLogDetailTemplate.test.ts
+++ b/app/components/templates/ListeningLogDetailTemplate.test.ts
@@ -65,7 +65,7 @@ describe("ListeningLogDetailTemplate", () => {
         global: { components: { ButtonSecondary, ButtonDanger } },
       });
       await wrapper.find(".btn-danger").trigger("click");
-      expect(window.confirm).toHaveBeenCalledWith("この鑑賞記録を削除しますか？");
+      expect(globalThis.confirm).toHaveBeenCalledWith("この鑑賞記録を削除しますか？");
     });
 
     it("confirm で OK を選択すると deleteLog が呼ばれる", async () => {

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -585,13 +585,13 @@ describe("useAuth", () => {
       const { loginWithGoogle } = useAuth();
       loginWithGoogle();
 
-      expect(window.location.href).toContain(
+      expect(globalThis.location.href).toContain(
         "test.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
       );
-      expect(window.location.href).toContain("identity_provider=Google");
-      expect(window.location.href).toContain("response_type=code");
-      expect(window.location.href).toContain("client_id=test-client-id");
-      expect(window.location.href).toContain("%2Fauth%2Fcallback");
+      expect(globalThis.location.href).toContain("identity_provider=Google");
+      expect(globalThis.location.href).toContain("response_type=code");
+      expect(globalThis.location.href).toContain("client_id=test-client-id");
+      expect(globalThis.location.href).toContain("%2Fauth%2Fcallback");
     });
   });
 

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -390,20 +390,20 @@ export const useAuth = () => {
   };
 
   const loginWithGoogle = (): void => {
-    const redirectUri = `${window.location.origin}/auth/callback`;
+    const redirectUri = `${globalThis.location.origin}/auth/callback`;
     const url = new URL(`https://${cognitoDomain}/oauth2/authorize`);
     url.searchParams.set("identity_provider", "Google");
     url.searchParams.set("redirect_uri", redirectUri);
     url.searchParams.set("response_type", "code");
     url.searchParams.set("client_id", cognitoClientId);
     url.searchParams.set("scope", "email openid profile");
-    window.location.href = url.toString();
+    globalThis.location.href = url.toString();
   };
 
   const handleOAuthCallback = async (
     code: string
   ): Promise<{ success: boolean; error?: string }> => {
-    const redirectUri = `${window.location.origin}/auth/callback`;
+    const redirectUri = `${globalThis.location.origin}/auth/callback`;
     const body = new URLSearchParams({
       grant_type: "authorization_code",
       client_id: cognitoClientId,

--- a/app/pages/listening-logs/index.test.ts
+++ b/app/pages/listening-logs/index.test.ts
@@ -62,7 +62,7 @@ describe("ListeningLogsPage（削除フロー結合）", () => {
   it("1件目の削除ボタンをクリックすると confirm が表示される", async () => {
     const wrapper = await mountSuspended(ListeningLogsPage);
     await wrapper.findAll(".btn-danger")[0].trigger("click");
-    expect(window.confirm).toHaveBeenCalledWith("この記録を削除しますか？");
+    expect(globalThis.confirm).toHaveBeenCalledWith("この記録を削除しますか？");
   });
 
   it("1件目の削除ボタンをクリックすると log-001 の deleteLog が呼ばれる", async () => {


### PR DESCRIPTION
## Summary

- SonarQube ルール `typescript:S7764`（Prefer `globalThis` over `window`）に該当する11箇所を修正
- `window.location.origin` / `window.location.href` → `globalThis.location.origin` / `globalThis.location.href`
- テストの `window.confirm` → `globalThis.confirm`

## 変更ファイル

| ファイル | 修正内容 |
|---|---|
| `app/composables/useAuth.ts` | `window.location.origin` / `window.location.href` → `globalThis.*` |
| `app/composables/useAuth.test.ts` | `window.location.href` → `globalThis.location.href` |
| `app/components/templates/ConcertLogDetailTemplate.test.ts` | `window.confirm` → `globalThis.confirm` |
| `app/components/templates/ListeningLogDetailTemplate.test.ts` | `window.confirm` → `globalThis.confirm` |
| `app/pages/listening-logs/index.test.ts` | `window.confirm` → `globalThis.confirm` |

## Test plan

- [x] `pnpm run test:frontend` — 503 tests passed
- [x] `pnpm run test:backend` — 372 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)