### PR TITLE
fix: sonarqube S6582 optional chain 式に書き換え

### DIFF
--- a/backend/src/concert-logs/delete.ts
+++ b/backend/src/concert-logs/delete.ts
@@ -13,7 +13,7 @@ export const handler = createHandler(async (event) => {
 
   const result = await dynamo.send(new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id } }));
   const item = result.Item as ConcertLog | undefined;
-  if (item === undefined || item.userId !== userId) {
+  if (item?.userId !== userId) {
     throw new createError.NotFound("Concert log not found");
   }
 

--- a/backend/src/concert-logs/get.ts
+++ b/backend/src/concert-logs/get.ts
@@ -13,7 +13,7 @@ export const handler = createHandler(async (event) => {
 
   const result = await dynamo.send(new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id } }));
   const item = result.Item as ConcertLog | undefined;
-  if (item === undefined || item.userId !== userId) {
+  if (item?.userId !== userId) {
     throw new createError.NotFound("Concert log not found");
   }
   return { statusCode: StatusCodes.OK, body: item };

--- a/backend/src/concert-logs/update.ts
+++ b/backend/src/concert-logs/update.ts
@@ -18,7 +18,7 @@ export const handler = createHandler(async (event) => {
     new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id } })
   );
   const existingItem = existing.Item as ConcertLog | undefined;
-  if (existingItem === undefined || existingItem.userId !== userId) {
+  if (existingItem?.userId !== userId) {
     throw new createError.NotFound("Concert log not found");
   }
 

--- a/backend/src/listening-logs/delete.ts
+++ b/backend/src/listening-logs/delete.ts
@@ -15,7 +15,7 @@ export const handler = createHandler(async (event) => {
     new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
   );
   const item = result.Item as ListeningLog | undefined;
-  if (item === undefined || item.userId !== userId) {
+  if (item?.userId !== userId) {
     throw new createError.NotFound("Listening log not found");
   }
 

--- a/backend/src/listening-logs/get.ts
+++ b/backend/src/listening-logs/get.ts
@@ -15,7 +15,7 @@ export const handler = createHandler(async (event) => {
     new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
   );
   const item = result.Item as ListeningLog | undefined;
-  if (item === undefined || item.userId !== userId) {
+  if (item?.userId !== userId) {
     throw new createError.NotFound("Listening log not found");
   }
   return { statusCode: StatusCodes.OK, body: item };

--- a/backend/src/listening-logs/update.ts
+++ b/backend/src/listening-logs/update.ts
@@ -18,7 +18,7 @@ export const handler = createHandler(async (event) => {
     new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
   );
   const existingItem = existing.Item as ListeningLog | undefined;
-  if (existingItem === undefined || existingItem.userId !== userId) {
+  if (existingItem?.userId !== userId) {
     throw new createError.NotFound("Listening log not found");
   }
 


### PR DESCRIPTION
## Summary

- SonarQube ルール `typescript:S6582`（Prefer optional chain expression）に該当する6箇所を修正
- `item === undefined || item.userId !== userId` → `item?.userId !== userId` に書き換え
- `item` が `undefined` のとき `item?.userId` は `undefined` となり、文字列の `userId` と不一致になるため動作は等価

## 変更ファイル

| ファイル | 修正内容 |
|---|---|
| `backend/src/concert-logs/delete.ts` | optional chain に書き換え |
| `backend/src/concert-logs/get.ts` | optional chain に書き換え |
| `backend/src/concert-logs/update.ts` | optional chain に書き換え |
| `backend/src/listening-logs/delete.ts` | optional chain に書き換え |
| `backend/src/listening-logs/get.ts` | optional chain に書き換え |
| `backend/src/listening-logs/update.ts` | optional chain に書き換え |

## Test plan

- [x] `pnpm run test:backend` — 372 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)