### PR TITLE
fix: sonarqube S2068 ハードコードパスワード誤検知を NOSONAR で抑制

### DIFF
--- a/app/components/organisms/LoginForm.stories.ts
+++ b/app/components/organisms/LoginForm.stories.ts
@@ -30,7 +30,7 @@ export const WithErrors: Story = {
     isLoading: false,
     errors: {
       email: "有効なメールアドレスを入力してください",
-      password: "パスワードが正しくありません",
+      password: "パスワードが正しくありません", // NOSONAR: エラーメッセージであり実際のパスワードではない
       general: "ログインに失敗しました",
     },
   },

--- a/app/components/organisms/UserRegisterForm.stories.ts
+++ b/app/components/organisms/UserRegisterForm.stories.ts
@@ -32,7 +32,7 @@ export const WithErrors: Story = {
     isLoading: false,
     errors: {
       email: "有効なメールアドレスを入力してください",
-      password: "パスワードは8文字以上で入力してください",
+      password: "パスワードは8文字以上で入力してください", // NOSONAR: エラーメッセージであり実際のパスワードではない
     },
     successMessage: "",
   },

--- a/app/components/templates/LoginTemplate.stories.ts
+++ b/app/components/templates/LoginTemplate.stories.ts
@@ -30,7 +30,7 @@ export const WithErrors: Story = {
     isLoading: false,
     errors: {
       email: "有効なメールアドレスを入力してください",
-      password: "パスワードが正しくありません",
+      password: "パスワードが正しくありません", // NOSONAR: エラーメッセージであり実際のパスワードではない
       general: "ログインに失敗しました",
     },
   },

--- a/app/components/templates/UserRegisterTemplate.stories.ts
+++ b/app/components/templates/UserRegisterTemplate.stories.ts
@@ -32,7 +32,7 @@ export const WithErrors: Story = {
     isLoading: false,
     errors: {
       email: "このメールアドレスは既に登録されています",
-      password: "パスワードは8文字以上で、大文字・小文字・数字を含む必要があります",
+      password: "パスワードは8文字以上で、大文字・小文字・数字を含む必要があります", // NOSONAR: エラーメッセージであり実際のパスワードではない
     },
     successMessage: "",
   },

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -27,7 +27,7 @@ async function handleSubmit(email: string, password: string) {
       if (result.errorType === "email") {
         errors.email = "有効なメールアドレスを入力してください";
       } else if (result.errorType === "password") {
-        errors.password = "パスワードを入力してください";
+        errors.password = "パスワードを入力してください"; // NOSONAR: エラーメッセージであり実際のパスワードではない
       } else if (result.errorType === "not_confirmed") {
         sessionStorage.setItem("pendingPassword", password);
         await router.push("/auth/verify-email", { state: { email } });


### PR DESCRIPTION
## Summary

- SonarQube ルール `typescript:S2068`（Review hard-coded password）に該当する5箇所を修正
- いずれも `password` キーへのエラーメッセージ文字列代入であり、実際のパスワードではないため FP（偽陽性）
- `// NOSONAR: エラーメッセージであり実際のパスワードではない` を追加して抑制

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `app/components/organisms/LoginForm.stories.ts` | Storybook エラー状態のデモ用メッセージ |
| `app/components/organisms/UserRegisterForm.stories.ts` | 同上 |
| `app/components/templates/LoginTemplate.stories.ts` | 同上 |
| `app/components/templates/UserRegisterTemplate.stories.ts` | 同上 |
| `app/pages/auth/login.vue` | バリデーションエラーメッセージ |

## Test plan

- [x] `pnpm run test:frontend` — 503 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)