### PR TITLE
fix: sonarqube S7772 node: プレフィックスを付与

### DIFF
--- a/backend/src/concert-logs/create.ts
+++ b/backend/src/concert-logs/create.ts
@@ -1,5 +1,5 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { StatusCodes } from "http-status-codes";
 import { dynamo, TABLE_CONCERT_LOGS } from "../utils/dynamodb";
 import { createHandler, jsonBodyParser } from "../utils/middleware";

--- a/backend/src/listening-logs/create.ts
+++ b/backend/src/listening-logs/create.ts
@@ -1,5 +1,5 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { StatusCodes } from "http-status-codes";
 import { dynamo, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import { createHandler, jsonBodyParser } from "../utils/middleware";

--- a/backend/src/pieces/create.ts
+++ b/backend/src/pieces/create.ts
@@ -1,5 +1,5 @@
 import { PutCommand } from "@aws-sdk/lib-dynamodb";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
 import { StatusCodes } from "http-status-codes";
 import { dynamo, TABLE_PIECES } from "../utils/dynamodb";
 import { createHandler, jsonBodyParser } from "../utils/middleware";

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -12,7 +12,7 @@ import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as cognito from "aws-cdk-lib/aws-cognito";
 import type { Construct } from "constructs";
-import * as path from "path";
+import * as path from "node:path";
 
 export type StageName = "dev" | "stg" | "prod";
 


### PR DESCRIPTION
## Summary

- SonarQube ルール `typescript:S7772`（Prefer `node:` prefix）に該当する4箇所を修正
- `"crypto"` → `"node:crypto"`、`"path"` → `"node:path"` に変更
- Node.js 組み込みモジュールを明示的に `node:` プレフィックスで識別することで、同名の npm パッケージとの混同を防ぐ

## 変更ファイル

| ファイル | 修正内容 |
|---|---|
| `backend/src/concert-logs/create.ts` | `"crypto"` → `"node:crypto"` |
| `backend/src/pieces/create.ts` | `"crypto"` → `"node:crypto"` |
| `backend/src/listening-logs/create.ts` | `"crypto"` → `"node:crypto"` |
| `cdk/lib/classical-music-lake-stack.ts` | `"path"` → `"node:path"` |

## Test plan

- [x] `pnpm run test:backend` — 372 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)