### PR TITLE
fix: sonarqube S2933/S6660/S6594 readonly・else if・RegExp.exec に書き換え

### DIFF
--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -23,17 +23,15 @@ async function handleSubmit(email: string, password: string) {
 
     if (result.success) {
       await router.push("/");
+    } else if (result.errorType === "email") {
+      errors.email = "有効なメールアドレスを入力してください";
+    } else if (result.errorType === "password") {
+      errors.password = "パスワードを入力してください"; // NOSONAR: エラーメッセージであり実際のパスワードではない
+    } else if (result.errorType === "not_confirmed") {
+      sessionStorage.setItem("pendingPassword", password);
+      await router.push("/auth/verify-email", { state: { email } });
     } else {
-      if (result.errorType === "email") {
-        errors.email = "有効なメールアドレスを入力してください";
-      } else if (result.errorType === "password") {
-        errors.password = "パスワードを入力してください"; // NOSONAR: エラーメッセージであり実際のパスワードではない
-      } else if (result.errorType === "not_confirmed") {
-        sessionStorage.setItem("pendingPassword", password);
-        await router.push("/auth/verify-email", { state: { email } });
-      } else {
-        errors.general = "メールアドレスまたはパスワードが正しくありません。";
-      }
+      errors.general = "メールアドレスまたはパスワードが正しくありません。";
     }
   } finally {
     isLoading.value = false;

--- a/app/pages/auth/user-register.vue
+++ b/app/pages/auth/user-register.vue
@@ -28,16 +28,14 @@ async function handleSubmit(email: string, password: string) {
     if (result.success) {
       sessionStorage.setItem("pendingPassword", password);
       router.push({ path: "/auth/verify-email", state: { email } });
+    } else if (result.error?.includes("email")) {
+      errors.email = result.error;
+    } else if (result.error?.includes("password")) {
+      errors.password = result.error;
+    } else if (result.error?.includes("already")) {
+      errors.email = "このメールアドレスは既に登録されています";
     } else {
-      if (result.error?.includes("email")) {
-        errors.email = result.error;
-      } else if (result.error?.includes("password")) {
-        errors.password = result.error;
-      } else if (result.error?.includes("already")) {
-        errors.email = "このメールアドレスは既に登録されています";
-      } else {
-        errors.email = result.error || "登録に失敗しました";
-      }
+      errors.email = result.error || "登録に失敗しました";
     }
   } finally {
     isLoading.value = false;

--- a/app/utils/video.ts
+++ b/app/utils/video.ts
@@ -3,12 +3,12 @@ export function isYouTubeUrl(url: string): boolean {
 }
 
 export function extractYouTubeVideoId(url: string): string | null {
-  const watchMatch = url.match(/youtube\.com\/watch\?v=([^&]+)/);
+  const watchMatch = /youtube\.com\/watch\?v=([^&]+)/.exec(url);
   if (watchMatch !== null) {
     return watchMatch[1];
   }
 
-  const shortMatch = url.match(/youtu\.be\/([^?]+)/);
+  const shortMatch = /youtu\.be\/([^?]+)/.exec(url);
   if (shortMatch !== null) {
     return shortMatch[1];
   }

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -21,8 +21,8 @@ export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
 }
 
 export class ClassicalMusicLakeStack extends cdk.Stack {
-  private corsAllowOrigin: string = "";
-  private corsAllowOrigins: string[] = [];
+  private readonly corsAllowOrigin: string = "";
+  private readonly corsAllowOrigins: string[] = [];
 
   constructor(scope: Construct, id: string, props: ClassicalMusicLakeStackProps) {
     super(scope, id, props);


### PR DESCRIPTION
## Summary

グループ7〜9の SonarQube 指摘をまとめて修正。

### S2933 — Member never reassigned（2件）
- `cdk/lib/classical-music-lake-stack.ts`: `corsAllowOrigin` / `corsAllowOrigins` を `private readonly` に変更（コンストラクタ内でのみ代入）

### S6660 — If sole statement in else block（2件）
- `app/pages/auth/login.vue`: `else { if (...) }` → `else if (...)` にフラット化
- `app/pages/auth/user-register.vue`: 同上

### S6594 — Use `RegExp.exec()`（2件）
- `app/utils/video.ts`: `str.match(re)` → `re.exec(str)` に書き換え

## Test plan

- [x] `pnpm run test:frontend` — 503 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)