### PR TITLE
fix: sonarqube ItemTagNotWithinContainerTagCheck ConcertLogForm.vue を除外

### DIFF
--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -141,8 +141,8 @@ function handleSubmit() {
         handle=".drag-handle"
       >
         <template #item="{ element, index }">
-          <li data-testid="program-item" class="program-item">
-            <!-- NOSONAR -->
+          <!-- prettier-ignore -->
+          <li data-testid="program-item" class="program-item"> <!-- NOSONAR -->
             <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
             <span class="piece-info">{{ element.title }} / {{ element.composer }}</span>
             <button

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -141,8 +141,8 @@ function handleSubmit() {
         handle=".drag-handle"
       >
         <template #item="{ element, index }">
-          <!-- prettier-ignore -->
-          <li data-testid="program-item" class="program-item"> <!-- NOSONAR -->
+          <li data-testid="program-item" class="program-item">
+            <!-- NOSONAR -->
             <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
             <span class="piece-info">{{ element.title }} / {{ element.composer }}</span>
             <button

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=konabe_classical-music-lake
+
+# vue-draggable は tag="ol" により実行時は <ol> でレンダリングされるが、
+# 静的解析では検出できないため、ConcertLogForm.vue に限り除外する
+sonar.issue.ignore.multicriteria=e1
+sonar.issue.ignore.multicriteria.e1.ruleKey=Web:ItemTagNotWithinContainerTagCheck
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/ConcertLogForm.vue


### PR DESCRIPTION
## Summary
- `vue-draggable` の `tag="ol"` は実行時に `<ol>` でレンダリングされるが、SonarQube 静的解析では `<li>` が `<ol>`/`<ul>` 外にあると誤検知される
- `sonar-project.properties` を作成し、`ConcertLogForm.vue` に限り `Web:ItemTagNotWithinContainerTagCheck` ルールを除外
- SonarQube ルール: `Web:ItemTagNotWithinContainerTagCheck`

## なぜ NOSONAR ではなく sonar-project.properties か
- `<!-- NOSONAR -->` を `<li>` と同行に配置する必要があるが、Prettier が常に改行してしまう
- `<!-- prettier-ignore -->` を使うと Vue スロットのレンダリングが壊れテストが失敗する

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全 369 件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)