### PR TITLE
fix: sonarqube S7924 削除ボタンのホバー背景色を WCAG AA 準拠に変更

### DIFF
--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -236,7 +236,7 @@ function handleSubmit() {
 }
 
 .btn-remove-piece:hover {
-  background: #e53e3e;
+  background: #c0392b;
   color: #fff;
 }
 </style>


### PR DESCRIPTION
## Summary
- `ConcertLogForm.vue` の `.btn-remove-piece:hover` の背景色を `#e53e3e` → `#c0392b` に変更
- ホバー時の白テキスト (`#fff`) とのコントラスト比: 4.07:1 → 5.35:1（WCAG AA 基準: 4.5:1 以上）
- SonarQube ルール: `css:S7924`

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)