### PR TITLE
fix: sonarqube FrameWithoutTitleCheck iframe に title 属性を追加

### DIFF
--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -69,7 +69,13 @@ onUnmounted(() => {
 
 <template>
   <div class="video-player">
-    <iframe v-if="isYouTube" :id="iframeId" :src="embedUrl" class="youtube-iframe" />
+    <iframe
+      v-if="isYouTube"
+      :id="iframeId"
+      :src="embedUrl"
+      class="youtube-iframe"
+      title="YouTube 動画プレーヤー"
+    />
     <a
       v-else
       :href="videoUrl"


### PR DESCRIPTION
## Summary
- `VideoPlayer.vue` の `<iframe>` に `title="YouTube 動画プレーヤー"` 属性を追加
- スクリーンリーダー向けのアクセシビリティ改善
- SonarQube ルール: `Web:FrameWithoutTitleCheck`

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)