### PR TITLE
fix: sonarqube S2137 PieceDetailTemplate.stories の Error を WithError に改名

### DIFF
--- a/app/components/templates/PieceDetailTemplate.stories.ts
+++ b/app/components/templates/PieceDetailTemplate.stories.ts
@@ -41,7 +41,7 @@ export const WithoutVideo: Story = {
   },
 };
 
-export const Error: Story = {
+export const WithError: Story = {
   args: {
     piece: null,
     error: new globalThis.Error("取得失敗"),


### PR DESCRIPTION
## Summary
- `PieceDetailTemplate.stories.ts` の `export const Error` を `export const WithError` に改名
- `Error` はグローバルオブジェクト名であり、変数名として使用しないべき
- SonarQube ルール: `typescript:S2137`

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)