### PR TITLE
fix: sonarqube S7773 parseInt を Number.parseInt に書き換え

### DIFF
--- a/scripts/generate-mock-data.mjs
+++ b/scripts/generate-mock-data.mjs
@@ -14,7 +14,7 @@ import { randomUUID } from "node:crypto";
 const args = process.argv.slice(2);
 const countArg = args.find((a) => a.startsWith("--count="));
 const outputArg = args.find((a) => a.startsWith("--output="));
-const rawCount = countArg ? parseInt(countArg.split("=")[1], 10) : 10;
+const rawCount = countArg ? Number.parseInt(countArg.split("=")[1], 10) : 10;
 if (!Number.isInteger(rawCount) || rawCount < 0) {
   console.error("エラー: --count には 0 以上の整数を指定してください");
   process.exit(1);


### PR DESCRIPTION
## Summary
- `scripts/generate-mock-data.mjs` の `parseInt` を `Number.parseInt` に変更
- グローバルの `parseInt` ではなく `Number` モジュールのメソッドを使用する推奨パターン
- SonarQube ルール: `javascript:S7773`

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)