### PR TITLE
fix: sonarqube S1848 CDK スタックインスタンス化の結果を変数に代入

### DIFF
--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -17,6 +17,7 @@ const stackName =
   stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
 
 new ClassicalMusicLakeStack(app, stackName, {
+  // NOSONAR: CDK はコンストラクタ呼び出しで app に登録される設計のため代入は不要
   stageName,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -16,8 +16,7 @@ const stageName = rawStageName as StageName;
 const stackName =
   stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
 
-new ClassicalMusicLakeStack(app, stackName, {
-  // NOSONAR: CDK はコンストラクタ呼び出しで app に登録される設計のため代入は不要
+const _stack = new ClassicalMusicLakeStack(app, stackName, {
   stageName,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,


### PR DESCRIPTION
## Summary
- `cdk/bin/app.ts` の `new ClassicalMusicLakeStack(...)` の結果を `const _stack` に代入
- CDK はコンストラクタ呼び出しで `app` に自己登録する設計だが、SonarQube が「使用されないオブジェクト」として検知していた
- `_` プレフィックスにより ESLint の `no-unused-vars` ルールは無視される
- SonarQube ルール: `typescript:S1848`

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)