### PR TITLE
fix: sonarqube S7785 Promise チェーンを top-level await に書き換え

### DIFF
--- a/backend/scripts/seed-test-db.mjs
+++ b/backend/scripts/seed-test-db.mjs
@@ -126,7 +126,9 @@ async function main() {
   console.log("シード完了");
 }
 
-main().catch((e) => {
+try {
+  await main();
+} catch (e) {
   console.error("エラー:", e.message);
   process.exit(1);
-});
+}

--- a/backend/scripts/setup-test-db.mjs
+++ b/backend/scripts/setup-test-db.mjs
@@ -58,7 +58,9 @@ async function main() {
   console.log(`テーブルを作成しました: ${TABLE_NAME}`);
 }
 
-main().catch((e) => {
+try {
+  await main();
+} catch (e) {
   console.error("エラー:", e.message);
   process.exit(1);
-});
+}


### PR DESCRIPTION
## Summary
- `backend/scripts/seed-test-db.mjs` と `setup-test-db.mjs` の `main().catch(...)` を top-level await に書き換え
- `.mjs` ファイルは ES Module のため top-level await が使用可能
- SonarQube ルール: `javascript:S7785`

## 変更内容
```js
// Before
main().catch((e) => {
  console.error("エラー:", e.message);
  process.exit(1);
});

// After
try {
  await main();
} catch (e) {
  console.error("エラー:", e.message);
  process.exit(1);
}
```

## Test plan
- [ ] フロントエンドテスト: 全テストパス
- [ ] バックエンドテスト: 全テストパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)