### PR TITLE
fix: generate-mock-data の Security Hotspot を修正

### DIFF
--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -141,7 +141,7 @@ function handleSubmit() {
       >
         <template #item="{ element, index }">
           <li data-testid="program-item" class="program-item">
-            <!-- NOSONAR: draggable コンポーネントが tag="ol" で ol を生成するため li の親は ol になる -->
+            <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
             <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
             <span class="piece-info">{{ element.title }} / {{ element.composer }}</span>
             <button

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -140,18 +140,11 @@ function handleSubmit() {
         handle=".drag-handle"
       >
         <template #item="{ element, index }">
-          <li data-testid="program-item" class="program-item">
-            <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
+          <!-- prettier-ignore -->
+          <li data-testid="program-item" class="program-item"> <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
             <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
             <span class="piece-info">{{ element.title }} / {{ element.composer }}</span>
-            <button
-              type="button"
-              data-testid="remove-piece"
-              class="btn-remove-piece"
-              @click="removePiece(index)"
-            >
-              削除
-            </button>
+            <button type="button" data-testid="remove-piece" class="btn-remove-piece" @click="removePiece(index)">削除</button>
           </li>
         </template>
       </draggable>

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -140,11 +140,18 @@ function handleSubmit() {
         handle=".drag-handle"
       >
         <template #item="{ element, index }">
-          <!-- prettier-ignore -->
-          <li data-testid="program-item" class="program-item"> <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
+          <li data-testid="program-item" class="program-item">
+            <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
             <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
             <span class="piece-info">{{ element.title }} / {{ element.composer }}</span>
-            <button type="button" data-testid="remove-piece" class="btn-remove-piece" @click="removePiece(index)">削除</button>
+            <button
+              type="button"
+              data-testid="remove-piece"
+              class="btn-remove-piece"
+              @click="removePiece(index)"
+            >
+              削除
+            </button>
           </li>
         </template>
       </draggable>

--- a/scripts/generate-mock-data.mjs
+++ b/scripts/generate-mock-data.mjs
@@ -126,13 +126,13 @@ function generateLog(index) {
     updatedAt: createdDate.toISOString(),
   };
 
-  if (Math.random() > 0.4) {
-    // NOSONAR
+  const addConductor = Math.random() > 0.4; // NOSONAR: モックデータ生成用でありセキュリティ目的ではない
+  if (addConductor) {
     log.conductor = randomItem(conductors);
   }
 
-  if (Math.random() > 0.5) {
-    // NOSONAR
+  const addMemo = Math.random() > 0.5; // NOSONAR: モックデータ生成用でありセキュリティ目的ではない
+  if (addMemo) {
     log.memo = randomItem(memos);
   }
 

--- a/scripts/generate-mock-data.mjs
+++ b/scripts/generate-mock-data.mjs
@@ -127,12 +127,12 @@ function generateLog(index) {
   };
 
   if (Math.random() > 0.4) {
-    // NOSONAR: モックデータ生成用でありセキュリティ目的ではない
+    // NOSONAR
     log.conductor = randomItem(conductors);
   }
 
   if (Math.random() > 0.5) {
-    // NOSONAR: モックデータ生成用でありセキュリティ目的ではない
+    // NOSONAR
     log.memo = randomItem(memos);
   }
 


### PR DESCRIPTION
## Summary

- `generate-mock-data.mjs`: `Math.random()` を変数（`addConductor`, `addMemo`）に抽出し `// NOSONAR` を同一行に付与
  - prettier が `if (...) { // NOSONAR` を次行コメントに変換するため変数抽出で回避
  - NOSONAR はフラグ対象と同じ行に書かないと Hotspot が抑制されない
- `ConcertLogForm.vue`: NOSONAR コメントの文言を短縮（`sonar-project.properties` の除外設定が有効なため実質影響なし）

## 背景

PR #460 でマージされた修正では `generate-mock-data.mjs` の Hotspot が残存していた。
原因は NOSONAR コメントが `Math.random()` と異なる行にあったため。

## Test plan

- [x] フロントエンドテスト: `pnpm run test:frontend` → 503 tests passed
- [x] バックエンドテスト: `pnpm run test:backend` → 369 tests passed
- [ ] SonarCloud スキャン後に Hotspot 0 件になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)