### PR TITLE
fix: cdk bin/app.ts の未使用変数 _stack を削除し NOSONAR を付与

### DIFF
--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -16,7 +16,8 @@ const stageName = rawStageName as StageName;
 const stackName =
   stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
 
-const _stack = new ClassicalMusicLakeStack(app, stackName, {
+// prettier-ignore
+new ClassicalMusicLakeStack(app, stackName, { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
   stageName,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,


### PR DESCRIPTION
## Summary

- `cdk/bin/app.ts`: `const _stack =` の変数代入を削除し TypeScript TS6133 エラーを解消
- `// prettier-ignore` で整形を抑制し、`new ClassicalMusicLakeStack` と同じ行に `// NOSONAR` を配置

## 背景

PR #458 で導入された `const _stack = new ClassicalMusicLakeStack(...)` が
TypeScript の `noUnusedLocals` 設定により `TS6133: '_stack' is declared but its value is never read` エラーを発生させ、main ブランチの Deploy ワークフローが失敗していた。

CDK ではスタックをインスタンス化するだけで `app` への登録が完了するため、戻り値の変数代入は不要。

## Test plan

- [x] フロントエンドテスト: `pnpm run test:frontend` → 503 tests passed
- [x] バックエンドテスト: `pnpm run test:backend` → 369 tests passed
- [ ] Deploy ワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)