### PR TITLE
Add custom domain and Route53 DNS management for CloudFront

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -112,6 +112,14 @@ jobs:
             || aws ecr create-repository --repository-name "$REPO" 2>/dev/null \
             || true
 
+      - name: Ensure ECR repository for CDK bootstrap (us-east-1)
+        run: |
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          REPO="cdk-hnb659fds-container-assets-${ACCOUNT}-us-east-1"
+          aws ecr describe-repositories --repository-names "$REPO" --region us-east-1 2>/dev/null \
+            || aws ecr create-repository --repository-name "$REPO" --region us-east-1 2>/dev/null \
+            || true
+
       # ----------------------------------------
       # 孤立リソースのクリーンアップ
       # ロールバック時に残ったロググループを削除（存在しない場合は無視）
@@ -120,8 +128,17 @@ jobs:
         run: |
           aws logs delete-log-group --log-group-name "/aws/apigateway/classical-music-lake-${STAGE_NAME}" 2>/dev/null || true
 
-      - name: CDK Bootstrap
+      - name: CDK Bootstrap (ap-northeast-1)
         run: npx cdk bootstrap
+        working-directory: cdk
+        env:
+          STAGE_NAME: ${{ env.STAGE_NAME }}
+
+      # DnsStack（ACM 証明書）が us-east-1 にあるため、crossRegionReferences 用にブートストラップ
+      - name: CDK Bootstrap (us-east-1)
+        run: |
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          npx cdk bootstrap "aws://${ACCOUNT}/us-east-1"
         working-directory: cdk
         env:
           STAGE_NAME: ${{ env.STAGE_NAME }}
@@ -131,13 +148,15 @@ jobs:
       # フロントエンドの S3 アップロードはこの後のステップで行う
       # dev/stg: --hotswap-fallback で Lambda 変更時は CloudFormation をバイパスして直接更新（高速化）
       # prod: 安全のためフル CloudFormation デプロイ
+      # NOTE: DnsStack は ACM 証明書の DNS 検証完了まで CloudFormation がペンディングするため
+      #       CI/CD では対象外。初回は手動で `npx cdk deploy NocturneAppDnsStack` を実行すること
       # ----------------------------------------
       - name: CDK Deploy
         run: |
           if [ "$STAGE_NAME" = "prod" ]; then
-            pnpm run deploy
+            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never
           else
-            pnpm run deploy -- --hotswap-fallback
+            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never --hotswap-fallback
           fi
         working-directory: cdk
         env:

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -2,6 +2,7 @@
 import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { ClassicalMusicLakeStack, type StageName } from "../lib/classical-music-lake-stack";
+import { DnsStack } from "../lib/dns-stack";
 
 const app = new cdk.App();
 
@@ -16,12 +17,31 @@ const stageName = rawStageName as StageName;
 const stackName =
   stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
 
+// -------------------------
+// DNS スタック（us-east-1）
+// CloudFront 用の ACM 証明書は us-east-1 に作成する必要がある
+// 初回デプロイ時は手動で実行: STAGE_NAME=prod npx cdk deploy NocturneAppDnsStack
+// ※ ACM 証明書の DNS 検証が完了するまで CloudFormation がペンディングになるため、
+//    先にこのスタックだけデプロイし、お名前.comで NS レコードを設定してから
+//    メインスタックをデプロイすること
+// -------------------------
+const dnsStack = new DnsStack(app, "NocturneAppDnsStack", {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: "us-east-1",
+  },
+  crossRegionReferences: true,
+});
+
 // prettier-ignore
 new ClassicalMusicLakeStack(app, stackName, { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
   stageName,
+  hostedZone: dnsStack.hostedZone,
+  certificate: dnsStack.certificate,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
   },
+  crossRegionReferences: true,
   terminationProtection: stageName === "prod",
 });

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -11,6 +11,9 @@ import * as s3 from "aws-cdk-lib/aws-s3";
 import * as cloudfront from "aws-cdk-lib/aws-cloudfront";
 import * as origins from "aws-cdk-lib/aws-cloudfront-origins";
 import * as cognito from "aws-cdk-lib/aws-cognito";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as route53Targets from "aws-cdk-lib/aws-route53-targets";
+import type * as acm from "aws-cdk-lib/aws-certificatemanager";
 import type { Construct } from "constructs";
 import * as path from "node:path";
 
@@ -18,6 +21,8 @@ export type StageName = "dev" | "stg" | "prod";
 
 export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
   stageName: StageName;
+  hostedZone: route53.IHostedZone;
+  certificate: acm.ICertificate;
 }
 
 export class ClassicalMusicLakeStack extends cdk.Stack {
@@ -27,8 +32,9 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ClassicalMusicLakeStackProps) {
     super(scope, id, props);
 
-    const { stageName } = props;
+    const { stageName, hostedZone, certificate } = props;
     const isProd = stageName === "prod";
+    const domainName = isProd ? "nocturne-app.com" : `${stageName}.nocturne-app.com`;
 
     // -------------------------
     // DynamoDB テーブル
@@ -169,6 +175,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     );
 
     const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
+      domainNames: [domainName],
+      certificate,
       defaultBehavior: {
         origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
@@ -203,13 +211,15 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       ],
     });
 
-    // CloudFront URL を CORS オリジンとして Lambda 環境変数に設定
-    this.corsAllowOrigin = `https://${distribution.distributionDomainName}`;
+    // カスタムドメインを CORS オリジンとして Lambda 環境変数に設定
+    // 移行期間中は CloudFront デフォルトドメインも許可（DNS 切り替え完了後に削除可能）
+    this.corsAllowOrigin = `https://${domainName}`;
+    const cloudFrontOrigin = `https://${distribution.distributionDomainName}`;
     // dev 環境のみローカル開発用に localhost を許可（NOTE: 3000だとなぜか起動できない）
     this.corsAllowOrigins =
       stageName === "dev"
-        ? [this.corsAllowOrigin, "http://localhost:3010"]
-        : [this.corsAllowOrigin];
+        ? [this.corsAllowOrigin, cloudFrontOrigin, "http://localhost:3010"]
+        : [this.corsAllowOrigin, cloudFrontOrigin];
 
     // -------------------------
     // Google Identity Provider
@@ -235,8 +245,15 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     }
 
     // App Client: フロントエンド用
-    const callbackUrls = [`https://${distribution.distributionDomainName}/auth/callback`];
-    const logoutUrls = [`https://${distribution.distributionDomainName}/auth/login`];
+    // 移行期間中は CloudFront デフォルトドメインも callback URL に含める
+    const callbackUrls = [
+      `https://${domainName}/auth/callback`,
+      `https://${distribution.distributionDomainName}/auth/callback`,
+    ];
+    const logoutUrls = [
+      `https://${domainName}/auth/login`,
+      `https://${distribution.distributionDomainName}/auth/login`,
+    ];
     if (stageName === "dev") {
       callbackUrls.push("http://localhost:3010/auth/callback");
       logoutUrls.push("http://localhost:3010/auth/login");
@@ -691,6 +708,15 @@ function handler(event) {
     // NOTE: Storybook ファイルの S3 アップロードも GitHub Actions ワークフローで実行する。
 
     // -------------------------
+    // Route53 A レコード（カスタムドメイン → CloudFront）
+    // -------------------------
+    new route53.ARecord(this, "CloudFrontAliasRecord", {
+      zone: hostedZone,
+      recordName: domainName,
+      target: route53.RecordTarget.fromAlias(new route53Targets.CloudFrontTarget(distribution)),
+    });
+
+    // -------------------------
     // CloudWatch アラーム
     // -------------------------
     const allFunctions = [
@@ -764,12 +790,12 @@ function handler(event) {
     });
 
     new cdk.CfnOutput(this, "SpaUrl", {
-      value: this.corsAllowOrigin,
-      description: "CloudFront URL (フロントエンド)",
+      value: `https://${domainName}`,
+      description: "カスタムドメイン URL (フロントエンド)",
     });
 
     new cdk.CfnOutput(this, "StorybookUrl", {
-      value: `${this.corsAllowOrigin}/storybook/`,
+      value: `https://${domainName}/storybook/`,
       description: "Storybook URL",
     });
 

--- a/cdk/lib/dns-stack.ts
+++ b/cdk/lib/dns-stack.ts
@@ -1,0 +1,43 @@
+import * as cdk from "aws-cdk-lib";
+import * as route53 from "aws-cdk-lib/aws-route53";
+import * as acm from "aws-cdk-lib/aws-certificatemanager";
+import type { Construct } from "constructs";
+
+const DOMAIN_NAME = "nocturne-app.com";
+
+export class DnsStack extends cdk.Stack {
+  public readonly hostedZone: route53.IHostedZone;
+  public readonly certificate: acm.ICertificate;
+
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Route53 Hosted Zone
+    this.hostedZone = new route53.PublicHostedZone(this, "HostedZone", {
+      zoneName: DOMAIN_NAME,
+    });
+
+    // ACM 証明書（CloudFront 用: us-east-1 にデプロイ必須）
+    // nocturne-app.com + *.nocturne-app.com でワイルドカード対応
+    this.certificate = new acm.Certificate(this, "Certificate", {
+      domainName: DOMAIN_NAME,
+      subjectAlternativeNames: [`*.${DOMAIN_NAME}`],
+      validation: acm.CertificateValidation.fromDns(this.hostedZone),
+    });
+
+    new cdk.CfnOutput(this, "NameServers", {
+      value: cdk.Fn.join(", ", this.hostedZone.hostedZoneNameServers!),
+      description: "お名前.comに設定するNSレコード",
+    });
+
+    new cdk.CfnOutput(this, "HostedZoneId", {
+      value: this.hostedZone.hostedZoneId,
+      description: "Route53 Hosted Zone ID",
+    });
+
+    new cdk.CfnOutput(this, "CertificateArn", {
+      value: this.certificate.certificateArn,
+      description: "ACM 証明書 ARN",
+    });
+  }
+}

--- a/cdk/lib/dns-stack.ts
+++ b/cdk/lib/dns-stack.ts
@@ -13,22 +13,25 @@ export class DnsStack extends cdk.Stack {
     super(scope, id, props);
 
     // Route53 Hosted Zone
-    this.hostedZone = new route53.PublicHostedZone(this, "HostedZone", {
+    const hostedZone = new route53.PublicHostedZone(this, "HostedZone", {
       zoneName: DOMAIN_NAME,
     });
+    this.hostedZone = hostedZone;
 
     // ACM 証明書（CloudFront 用: us-east-1 にデプロイ必須）
     // nocturne-app.com + *.nocturne-app.com でワイルドカード対応
     this.certificate = new acm.Certificate(this, "Certificate", {
       domainName: DOMAIN_NAME,
       subjectAlternativeNames: [`*.${DOMAIN_NAME}`],
-      validation: acm.CertificateValidation.fromDns(this.hostedZone),
+      validation: acm.CertificateValidation.fromDns(hostedZone),
     });
 
-    new cdk.CfnOutput(this, "NameServers", {
-      value: cdk.Fn.join(", ", this.hostedZone.hostedZoneNameServers!),
-      description: "お名前.comに設定するNSレコード",
-    });
+    if (hostedZone.hostedZoneNameServers) {
+      new cdk.CfnOutput(this, "NameServers", {
+        value: cdk.Fn.join(", ", hostedZone.hostedZoneNameServers),
+        description: "お名前.comに設定するNSレコード",
+      });
+    }
 
     new cdk.CfnOutput(this, "HostedZoneId", {
       value: this.hostedZone.hostedZoneId,

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -28,8 +28,8 @@
 
 ```text
 [ユーザー]
-    ↓
-[CloudFront] ← S3 (静的ホスティング)
+    ↓ nocturne-app.com / stg.nocturne-app.com / dev.nocturne-app.com
+[Route53] → [CloudFront + ACM証明書] ← S3 (静的ホスティング)
     ↓
 [Nuxt.js SPA]
     ↓ (API呼び出し + JWT トークン)
@@ -747,11 +747,25 @@ Authorization: Bearer {accessToken}
 - **App Client**: SRP 認証フロー（シークレットなし）
 - **CDK Output**: `CognitoUserPoolId`, `CognitoClientId`, `CognitoUserPoolArn`
 
+#### Route53
+
+- **Hosted Zone**: `nocturne-app.com`（`NocturneAppDnsStack` で管理、us-east-1）
+- **A レコード**: 各環境の CloudFront ディストリビューションへのエイリアスレコード
+  - prod: `nocturne-app.com`
+  - stg: `stg.nocturne-app.com`
+  - dev: `dev.nocturne-app.com`
+
+#### ACM (Certificate Manager)
+
+- **証明書**: `nocturne-app.com` + `*.nocturne-app.com`（ワイルドカード）
+- **リージョン**: us-east-1（CloudFront 用の証明書は us-east-1 に配置が必須）
+- **検証方式**: DNS 検証（Route53 の Hosted Zone で自動検証）
+
 #### API Gateway
 
 - **名前**: `classical-music-lake`
 - **ステージ**: `prod`
-- **CORS**: CloudFront URL のみ許可（プリフライト・GatewayResponse の両方で設定）
+- **CORS**: カスタムドメイン URL を許可（プリフライト・GatewayResponse の両方で設定）
 
 #### S3
 
@@ -762,6 +776,7 @@ Authorization: Bearer {accessToken}
 #### CloudFront
 
 - **用途**: SPAの配信
+- **カスタムドメイン**: 環境ごとにカスタムドメインを設定（ACM 証明書を使用）
 - **エラーハンドリング**: 404/403 → index.html（SPA対応）
 - **プロトコル**: HTTPS強制
 
@@ -776,7 +791,7 @@ Authorization: Bearer {accessToken}
 - `DYNAMO_TABLE_LISTENING_LOGS`: 視聴ログテーブル名（CDK が自動設定）
 - `DYNAMO_TABLE_PIECES`: 楽曲マスタテーブル名（CDK が自動設定）
 - `DYNAMO_TABLE_CONCERT_LOGS`: コンサート記録テーブル名（CDK が自動設定）
-- `CORS_ALLOW_ORIGIN`: 許可する CORS オリジン（CDK が CloudFront URL を自動設定。未設定時は `"*"` にフォールバックするが、本番・stg は CDK が必ず設定するため未設定にはならない）
+- `CORS_ALLOW_ORIGIN`: 許可する CORS オリジン（CDK がカスタムドメイン URL + CloudFront URL を自動設定。未設定時は `"*"` にフォールバックするが、本番・stg は CDK が必ず設定するため未設定にはならない）
 
 #### CI/CD（GitHub Secrets）
 
@@ -799,11 +814,13 @@ Authorization: Bearer {accessToken}
 
 ### 6.1 環境構成
 
-| 環境   | スタック名                    | DynamoDB テーブル名（視聴ログ）      | DynamoDB テーブル名（コンサート記録） | 削除ポリシー | 用途                                     |
-| ------ | ----------------------------- | ------------------------------------ | ------------------------------------- | ------------ | ---------------------------------------- |
-| `prod` | `ClassicalMusicLakeStack`     | `classical-music-listening-logs`     | `classical-music-concert-logs`        | RETAIN       | 本番環境                                 |
-| `stg`  | `ClassicalMusicLakeStack-stg` | `classical-music-listening-logs-stg` | `classical-music-concert-logs-stg`    | DESTROY      | リリース前の検証環境                     |
-| `dev`  | `ClassicalMusicLakeStack-dev` | `classical-music-listening-logs-dev` | `classical-music-concert-logs-dev`    | DESTROY      | 開発環境（ローカル環境からの接続も想定） |
+| 環境   | スタック名                    | カスタムドメイン       | DynamoDB テーブル名（視聴ログ）      | DynamoDB テーブル名（コンサート記録） | 削除ポリシー | 用途                                     |
+| ------ | ----------------------------- | ---------------------- | ------------------------------------ | ------------------------------------- | ------------ | ---------------------------------------- |
+| `prod` | `ClassicalMusicLakeStack`     | `nocturne-app.com`     | `classical-music-listening-logs`     | `classical-music-concert-logs`        | RETAIN       | 本番環境                                 |
+| `stg`  | `ClassicalMusicLakeStack-stg` | `stg.nocturne-app.com` | `classical-music-listening-logs-stg` | `classical-music-concert-logs-stg`    | DESTROY      | リリース前の検証環境                     |
+| `dev`  | `ClassicalMusicLakeStack-dev` | `dev.nocturne-app.com` | `classical-music-listening-logs-dev` | `classical-music-concert-logs-dev`    | DESTROY      | 開発環境（ローカル環境からの接続も想定） |
+
+> **DNS スタック**: `NocturneAppDnsStack`（us-east-1）は全環境で共有する Route53 Hosted Zone と ACM 証明書を管理する。初回のみ手動デプロイが必要（`npx cdk deploy NocturneAppDnsStack`）。
 
 ### 6.2 デプロイフロー
 
@@ -813,9 +830,11 @@ GitHub (release published)   → prod 自動デプロイ
 GitHub (dev* タグ push)      → dev 自動デプロイ
 GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
   → GitHub Actions
-    → CDK デプロイ (STAGE_NAME 環境変数で対象環境を指定)
+    → CDK Bootstrap (ap-northeast-1 + us-east-1)
+    → CDK デプロイ (STAGE_NAME 環境変数で対象スタックを指定)
       → Lambda + API Gateway + DynamoDB 作成/更新
-      → S3 + CloudFront 作成/更新
+      → S3 + CloudFront 作成/更新（カスタムドメイン + ACM 証明書）
+      → Route53 A レコード作成/更新
     → スタック出力取得（API URL・Cognito ドメイン等）
     → Nuxt ビルド (pnpm run generate)
     → Storybook ビルド


### PR DESCRIPTION
## 概要

CloudFront ディストリビューションにカスタムドメイン（nocturne-app.com）を設定し、Route53 で DNS 管理を行うようにしました。ACM 証明書を使用して HTTPS 通信を実現し、環境ごとに異なるサブドメイン（prod: nocturne-app.com、stg: stg.nocturne-app.com、dev: dev.nocturne-app.com）を割り当てます。

## 変更の種類

- [x] 新機能
- [x] インフラストラクチャ

## 変更内容

### 新規ファイル
- **`cdk/lib/dns-stack.ts`**: Route53 Hosted Zone と ACM 証明書を管理する新しいスタック
  - `nocturne-app.com` の Hosted Zone を作成
  - ワイルドカード対応の ACM 証明書（`*.nocturne-app.com`）を生成
  - DNS 検証を自動化

### ClassicalMusicLakeStack の変更
- **プロパティ追加**: `hostedZone` と `certificate` を受け取るように拡張
- **CloudFront 設定**: カスタムドメインと ACM 証明書を設定
- **Route53 A レコード**: CloudFront ディストリビューションへのエイリアスレコードを作成
- **CORS 設定**: 移行期間中は CloudFront デフォルトドメインも許可（DNS 切り替え完了後に削除可能）
- **Cognito コールバック URL**: カスタムドメインとデフォルトドメインの両方を登録
- **出力値**: カスタムドメイン URL を表示

### CDK アプリケーション設定
- **`cdk/bin/app.ts`**: DnsStack を初期化し、ClassicalMusicLakeStack に参照を渡す
- **クロスリージョン参照**: us-east-1（DnsStack）と ap-northeast-1（ClassicalMusicLakeStack）間の参照を有効化

### CI/CD パイプライン
- **`deploy.yml`**: 
  - us-east-1 用の ECR リポジトリ作成ステップを追加
  - ap-northeast-1 と us-east-1 の両方で CDK Bootstrap を実行
  - DnsStack は初回手動デプロイが必要な旨をコメント追加

### ドキュメント更新
- **`docs/SPEC.md`**: 
  - アーキテクチャ図に Route53 と ACM を追加
  - Route53 と ACM の仕様を記載
  - 環境構成表にカスタムドメイン列を追加
  - デプロイフローに us-east-1 ブートストラップを追加

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] CDK 構文検証を実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] `docs/SPEC.md` を更新した

## 注記

DnsStack（ACM 証明書）は初回のみ手動デプロイが必要です：
```bash
STAGE_NAME=prod npx cdk deploy NocturneAppDnsStack
```

お名前.com で NS レコードを設定してから、メインスタックをデプロイしてください。

https://claude.ai/code/session_014MfGNNteN7Tr8CdZc7KiBB