### PR TITLE
fix: SonarCloud で検出された issue を修正

### DIFF
--- a/.claude/skills/sonarqube-issues/SKILL.md
+++ b/.claude/skills/sonarqube-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sonarqube-issues
-description: SonarQube CloudからIssue・Security Hotspot・コード重複（Duplications）を取得して一覧表示する。コード品質・セキュリティの確認やIssue対応時に使う。
+description: SonarQube CloudからIssue・Security Hotspot・コード重複（Duplications）・カバレッジを取得して一覧表示する。コード品質・セキュリティの確認やIssue対応時に使う。
 disable-model-invocation: true
 allowed-tools: WebFetch
 argument-hint: "[severities|types|statuses|hotspots] (例: severities:CRITICAL,MAJOR types:BUG hotspots:TO_REVIEW)"
@@ -73,6 +73,28 @@ https://sonarcloud.io/api/measures/component?component=konabe_classical-music-la
 | `duplicated_blocks` | 重複ブロック数 |
 | `duplicated_files` | 重複を含むファイル数 |
 
+### 2b. Coverage サマリーの取得
+
+Issue サマリーと**同時に**以下の URL を WebFetch で呼び出す：
+
+```text
+https://sonarcloud.io/api/measures/component?component=konabe_classical-music-lake&metricKeys=coverage,line_coverage,branch_coverage,lines_to_cover,uncovered_lines,conditions_to_cover,uncovered_conditions
+```
+
+レスポンスの `component.measures` 配列から以下を抽出する：
+
+| metricKey | 意味 |
+|-----------|------|
+| `coverage` | 総合カバレッジ（%） |
+| `line_coverage` | ライン カバレッジ（%） |
+| `branch_coverage` | ブランチ カバレッジ（%） |
+| `lines_to_cover` | カバレッジ対象の総行数 |
+| `uncovered_lines` | カバーされていない行数 |
+| `conditions_to_cover` | カバレッジ対象の総条件数 |
+| `uncovered_conditions` | カバーされていない条件数 |
+
+値が存在しない場合は "N/A" と表示する。
+
 ### 3. サマリーの表示
 
 以下のフォーマットで表示する：
@@ -122,6 +144,18 @@ https://sonarcloud.io/api/measures/component?component=konabe_classical-music-la
 | 重複行数 | N 行 |
 | 重複ブロック数 | N |
 | 重複を含むファイル数 | N |
+
+## Coverage サマリー
+
+| 指標 | 値 |
+|------|----|
+| 総合カバレッジ | N.N% |
+| ライン カバレッジ | N.N% |
+| ブランチ カバレッジ | N.N% |
+| カバレッジ対象行数 | N 行 |
+| 未カバー行数 | N 行 |
+| カバレッジ対象条件数 | N |
+| 未カバー条件数 | N |
 ```
 
 ### 4. 詳細 Issue 一覧の取得

--- a/app/composables/useCognitoConfig.ts
+++ b/app/composables/useCognitoConfig.ts
@@ -1,7 +1,7 @@
 export function useCognitoConfig() {
   const config = useRuntimeConfig();
   return {
-    domain: config.public.cognitoDomain as string,
-    clientId: config.public.cognitoClientId as string,
+    domain: config.public.cognitoDomain,
+    clientId: config.public.cognitoClientId,
   };
 }

--- a/app/composables/useConcertLogs.test.ts
+++ b/app/composables/useConcertLogs.test.ts
@@ -1,5 +1,5 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { useListeningLogs } from "./useListeningLogs";
+import { useConcertLogs } from "./useConcertLogs";
 import { ACCESS_TOKEN_KEY, ID_TOKEN_KEY, REFRESH_TOKEN_KEY, TOKEN_EXPIRES_AT_KEY } from "./useAuth";
 
 const mockFetch = vi.fn();
@@ -45,7 +45,7 @@ beforeEach(() => {
   localStorage.clear();
 });
 
-describe("useListeningLogs", () => {
+describe("useConcertLogs", () => {
   describe("list", () => {
     it("401 エラー時にトークンを削除してログイン画面へリダイレクトする", async () => {
       localStorage.setItem(ACCESS_TOKEN_KEY, "expired-access-token");
@@ -67,7 +67,7 @@ describe("useListeningLogs", () => {
         }
       );
 
-      useListeningLogs();
+      useConcertLogs();
       await capturedOnResponseError?.({ response: { status: 401 } });
 
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
@@ -90,7 +90,7 @@ describe("useListeningLogs", () => {
         }
       );
 
-      useListeningLogs();
+      useConcertLogs();
       capturedOnResponseError?.({ response: { status: 500 } });
 
       expect(mockRouterPush).not.toHaveBeenCalled();
@@ -105,20 +105,18 @@ describe("useListeningLogs", () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 201,
-        json: async () => ({ id: "new-id", composer: "バッハ" }),
+        json: async () => ({ id: "new-id", title: "定期演奏会" }),
       });
 
-      const { create } = useListeningLogs();
+      const { create } = useConcertLogs();
       await create({
-        listenedAt: "2024-01-15T20:00:00.000Z",
-        composer: "バッハ",
-        piece: "ゴルトベルク変奏曲",
-        rating: 5,
-        isFavorite: false,
+        title: "定期演奏会 第123回",
+        concertDate: "2024-01-15T19:00:00.000Z",
+        venue: "サントリーホール",
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.example.com/listening-logs",
+        "https://api.example.com/concert-logs",
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
@@ -136,14 +134,12 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Unauthorized" }),
       });
 
-      const { create } = useListeningLogs();
+      const { create } = useConcertLogs();
       await expect(
         create({
-          listenedAt: "2024-01-15T20:00:00.000Z",
-          composer: "バッハ",
-          piece: "ゴルトベルク変奏曲",
-          rating: 5,
-          isFavorite: false,
+          title: "定期演奏会",
+          concertDate: "2024-01-15T19:00:00.000Z",
+          venue: "サントリーホール",
         })
       ).rejects.toThrow("Unauthorized");
 
@@ -160,14 +156,12 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Bad Request" }),
       });
 
-      const { create } = useListeningLogs();
+      const { create } = useConcertLogs();
       await expect(
         create({
-          listenedAt: "2024-01-15T20:00:00.000Z",
-          composer: "バッハ",
-          piece: "ゴルトベルク変奏曲",
-          rating: 5,
-          isFavorite: false,
+          title: "定期演奏会",
+          concertDate: "2024-01-15T19:00:00.000Z",
+          venue: "サントリーホール",
         })
       ).rejects.toThrow("Bad Request");
     });
@@ -181,14 +175,14 @@ describe("useListeningLogs", () => {
       mockFetch.mockResolvedValue({
         ok: true,
         status: 200,
-        json: async () => ({ id: "abc-123", rating: 4 }),
+        json: async () => ({ id: "abc-123", title: "更新後のコンサート" }),
       });
 
-      const { update } = useListeningLogs();
-      await update("abc-123", { rating: 4 });
+      const { update } = useConcertLogs();
+      await update("abc-123", { title: "更新後のコンサート" });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.example.com/listening-logs/abc-123",
+        "https://api.example.com/concert-logs/abc-123",
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
@@ -206,8 +200,8 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Unauthorized" }),
       });
 
-      const { update } = useListeningLogs();
-      await expect(update("abc-123", { rating: 4 })).rejects.toThrow("Unauthorized");
+      const { update } = useConcertLogs();
+      await expect(update("abc-123", { title: "更新後" })).rejects.toThrow("Unauthorized");
 
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
       expect(mockRouterPush).toHaveBeenCalledWith("/auth/login");
@@ -222,8 +216,8 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Not Found" }),
       });
 
-      const { update } = useListeningLogs();
-      await expect(update("abc-123", { rating: 4 })).rejects.toThrow("Not Found");
+      const { update } = useConcertLogs();
+      await expect(update("abc-123", { title: "更新後" })).rejects.toThrow("Not Found");
     });
   });
 
@@ -237,11 +231,11 @@ describe("useListeningLogs", () => {
         status: 204,
       });
 
-      const { deleteLog } = useListeningLogs();
+      const { deleteLog } = useConcertLogs();
       await deleteLog("abc-123");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.example.com/listening-logs/abc-123",
+        "https://api.example.com/concert-logs/abc-123",
         expect.objectContaining({
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
@@ -258,7 +252,7 @@ describe("useListeningLogs", () => {
         status: 204,
       });
 
-      const { deleteLog } = useListeningLogs();
+      const { deleteLog } = useConcertLogs();
       await expect(deleteLog("abc-123")).resolves.toBeUndefined();
     });
 
@@ -271,7 +265,7 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Unauthorized" }),
       });
 
-      const { deleteLog } = useListeningLogs();
+      const { deleteLog } = useConcertLogs();
       await expect(deleteLog("abc-123")).rejects.toThrow("Unauthorized");
 
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
@@ -287,24 +281,8 @@ describe("useListeningLogs", () => {
         json: async () => ({ message: "Not Found" }),
       });
 
-      const { deleteLog } = useListeningLogs();
+      const { deleteLog } = useConcertLogs();
       await expect(deleteLog("abc-123")).rejects.toThrow("Not Found");
-    });
-  });
-
-  describe("await との互換性", () => {
-    it("useListeningLogs() を await した結果でも deleteLog が関数として参照できる", async () => {
-      // thenable ではない通常オブジェクトを await すると自身に解決されるため、
-      // 返り値の全プロパティが保持されることを保証する。
-      const result = useListeningLogs();
-      const awaited = await result;
-      expect(typeof awaited.deleteLog).toBe("function");
-    });
-
-    it("useListeningLogs() を await した結果でも refresh が関数として参照できる", async () => {
-      const result = useListeningLogs();
-      const awaited = await result;
-      expect(typeof awaited.refresh).toBe("function");
     });
   });
 });

--- a/app/composables/useConcertLogs.ts
+++ b/app/composables/useConcertLogs.ts
@@ -58,7 +58,19 @@ export const useConcertLogs = () => {
     clearNuxtData();
   };
 
-  return { ...list, create, update, deleteLog };
+  const { data, pending, error, refresh, execute, status, then: thenFn } = list;
+  return {
+    data,
+    pending,
+    error,
+    refresh,
+    execute,
+    status,
+    then: thenFn,
+    create,
+    update,
+    deleteLog,
+  };
 };
 
 export const useConcertLog = (id: () => string) => {

--- a/app/composables/useConcertLogs.ts
+++ b/app/composables/useConcertLogs.ts
@@ -58,7 +58,7 @@ export const useConcertLogs = () => {
     clearNuxtData();
   };
 
-  const { data, pending, error, refresh, execute, status, then: thenFn } = list;
+  const { data, pending, error, refresh, execute, status } = list;
   return {
     data,
     pending,
@@ -66,7 +66,6 @@ export const useConcertLogs = () => {
     refresh,
     execute,
     status,
-    then: thenFn,
     create,
     update,
     deleteLog,

--- a/app/composables/useListeningLogs.ts
+++ b/app/composables/useListeningLogs.ts
@@ -58,7 +58,7 @@ export const useListeningLogs = () => {
     clearNuxtData();
   };
 
-  const { data, pending, error, refresh, execute, status, then: thenFn } = list;
+  const { data, pending, error, refresh, execute, status } = list;
   return {
     data,
     pending,
@@ -66,7 +66,6 @@ export const useListeningLogs = () => {
     refresh,
     execute,
     status,
-    then: thenFn,
     create,
     update,
     deleteLog,

--- a/app/composables/useListeningLogs.ts
+++ b/app/composables/useListeningLogs.ts
@@ -58,7 +58,19 @@ export const useListeningLogs = () => {
     clearNuxtData();
   };
 
-  return { ...list, create, update, deleteLog };
+  const { data, pending, error, refresh, execute, status, then: thenFn } = list;
+  return {
+    data,
+    pending,
+    error,
+    refresh,
+    execute,
+    status,
+    then: thenFn,
+    create,
+    update,
+    deleteLog,
+  };
 };
 
 export const useListeningLog = (id: () => string) => {

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -16,7 +16,8 @@ export const usePieces = () => {
     return result;
   };
 
-  return { ...list, createPiece, updatePiece };
+  const { data, pending, error, refresh, execute, status } = list;
+  return { data, pending, error, refresh, execute, status, createPiece, updatePiece };
 };
 
 export const usePiece = (id: () => string) => {

--- a/app/pages/concert-logs/index.vue
+++ b/app/pages/concert-logs/index.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 definePageMeta({ middleware: "auth" });
 
-// useConcertLogs は useFetch の then が spread されるため thenable になる。
-// `await useConcertLogs()` は asyncReturn（AsyncData本体）に解決され
-// create が undefined になる。変数を分けて await することで回避する。
-const concertLogs = useConcertLogs();
-await concertLogs;
-const { data: logs } = concertLogs;
+const { data: logs } = useConcertLogs();
 </script>
 
 <template>

--- a/app/pages/listening-logs/index.vue
+++ b/app/pages/listening-logs/index.vue
@@ -1,12 +1,7 @@
 <script setup lang="ts">
 definePageMeta({ middleware: "auth" });
 
-// useListeningLogs は useFetch の then が spread されるため thenable になる。
-// `await useListeningLogs()` は asyncReturn（AsyncData本体）に解決され
-// deleteLog が undefined になる。変数を分けて await することで回避する。
-const listeningLogs = useListeningLogs();
-await listeningLogs;
-const { data: logs, refresh, deleteLog } = listeningLogs;
+const { data: logs, refresh, deleteLog } = useListeningLogs();
 
 async function handleDelete(id: string) {
   if (!confirm("この記録を削除しますか？")) {

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -72,10 +72,7 @@ export const updatePieceSchema = z.object({
   region: z.union([pieceRegionSchema, z.literal("")]).optional(),
 });
 
-const emailSchema = z
-  .string({ error: () => "email is required" })
-  .trim()
-  .email("email must be a valid email address");
+const emailSchema = z.email("email must be a valid email address").trim();
 
 const passwordSchema = z
   .string({ error: () => "password is required" })
@@ -130,7 +127,7 @@ export const createConcertLogSchema = z.object({
   conductor: z.string().trim().max(100, "conductor must be 100 characters or less").optional(),
   orchestra: z.string().trim().max(100, "orchestra must be 100 characters or less").optional(),
   soloist: z.string().trim().max(100, "soloist must be 100 characters or less").optional(),
-  pieceIds: z.array(z.string().uuid("pieceId must be a valid UUID")).optional(),
+  pieceIds: z.array(z.uuid("pieceId must be a valid UUID")).optional(),
 });
 
 export const updateConcertLogSchema = createConcertLogSchema.partial();


### PR DESCRIPTION
## Summary

- `useConcertLogs` / `useListeningLogs` / `usePieces` で `useFetch` 戻り値（thenable）をスプレッドしていた問題を修正（`typescript:S6544` MAJOR BUG × 3件）
- `useCognitoConfig` の不要な型アサーション `as string` を削除（`typescript:S4325` MINOR × 2件）
- `schemas.ts` の非推奨 Zod メソッド（`.string().email()` / `.string().uuid()`）を Zod v4 スタイル（`z.email()` / `z.uuid()`）に置換（`typescript:S1874` MINOR × 2件）
- `sonarqube-issues` スキルにカバレッジ取得（ステップ 2b）と表示フォーマットを追加

## Test plan

- [ ] バックエンドテスト: `pnpm run test:backend` (369件 pass)
- [ ] フロントエンドテスト: `pnpm run test:frontend` (503件 pass)
- [ ] `concert-logs` / `listening-logs` 一覧ページで `await` パターンが引き続き動作すること
- [ ] ログイン・登録フローでメール入力バリデーションが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)