### PR TITLE
fix(ci): cdk deploy に --exclusively を再追加して NocturneAppDnsStack の自動更新を防ぐ

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -154,9 +154,9 @@ jobs:
       - name: CDK Deploy
         run: |
           if [ "$STAGE_NAME" = "prod" ]; then
-            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never
+            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never --exclusively
           else
-            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never --hotswap-fallback
+            npx cdk deploy "${{ steps.stack.outputs.name }}" --require-approval never --hotswap-fallback --exclusively
           fi
         working-directory: cdk
         env:


### PR DESCRIPTION
## Summary

- `npx cdk deploy ClassicalMusicLakeStack-{env}` 実行時、CDK が依存の `NocturneAppDnsStack`（us-east-1）も自動デプロイしようとする
- `NocturneAppDnsStack` の cross-region SSM エクスポートが `ClassicalMusicLakeStack-stg` に使用中のため更新できず、`UPDATE_ROLLBACK_FAILED` 状態に陥っていた
- `--exclusively` フラグを追加して指定スタックのみデプロイするよう修正（`NocturneAppDnsStack` は証明書・HostedZone の初回作成時のみ手動デプロイ）

## 根本原因

`bin/app.ts` では `ClassicalMusicLakeStack` が `DnsStack.hostedZone` / `DnsStack.certificate` を参照しているため、CDK はデプロイ時に `NocturneAppDnsStack` を依存スタックとして自動更新しようとする。`crossRegionReferences: true` で作成される cross-region SSM パラメータは使用中のスタックがある間は更新不可という CloudFormation の制約に引っかかっていた。

## 手動対応が必要な事項

`NocturneAppDnsStack` が現在 `UPDATE_ROLLBACK_FAILED` 状態のため、このPRマージ後も初回デプロイは失敗する可能性がある。以下の手順で手動回復が必要：

1. AWS CloudFormation コンソール → us-east-1 → `NocturneAppDnsStack`
2. 「スタックのアクション」→「スタックの更新のロールバックを続行する（Continue Update Rollback）」を実行
3. 回復後、通常の CI/CD デプロイが動作するようになる

## Test plan

- [ ] `NocturneAppDnsStack` を手動回復後、dev タグ push で dev 環境デプロイが成功することを確認
- [ ] main ブランチ push で stg 環境デプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)