### PR TITLE
feat(pieces): 楽曲一覧のサムネイルから遷移時に動画を自動再生する

### DIFF
--- a/app/components/molecules/PieceItem.test.ts
+++ b/app/components/molecules/PieceItem.test.ts
@@ -200,18 +200,27 @@ describe("PieceItem", () => {
         props: { piece: samplePieceWithYouTubeUrl },
       });
       expect(wrapper.find(".piece-thumbnail").attributes("aria-label")).toBe(
-        "交響曲第9番 ニ短調 Op.125 の詳細を開く"
+        "交響曲第9番 ニ短調 Op.125 の動画を再生"
       );
     });
 
-    it("サムネイル領域クリックで detail イベントが emit される", async () => {
+    it("サムネイル領域クリックで play イベントが emit される", async () => {
       const wrapper = await mountSuspended(PieceItem, {
         props: { piece: samplePieceWithYouTubeUrl },
         ...globalComponents,
       });
       await wrapper.find(".piece-thumbnail").trigger("click");
-      expect(wrapper.emitted("detail")).toBeDefined();
-      expect(wrapper.emitted("detail")?.length).toBe(1);
+      expect(wrapper.emitted("play")).toBeDefined();
+      expect(wrapper.emitted("play")?.length).toBe(1);
+    });
+
+    it("サムネイル領域クリックでは detail イベントが emit されない", async () => {
+      const wrapper = await mountSuspended(PieceItem, {
+        props: { piece: samplePieceWithYouTubeUrl },
+        ...globalComponents,
+      });
+      await wrapper.find(".piece-thumbnail").trigger("click");
+      expect(wrapper.emitted("detail")).toBeUndefined();
     });
   });
 });

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -10,6 +10,7 @@ const emit = defineEmits<{
   edit: [];
   delete: [];
   detail: [];
+  play: [];
 }>();
 
 const hasYouTubeThumbnail = computed(
@@ -25,8 +26,8 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
       v-if="hasYouTubeThumbnail"
       type="button"
       class="piece-thumbnail"
-      :aria-label="`${piece.title} の詳細を開く`"
-      @click="emit('detail')"
+      :aria-label="`${piece.title} の動画を再生`"
+      @click="emit('play')"
     >
       <YouTubeThumbnail :video-url="piece.videoUrl" :alt="thumbnailAlt" />
     </button>

--- a/app/components/molecules/VideoPlayer.test.ts
+++ b/app/components/molecules/VideoPlayer.test.ts
@@ -28,6 +28,20 @@ describe("VideoPlayer", () => {
       });
       expect(wrapper.find("a.external-link").exists()).toBe(false);
     });
+
+    it("autoplay が未指定のときは embed URL に autoplay=1 が含まれない", async () => {
+      const wrapper = await mountSuspended(VideoPlayer, {
+        props: { videoUrl: youtubeUrl },
+      });
+      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay=1");
+    });
+
+    it("autoplay が true のとき embed URL に autoplay=1 が追加される", async () => {
+      const wrapper = await mountSuspended(VideoPlayer, {
+        props: { videoUrl: youtubeUrl, autoplay: true },
+      });
+      expect(wrapper.find("iframe").attributes("src")).toContain("autoplay=1");
+    });
   });
 
   describe("非 YouTube URL の場合", () => {

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -1,16 +1,23 @@
 <script setup lang="ts">
 import { isYouTubeUrl, toYouTubeEmbedUrl } from "~/utils/video";
 
-const props = defineProps<{
-  videoUrl: string;
-}>();
+const props = withDefaults(
+  defineProps<{
+    videoUrl: string;
+    autoplay?: boolean;
+  }>(),
+  { autoplay: false }
+);
 
 const emit = defineEmits<{
   play: [];
 }>();
 
 const isYouTube = computed(() => isYouTubeUrl(props.videoUrl));
-const embedUrl = computed(() => toYouTubeEmbedUrl(props.videoUrl));
+const embedUrl = computed(() => {
+  const base = toYouTubeEmbedUrl(props.videoUrl);
+  return props.autoplay ? `${base}&autoplay=1` : base;
+});
 
 type YTPlayer = { destroy: () => void };
 

--- a/app/components/organisms/PieceList.test.ts
+++ b/app/components/organisms/PieceList.test.ts
@@ -7,6 +7,7 @@ const makePieces = (): Piece[] => [
     id: "piece-1",
     title: "交響曲第9番",
     composer: "ベートーヴェン",
+    videoUrl: "https://www.youtube.com/watch?v=abc123",
     createdAt: "2024-01-01T00:00:00.000Z",
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
@@ -91,6 +92,24 @@ describe("PieceList", () => {
       await wrapper.findAll(".btn-danger")[0].trigger("click");
       const emitted = wrapper.emitted("delete") as [Piece][];
       expect(emitted[0][0].id).toBe("piece-1");
+    });
+
+    it("詳細ボタンクリックで autoplay なしの詳細ページへ遷移する", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      const routerPushSpy = vi.spyOn(wrapper.vm.$router, "push");
+      await wrapper.findAll(".btn-detail")[0].trigger("click");
+      expect(routerPushSpy).toHaveBeenCalledWith("/pieces/piece-1");
+    });
+
+    it("サムネイルクリックで autoplay=1 付きの詳細ページへ遷移する", async () => {
+      const wrapper = await mountSuspended(PieceList, {
+        props: { pieces: makePieces(), error: null },
+      });
+      const routerPushSpy = vi.spyOn(wrapper.vm.$router, "push");
+      await wrapper.find(".piece-thumbnail").trigger("click");
+      expect(routerPushSpy).toHaveBeenCalledWith("/pieces/piece-1?autoplay=1");
     });
   });
 });

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -29,6 +29,7 @@ const router = useRouter();
         <PieceItem
           :piece="piece"
           @detail="router.push(`/pieces/${piece.id}`)"
+          @play="router.push(`/pieces/${piece.id}?autoplay=1`)"
           @edit="router.push(`/pieces/${piece.id}/edit`)"
           @delete="emit('delete', piece)"
         />

--- a/app/components/templates/PieceDetailTemplate.test.ts
+++ b/app/components/templates/PieceDetailTemplate.test.ts
@@ -60,6 +60,20 @@ describe("PieceDetailTemplate", () => {
       });
       expect(wrapper.find(".quick-log-form").exists()).toBe(false);
     });
+
+    it("autoplay が未指定のとき iframe の src に autoplay=1 が含まれない", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: { piece: pieceWithVideo, error: null },
+      });
+      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay=1");
+    });
+
+    it("autoplay が true のとき iframe の src に autoplay=1 が含まれる", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: { piece: pieceWithVideo, error: null, autoplay: true },
+      });
+      expect(wrapper.find("iframe").attributes("src")).toContain("autoplay=1");
+    });
   });
 
   describe("videoUrl なし", () => {

--- a/app/components/templates/PieceDetailTemplate.vue
+++ b/app/components/templates/PieceDetailTemplate.vue
@@ -1,10 +1,14 @@
 <script setup lang="ts">
 import type { Piece, Rating } from "~/types";
 
-defineProps<{
-  piece: Piece | null;
-  error: Error | null;
-}>();
+withDefaults(
+  defineProps<{
+    piece: Piece | null;
+    error: Error | null;
+    autoplay?: boolean;
+  }>(),
+  { autoplay: false }
+);
 
 const emit = defineEmits<{
   save: [values: { rating: Rating; isFavorite: boolean; memo: string }];
@@ -33,7 +37,11 @@ const hasStartedPlaying = ref(false);
       </div>
 
       <template v-if="piece.videoUrl">
-        <VideoPlayer :video-url="piece.videoUrl" @play="hasStartedPlaying = true" />
+        <VideoPlayer
+          :video-url="piece.videoUrl"
+          :autoplay="autoplay"
+          @play="hasStartedPlaying = true"
+        />
 
         <QuickLogForm
           v-if="hasStartedPlaying"

--- a/app/pages/pieces/[id]/index.vue
+++ b/app/pages/pieces/[id]/index.vue
@@ -5,6 +5,8 @@ const route = useRoute();
 const { data: piece, error } = await usePiece(() => route.params.id as string);
 const { create } = useListeningLogs();
 
+const autoplay = computed(() => route.query.autoplay === "1");
+
 async function handleSave(values: { rating: Rating; isFavorite: boolean; memo: string }) {
   if (piece.value === null) {
     return;
@@ -20,5 +22,10 @@ async function handleSave(values: { rating: Rating; isFavorite: boolean; memo: s
 </script>
 
 <template>
-  <PieceDetailTemplate :piece="piece ?? null" :error="error" @save="handleSave" />
+  <PieceDetailTemplate
+    :piece="piece ?? null"
+    :error="error"
+    :autoplay="autoplay"
+    @save="handleSave"
+  />
 </template>


### PR DESCRIPTION
楽曲一覧でサムネイルをクリックした場合のみ `?autoplay=1` を付けて詳細へ遷移し、
動画を最初から自動再生する。詳細ボタンからの遷移では従来どおり自動再生しない。

closes #465