### PR TITLE
fix(cdk): 全ステージの Consumer スタックを常に synth する

### DIFF
--- a/.github/workflows/deploy-dns.yml
+++ b/.github/workflows/deploy-dns.yml
@@ -73,6 +73,59 @@ jobs:
         working-directory: cdk
 
       # ----------------------------------------
+      # 診断: スタックの現在状態と直近のイベントを出力する
+      # UPDATE_ROLLBACK_FAILED で詰まっている場合、どのリソースが
+      # 原因かをログから特定できるようにする
+      # ----------------------------------------
+      - name: Show CFN stack status and recent events
+        run: |
+          STATUS=$(aws cloudformation describe-stacks \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1 \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "NOT_FOUND")
+          echo "NocturneAppDnsStack status: $STATUS"
+          echo "Recent stack events:"
+          aws cloudformation describe-stack-events \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1 \
+            --max-items 30 \
+            --query 'StackEvents[].[Timestamp,ResourceStatus,ResourceType,LogicalResourceId,ResourceStatusReason]' \
+            --output table || true
+
+      # ----------------------------------------
+      # UPDATE_ROLLBACK_FAILED からの自動復旧
+      # 過去の DnsStack 更新時にロールバックも失敗して固着した場合、
+      # cdk deploy はそのままでは動かないので continue-update-rollback
+      # を発行してロールバックを完了させる
+      # ----------------------------------------
+      - name: Continue rollback if stuck
+        run: |
+          STATUS=$(aws cloudformation describe-stacks \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1 \
+            --query 'Stacks[0].StackStatus' \
+            --output text 2>/dev/null || echo "NOT_FOUND")
+          if [ "$STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
+            echo "Stack is UPDATE_ROLLBACK_FAILED. Attempting continue-update-rollback..."
+            aws cloudformation continue-update-rollback \
+              --stack-name NocturneAppDnsStack \
+              --region us-east-1
+            echo "Waiting for rollback to complete..."
+            aws cloudformation wait stack-rollback-complete \
+              --stack-name NocturneAppDnsStack \
+              --region us-east-1
+            FINAL_STATUS=$(aws cloudformation describe-stacks \
+              --stack-name NocturneAppDnsStack \
+              --region us-east-1 \
+              --query 'Stacks[0].StackStatus' \
+              --output text)
+            echo "Rollback completed. Final status: $FINAL_STATUS"
+          else
+            echo "Stack is not in UPDATE_ROLLBACK_FAILED state. Skipping recovery."
+          fi
+
+      # ----------------------------------------
       # DnsStack をデプロイして us-east-1 の
       # /cdk/exports/<ConsumerStackName>/... SSM パラメータを更新する。
       # app.ts で全 3 ステージの Consumer を instantiate しているため、

--- a/.github/workflows/deploy-dns.yml
+++ b/.github/workflows/deploy-dns.yml
@@ -14,6 +14,10 @@ name: Deploy DNS Stack
 
 on:
   workflow_dispatch:
+  # TODO: マージ前に必ずこの push トリガーを削除すること（PR ブランチでの検証用）
+  push:
+    branches:
+      - claude/fix-deploy-action-NT9Vc
 
 concurrency:
   group: deploy-dns

--- a/.github/workflows/deploy-dns.yml
+++ b/.github/workflows/deploy-dns.yml
@@ -95,9 +95,11 @@ jobs:
 
       # ----------------------------------------
       # UPDATE_ROLLBACK_FAILED からの自動復旧
-      # 過去の DnsStack 更新時にロールバックも失敗して固着した場合、
-      # cdk deploy はそのままでは動かないので continue-update-rollback
-      # を発行してロールバックを完了させる
+      # DnsStack 更新時に ExportsWriter（Custom::CrossRegionExportWriter）が
+      # 他のステージで現在も参照中の SSM エクスポートを削除しようとして失敗し、
+      # ロールバックも失敗して固着する既知の問題がある
+      # UPDATE_FAILED 状態のリソースを --resources-to-skip に渡して
+      # continue-update-rollback を発行する
       # ----------------------------------------
       - name: Continue rollback if stuck
         run: |
@@ -106,24 +108,40 @@ jobs:
             --region us-east-1 \
             --query 'Stacks[0].StackStatus' \
             --output text 2>/dev/null || echo "NOT_FOUND")
-          if [ "$STATUS" = "UPDATE_ROLLBACK_FAILED" ]; then
-            echo "Stack is UPDATE_ROLLBACK_FAILED. Attempting continue-update-rollback..."
+          if [ "$STATUS" != "UPDATE_ROLLBACK_FAILED" ]; then
+            echo "Stack status is $STATUS. Skipping recovery."
+            exit 0
+          fi
+
+          echo "Stack is UPDATE_ROLLBACK_FAILED. Resolving failed resources..."
+          SKIP=$(aws cloudformation describe-stack-resources \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1 \
+            --query 'StackResources[?ResourceStatus==`UPDATE_FAILED`].LogicalResourceId' \
+            --output text)
+          echo "Resources to skip: ${SKIP:-<none>}"
+
+          if [ -n "$SKIP" ]; then
+            aws cloudformation continue-update-rollback \
+              --stack-name NocturneAppDnsStack \
+              --region us-east-1 \
+              --resources-to-skip $SKIP
+          else
             aws cloudformation continue-update-rollback \
               --stack-name NocturneAppDnsStack \
               --region us-east-1
-            echo "Waiting for rollback to complete..."
-            aws cloudformation wait stack-rollback-complete \
-              --stack-name NocturneAppDnsStack \
-              --region us-east-1
-            FINAL_STATUS=$(aws cloudformation describe-stacks \
-              --stack-name NocturneAppDnsStack \
-              --region us-east-1 \
-              --query 'Stacks[0].StackStatus' \
-              --output text)
-            echo "Rollback completed. Final status: $FINAL_STATUS"
-          else
-            echo "Stack is not in UPDATE_ROLLBACK_FAILED state. Skipping recovery."
           fi
+
+          echo "Waiting for rollback to complete..."
+          aws cloudformation wait stack-rollback-complete \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1
+          FINAL_STATUS=$(aws cloudformation describe-stacks \
+            --stack-name NocturneAppDnsStack \
+            --region us-east-1 \
+            --query 'Stacks[0].StackStatus' \
+            --output text)
+          echo "Rollback completed. Final status: $FINAL_STATUS"
 
       # ----------------------------------------
       # DnsStack をデプロイして us-east-1 の

--- a/.github/workflows/deploy-dns.yml
+++ b/.github/workflows/deploy-dns.yml
@@ -14,10 +14,6 @@ name: Deploy DNS Stack
 
 on:
   workflow_dispatch:
-  # TODO: マージ前に必ずこの push トリガーを削除すること（PR ブランチでの検証用）
-  push:
-    branches:
-      - claude/fix-deploy-action-NT9Vc
 
 concurrency:
   group: deploy-dns

--- a/.github/workflows/deploy-dns.yml
+++ b/.github/workflows/deploy-dns.yml
@@ -1,0 +1,79 @@
+name: Deploy DNS Stack
+
+# -----------------------------------------------------------------------
+# NocturneAppDnsStack（us-east-1）を手動でデプロイするためのワークフロー。
+# DnsStack の cross-region SSM エクスポートは Consumer スタックごとに
+# 作成されるため、app.ts で Consumer を追加・変更した後に一度だけ
+# 手動実行して us-east-1 の SSM パラメータを更新する用途で使う。
+#
+# deploy.yml とは異なり、DnsStack のみを対象に --exclusively なしで
+# デプロイする。ACM 証明書の DNS 検証が未完了の場合は CloudFormation が
+# ペンディングするため、初回デプロイ時はお名前.comで NS レコードを
+# 設定しておくこと。
+# -----------------------------------------------------------------------
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-dns
+  cancel-in-progress: false
+
+jobs:
+  deploy-dns:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install all dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate required secrets
+        env:
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        run: |
+          if [ -z "$AWS_ROLE_TO_ASSUME" ]; then
+            echo "::error::AWS_ROLE_TO_ASSUME secret is not set."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      - name: Ensure ECR repository for CDK bootstrap (us-east-1)
+        run: |
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          REPO="cdk-hnb659fds-container-assets-${ACCOUNT}-us-east-1"
+          aws ecr describe-repositories --repository-names "$REPO" --region us-east-1 2>/dev/null \
+            || aws ecr create-repository --repository-name "$REPO" --region us-east-1 2>/dev/null \
+            || true
+
+      - name: CDK Bootstrap (us-east-1)
+        run: |
+          ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+          npx cdk bootstrap "aws://${ACCOUNT}/us-east-1"
+        working-directory: cdk
+
+      # ----------------------------------------
+      # DnsStack をデプロイして us-east-1 の
+      # /cdk/exports/<ConsumerStackName>/... SSM パラメータを更新する。
+      # app.ts で全 3 ステージの Consumer を instantiate しているため、
+      # このデプロイで 3 環境分の SSM エクスポートが作成される。
+      # ----------------------------------------
+      - name: CDK Deploy (NocturneAppDnsStack)
+        run: npx cdk deploy NocturneAppDnsStack --require-approval never --exclusively
+        working-directory: cdk

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -6,21 +6,21 @@ import { DnsStack } from "../lib/dns-stack";
 
 const app = new cdk.App();
 
-const rawStageName = process.env.STAGE_NAME ?? "prod";
 const validStages: StageName[] = ["dev", "stg", "prod"];
+const rawStageName = process.env.STAGE_NAME ?? "prod";
 if (!validStages.includes(rawStageName as StageName)) {
   throw new Error(
     `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${validStages.join(", ")}`
   );
 }
-const stageName = rawStageName as StageName;
-const stackName =
-  stageName === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stageName}`;
+
+const stackNameFor = (stage: StageName): string =>
+  stage === "prod" ? "ClassicalMusicLakeStack" : `ClassicalMusicLakeStack-${stage}`;
 
 // -------------------------
 // DNS スタック（us-east-1）
 // CloudFront 用の ACM 証明書は us-east-1 に作成する必要がある
-// 初回デプロイ時は手動で実行: STAGE_NAME=prod npx cdk deploy NocturneAppDnsStack
+// 初回デプロイ時は手動で実行: npx cdk deploy NocturneAppDnsStack
 // ※ ACM 証明書の DNS 検証が完了するまで CloudFormation がペンディングになるため、
 //    先にこのスタックだけデプロイし、お名前.comで NS レコードを設定してから
 //    メインスタックをデプロイすること
@@ -33,15 +33,27 @@ const dnsStack = new DnsStack(app, "NocturneAppDnsStack", {
   crossRegionReferences: true,
 });
 
-// prettier-ignore
-new ClassicalMusicLakeStack(app, stackName, { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
-  stageName,
-  hostedZone: dnsStack.hostedZone,
-  certificate: dnsStack.certificate,
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
-  },
-  crossRegionReferences: true,
-  terminationProtection: stageName === "prod",
-});
+// -------------------------
+// 全ステージの Consumer スタックを常に instantiate する
+// DnsStack の cross-region SSM エクスポートは Consumer スタックごとに
+// /cdk/exports/<ConsumerStackName>/... のパスで作成される。
+// STAGE_NAME で分岐して 1 ステージ分だけ synth すると、DnsStack の
+// テンプレートから他ステージ用の SSM エクスポートが消え、別ステージの
+// deploy 時に "Parameters cannot be found" で失敗する。
+// 3 環境分を常に synth し、CI/CD では `cdk deploy <stackName> --exclusively`
+// で対象のみデプロイする運用とする。
+// -------------------------
+for (const stage of validStages) {
+  // prettier-ignore
+  new ClassicalMusicLakeStack(app, stackNameFor(stage), { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
+    stageName: stage,
+    hostedZone: dnsStack.hostedZone,
+    certificate: dnsStack.certificate,
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
+    },
+    crossRegionReferences: true,
+    terminationProtection: stage === "prod",
+  });
+}


### PR DESCRIPTION
prod デプロイが以下のエラーで失敗していた問題を修正する:
  Parameters [ssm:/cdk/exports/ClassicalMusicLakeStack/...] cannot be found

原因:
CDK の crossRegionReferences は Consumer スタックごとに
/cdk/exports/<ConsumerStackName>/... の SSM パラメータを us-east-1 に作成する
しかし app.ts は STAGE_NAME で 1 環境分しか instantiate していなかったため、
DnsStack の SSM エクスポートは synth 時に選ばれた 1 環境分しか生成されず、
他環境の deploy 時に SSM パラメータが見つからず ChangeSet 作成が失敗していた

対応:
STAGE_NAME に関係なく dev/stg/prod 全ステージの ClassicalMusicLakeStack
を常に instantiate し、DnsStack テンプレートに 3 環境分の SSM エクスポートを
含める。デプロイ対象は CI/CD 側で cdk deploy <stackName> --exclusively で絞る

反映には一度だけ手動で DnsStack を再デプロイする必要がある:
  npx cdk deploy NocturneAppDnsStack

https://claude.ai/code/session_01SJJKGtcKcPbdewrrAAzCn8