### PR TITLE
fix(ui): カードグリッド・モバイルヘッダー・ログイン UI の体裁修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ reports/mutation/
 
 # Temporary local output
 tmp/
+
+# Playwright MCP local snapshots
+.playwright-mcp/

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,6 @@ cdk/node_modules/
 package-lock.json
 pnpm-lock.yaml
 .claude/
+.playwright-mcp/
 # release-please が自動生成するため除外
 CHANGELOG.md

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -93,7 +93,9 @@ form {
   align-items: center;
   text-align: center;
   color: #7a5c38;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  margin: 1.25rem 0;
+  font-size: 0.85rem;
 }
 
 .divider::before,

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -287,11 +287,18 @@ defineProps<{
 /* ── Menu cards ── */
 .menu-cards {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(3, 1fr);
   gap: 1.5rem;
-  max-width: 760px;
+  max-width: 960px;
   margin: 2rem auto 0;
   padding: 0 2rem;
+}
+
+@media (max-width: 900px) {
+  .menu-cards {
+    grid-template-columns: 1fr;
+    max-width: 480px;
+  }
 }
 
 .card {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -135,24 +135,42 @@ watch(
 
 @media (max-width: 600px) {
   .app-header {
-    padding: 0.75rem 1rem;
+    padding: 0.75rem 0.75rem;
   }
 
   .app-header nav {
-    gap: 1rem;
+    gap: 0.5rem;
     flex-wrap: nowrap;
   }
 
+  .logo {
+    gap: 0.4rem;
+  }
+
+  .logo-img {
+    height: 26px;
+  }
+
   .logo-text {
-    font-size: 1.1rem;
+    display: none;
   }
 
   .nav-links {
-    gap: 0.75rem;
+    gap: 0.6rem;
+  }
+
+  .nav-links a,
+  .auth-links a {
+    font-size: 0.85rem;
   }
 
   .auth-links {
-    gap: 0.75rem;
+    gap: 0.6rem;
+  }
+
+  .logout-button {
+    padding: 0.3rem 0.6rem;
+    font-size: 0.8rem;
   }
 
   .app-main {


### PR DESCRIPTION
## Summary

- dev 環境（dev.nocturne-app.com）を Playwright で巡回して見つけた UI の体裁不良を修正
- トップページのメニューカードを 3 列レイアウトに統一（モバイルでは 1 列に折り返し）
- モバイル（≤600px）でヘッダーのナビ要素が画面幅を超える問題を解消（ロゴテキスト非表示・余白とフォント調整）
- ログインフォームの「または」セパレータがログインボタン / Google ログインボタンと密着していたため、上下マージンとフォントサイズを調整

## Test plan

- [ ] `https://dev.nocturne-app.com/` でメニューカードが 3 列で並ぶ
- [ ] モバイル幅（375px）でヘッダーの「鑑賞記録 / 新規登録 / ログイン」が画面内に収まる
- [ ] `https://dev.nocturne-app.com/auth/login` で「または」セパレータがボタンと適切な余白を持って表示される
- [ ] フロント・バックエンドのテストがパス（`pnpm run test:frontend` / `pnpm run test:backend`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)