### PR TITLE
feat(015-02): 楽曲マスタ書き込み API を管理者限定にする

### DIFF
--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import type { Context } from "aws-lambda";
 
 import { handler } from "./create";
-import { makeEvent, makeAuthEvent, makeAdminEvent, TEST_USER_ID } from "../../test/fixtures";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -17,9 +23,6 @@ vi.mock("../../repositories/piece-repository", () => ({
     return mockRepo;
   }),
 }));
-
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
 
 const validInput = {
   title: "交響曲第9番",

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { Context } from "aws-lambda";
 
 import { handler } from "./create";
-import { makeEvent } from "../../test/fixtures";
+import { makeEvent, makeAuthEvent, makeAdminEvent, TEST_USER_ID } from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -43,7 +43,7 @@ describe("POST /pieces (create)", () => {
       ["invalid json", 422, "Invalid or malformed JSON was provided"],
     ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
       const result = await handler(
-        makeEvent({ body, httpMethod: "POST", path: "/pieces" }),
+        makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/pieces" }),
         mockContext,
         mockCallback
       );
@@ -54,7 +54,7 @@ describe("POST /pieces (create)", () => {
 
   it("title がない場合は 400 を返す", async () => {
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ composer: "ベートーヴェン" }),
         httpMethod: "POST",
         path: "/pieces",
@@ -70,7 +70,7 @@ describe("POST /pieces (create)", () => {
     "title が空白のみ（%j）の場合は 400 を返す",
     async (whitespaceTitle) => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, title: whitespaceTitle }),
           httpMethod: "POST",
           path: "/pieces",
@@ -85,7 +85,7 @@ describe("POST /pieces (create)", () => {
 
   it("title が 200 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, title: "あ".repeat(201) }),
         httpMethod: "POST",
         path: "/pieces",
@@ -99,7 +99,7 @@ describe("POST /pieces (create)", () => {
 
   it("composer がない場合は 400 を返す", async () => {
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ title: "交響曲第9番" }),
         httpMethod: "POST",
         path: "/pieces",
@@ -115,7 +115,7 @@ describe("POST /pieces (create)", () => {
     "composer が空白のみ（%j）の場合は 400 を返す",
     async (whitespaceComposer) => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, composer: whitespaceComposer }),
           httpMethod: "POST",
           path: "/pieces",
@@ -130,7 +130,7 @@ describe("POST /pieces (create)", () => {
 
   it("composer が 100 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, composer: "あ".repeat(101) }),
         httpMethod: "POST",
         path: "/pieces",
@@ -146,7 +146,7 @@ describe("POST /pieces (create)", () => {
 
   it("videoUrl が不正な URL の場合は 400 を返す", async () => {
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, videoUrl: "not-a-url" }),
         httpMethod: "POST",
         path: "/pieces",
@@ -161,7 +161,11 @@ describe("POST /pieces (create)", () => {
   it("videoUrl なしで正常に作成して 201 を返す", async () => {
     mockRepo.save.mockResolvedValueOnce();
     const result = await handler(
-      makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/pieces",
+      }),
       mockContext,
       mockCallback
     );
@@ -179,7 +183,7 @@ describe("POST /pieces (create)", () => {
   it("有効な videoUrl を指定して作成できる", async () => {
     mockRepo.save.mockResolvedValueOnce();
     const result = await handler(
-      makeEvent({
+      makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, videoUrl: "https://www.youtube.com/watch?v=abc123" }),
         httpMethod: "POST",
         path: "/pieces",
@@ -195,7 +199,11 @@ describe("POST /pieces (create)", () => {
   it("作成アイテムに UUID が付与される", async () => {
     mockRepo.save.mockResolvedValueOnce();
     const result = await handler(
-      makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/pieces",
+      }),
       mockContext,
       mockCallback
     );
@@ -210,7 +218,11 @@ describe("POST /pieces (create)", () => {
 
     mockRepo.save.mockResolvedValueOnce();
     const result = await handler(
-      makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/pieces",
+      }),
       mockContext,
       mockCallback
     );
@@ -224,7 +236,7 @@ describe("POST /pieces (create)", () => {
     it("全カテゴリを指定して作成できる", async () => {
       mockRepo.save.mockResolvedValueOnce();
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({
             ...validInput,
             genre: "交響曲",
@@ -249,7 +261,11 @@ describe("POST /pieces (create)", () => {
     it("カテゴリなしで作成できる（後方互換性）", async () => {
       mockRepo.save.mockResolvedValueOnce();
       const result = await handler(
-        makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/pieces",
+        }),
         mockContext,
         mockCallback
       );
@@ -264,7 +280,7 @@ describe("POST /pieces (create)", () => {
     it("一部のカテゴリのみ指定して作成できる", async () => {
       mockRepo.save.mockResolvedValueOnce();
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, genre: "協奏曲", era: "ロマン派" }),
           httpMethod: "POST",
           path: "/pieces",
@@ -282,7 +298,7 @@ describe("POST /pieces (create)", () => {
 
     it("genre に不正な値を指定すると 400 を返す", async () => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, genre: "不正な値" }),
           httpMethod: "POST",
           path: "/pieces",
@@ -295,7 +311,7 @@ describe("POST /pieces (create)", () => {
 
     it("era に不正な値を指定すると 400 を返す", async () => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, era: "不正な値" }),
           httpMethod: "POST",
           path: "/pieces",
@@ -308,7 +324,7 @@ describe("POST /pieces (create)", () => {
 
     it("formation に不正な値を指定すると 400 を返す", async () => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, formation: "不正な値" }),
           httpMethod: "POST",
           path: "/pieces",
@@ -321,7 +337,7 @@ describe("POST /pieces (create)", () => {
 
     it("region に不正な値を指定すると 400 を返す", async () => {
       const result = await handler(
-        makeEvent({
+        makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, region: "不正な値" }),
           httpMethod: "POST",
           path: "/pieces",
@@ -336,10 +352,70 @@ describe("POST /pieces (create)", () => {
   it("Repository エラー時に 500 を返す", async () => {
     mockRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
-      makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/pieces",
+      }),
       mockContext,
       mockCallback
     );
     expect(result?.statusCode).toBe(500);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、データを保存しない", async () => {
+      const result = await handler(
+        makeAuthEvent(TEST_USER_ID, {
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/pieces",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、データを保存しない", async () => {
+      const result = await handler(
+        makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("cognito:groups がカンマ区切り文字列で admin を含まない場合は 403", async () => {
+      const result = await handler(
+        makeAuthEvent(
+          TEST_USER_ID,
+          { body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" },
+          "viewer,editor"
+        ),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("cognito:groups がカンマ区切り文字列で admin を含む場合は 201", async () => {
+      mockRepo.save.mockResolvedValueOnce();
+      const result = await handler(
+        makeAuthEvent(
+          TEST_USER_ID,
+          { body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" },
+          "admin,editor"
+        ),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(201);
+    });
   });
 });

--- a/backend/src/handlers/pieces/create.ts
+++ b/backend/src/handlers/pieces/create.ts
@@ -1,3 +1,4 @@
+import { requireAdmin } from "../../utils/auth";
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { createPieceSchema } from "../../utils/schemas";
@@ -7,6 +8,7 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 const usecase = createPieceUsecase();
 
 export const handler = createHandler(async (event) => {
+  requireAdmin(event);
   const input = parseRequestBody(event.body as unknown, createPieceSchema);
   const piece = await usecase.create(input);
   return created(piece);

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -1,8 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import type { APIGatewayProxyEvent } from "aws-lambda";
 
 import { handler } from "./delete";
-import { TEST_USER_ID } from "../../test/fixtures";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent as makeBaseEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -18,38 +25,21 @@ vi.mock("../../repositories/piece-repository", () => ({
   }),
 }));
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
 type AuthMode = "admin" | "non-admin" | "none";
 
 function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxyEvent {
-  let requestContext: APIGatewayProxyEvent["requestContext"];
-  if (auth === "none") {
-    requestContext = {} as APIGatewayProxyEvent["requestContext"];
-  } else {
-    const claims: Record<string, unknown> = { sub: TEST_USER_ID };
-    if (auth === "admin") {
-      claims["cognito:groups"] = ["admin"];
-    }
-    requestContext = {
-      authorizer: { claims },
-    } as unknown as APIGatewayProxyEvent["requestContext"];
-  }
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
+  const overrides: Partial<APIGatewayProxyEvent> = {
     httpMethod: "DELETE",
-    isBase64Encoded: false,
     path: `/pieces/${id ?? ""}`,
     pathParameters: id === null ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext,
-    resource: "",
   };
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeBaseEvent(overrides);
 }
 
 describe("DELETE /pieces/{id} (delete)", () => {

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "./delete";
+import { TEST_USER_ID } from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -20,7 +21,21 @@ vi.mock("../../repositories/piece-repository", () => ({
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
 
-function makeEvent(id: string | null): APIGatewayProxyEvent {
+type AuthMode = "admin" | "non-admin" | "none";
+
+function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxyEvent {
+  let requestContext: APIGatewayProxyEvent["requestContext"];
+  if (auth === "none") {
+    requestContext = {} as APIGatewayProxyEvent["requestContext"];
+  } else {
+    const claims: Record<string, unknown> = { sub: TEST_USER_ID };
+    if (auth === "admin") {
+      claims["cognito:groups"] = ["admin"];
+    }
+    requestContext = {
+      authorizer: { claims },
+    } as unknown as APIGatewayProxyEvent["requestContext"];
+  }
   return {
     body: null,
     headers: {},
@@ -32,7 +47,7 @@ function makeEvent(id: string | null): APIGatewayProxyEvent {
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
-    requestContext: {} as APIGatewayProxyEvent["requestContext"],
+    requestContext,
     resource: "",
   };
 }
@@ -66,5 +81,24 @@ describe("DELETE /pieces/{id} (delete)", () => {
     mockRepo.remove.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、削除しない", async () => {
+      const result = await handler(
+        makeEvent("test-id-123", "non-admin"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、削除しない", async () => {
+      const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from "http-status-codes";
+import { requireAdmin } from "../../utils/auth";
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { createPieceUsecase } from "../../usecases/piece-usecase";
@@ -6,6 +7,7 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 const usecase = createPieceUsecase();
 
 export const handler = createHandler(async (event) => {
+  requireAdmin(event);
   const id = getIdParam(event);
   await usecase.delete(id);
   return { statusCode: StatusCodes.NO_CONTENT, body: "" };

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -4,6 +4,7 @@ import createError from "http-errors";
 import type { Piece } from "../../types";
 
 import { handler } from "./update";
+import { TEST_USER_ID } from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -22,7 +23,25 @@ vi.mock("../../repositories/piece-repository", () => ({
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
 
-function makeEvent(id?: string, body?: string | null): APIGatewayProxyEvent {
+type AuthMode = "admin" | "non-admin" | "none";
+
+function makeEvent(
+  id?: string,
+  body?: string | null,
+  auth: AuthMode = "admin"
+): APIGatewayProxyEvent {
+  let requestContext: APIGatewayProxyEvent["requestContext"];
+  if (auth === "none") {
+    requestContext = {} as APIGatewayProxyEvent["requestContext"];
+  } else {
+    const claims: Record<string, unknown> = { sub: TEST_USER_ID };
+    if (auth === "admin") {
+      claims["cognito:groups"] = ["admin"];
+    }
+    requestContext = {
+      authorizer: { claims },
+    } as unknown as APIGatewayProxyEvent["requestContext"];
+  }
   return {
     body: body === undefined ? null : body,
     headers: {},
@@ -34,7 +53,7 @@ function makeEvent(id?: string, body?: string | null): APIGatewayProxyEvent {
     queryStringParameters: null,
     multiValueQueryStringParameters: null,
     stageVariables: null,
-    requestContext: {} as APIGatewayProxyEvent["requestContext"],
+    requestContext,
     resource: "",
   };
 }
@@ -390,5 +409,30 @@ describe("PUT /pieces/{id} (update)", () => {
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("videoUrl must be a valid URL");
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、データを更新しない", async () => {
+      const result = await handler(
+        makeEvent("abc-123", JSON.stringify({ title: "新タイトル" }), "non-admin"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.findById).not.toHaveBeenCalled();
+      expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、データを更新しない", async () => {
+      const result = await handler(
+        makeEvent("abc-123", JSON.stringify({ title: "新タイトル" }), "none"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.findById).not.toHaveBeenCalled();
+      expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -1,10 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 import type { Piece } from "../../types";
 
 import { handler } from "./update";
-import { TEST_USER_ID } from "../../test/fixtures";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent as makeBaseEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
@@ -20,9 +27,6 @@ vi.mock("../../repositories/piece-repository", () => ({
   }),
 }));
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
 type AuthMode = "admin" | "non-admin" | "none";
 
 function makeEvent(
@@ -30,32 +34,19 @@ function makeEvent(
   body?: string | null,
   auth: AuthMode = "admin"
 ): APIGatewayProxyEvent {
-  let requestContext: APIGatewayProxyEvent["requestContext"];
-  if (auth === "none") {
-    requestContext = {} as APIGatewayProxyEvent["requestContext"];
-  } else {
-    const claims: Record<string, unknown> = { sub: TEST_USER_ID };
-    if (auth === "admin") {
-      claims["cognito:groups"] = ["admin"];
-    }
-    requestContext = {
-      authorizer: { claims },
-    } as unknown as APIGatewayProxyEvent["requestContext"];
-  }
-  return {
+  const overrides: Partial<APIGatewayProxyEvent> = {
     body: body === undefined ? null : body,
-    headers: {},
-    multiValueHeaders: {},
     httpMethod: "PUT",
-    isBase64Encoded: false,
     path: `/pieces/${id ?? ""}`,
     pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext,
-    resource: "",
   };
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeBaseEvent(overrides);
 }
 
 const existingPiece: Piece = {

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -1,3 +1,4 @@
+import { requireAdmin } from "../../utils/auth";
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { updatePieceSchema } from "../../utils/schemas";
@@ -8,6 +9,7 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 const usecase = createPieceUsecase();
 
 export const handler = createHandler(async (event) => {
+  requireAdmin(event);
   const id = getIdParam(event);
   const input = parseRequestBody(event.body as unknown, updatePieceSchema);
   const piece = await usecase.update(id, input);

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -45,15 +45,25 @@ export const makeEvent = (overrides?: Partial<APIGatewayProxyEvent>): APIGateway
 
 export const makeAuthEvent = (
   userId: string,
+  overrides?: Partial<APIGatewayProxyEvent>,
+  groups?: string[] | string
+): APIGatewayProxyEvent => {
+  const claims: Record<string, unknown> = { sub: userId };
+  if (groups !== undefined) {
+    claims["cognito:groups"] = groups;
+  }
+  return {
+    ...makeEvent(overrides),
+    requestContext: {
+      authorizer: { claims },
+    } as unknown as APIGatewayProxyEvent["requestContext"],
+  };
+};
+
+export const makeAdminEvent = (
+  userId: string,
   overrides?: Partial<APIGatewayProxyEvent>
-): APIGatewayProxyEvent => ({
-  ...makeEvent(overrides),
-  requestContext: {
-    authorizer: {
-      claims: { sub: userId },
-    },
-  } as unknown as APIGatewayProxyEvent["requestContext"],
-});
+): APIGatewayProxyEvent => makeAuthEvent(userId, overrides, ["admin"]);
 
 export const mockContext: Context = {} as Context;
 export const mockCallback = { signal: new AbortController().signal };

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
-import { getUserId } from "./auth";
+import { getUserId, getUserGroups, isAdmin, requireAdmin } from "./auth";
 
 const makeEvent = (authorizer: unknown): APIGatewayProxyEvent =>
   ({
@@ -27,5 +27,97 @@ describe("getUserId", () => {
   it("有効な sub がある場合はその値を返す", () => {
     const result = getUserId(makeEvent({ claims: { sub: "user-abc-123" } }));
     expect(result).toBe("user-abc-123");
+  });
+});
+
+describe("getUserGroups", () => {
+  it("authorizer が null の場合は空配列を返す", () => {
+    expect(getUserGroups(makeEvent(null))).toEqual([]);
+  });
+
+  it("authorizer が undefined の場合は空配列を返す", () => {
+    expect(getUserGroups(makeEvent(undefined))).toEqual([]);
+  });
+
+  it("cognito:groups が未定義の場合は空配列を返す", () => {
+    expect(getUserGroups(makeEvent({ claims: { sub: "u" } }))).toEqual([]);
+  });
+
+  it("cognito:groups が空文字の場合は空配列を返す", () => {
+    expect(getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": "" } }))).toEqual([]);
+  });
+
+  it("cognito:groups が配列形式の場合はそのまま返す", () => {
+    expect(
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", "editor"] } }))
+    ).toEqual(["admin", "editor"]);
+  });
+
+  it("cognito:groups が配列の場合、文字列以外の要素は除外する", () => {
+    expect(
+      getUserGroups(
+        makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", 42, null, "editor"] } })
+      )
+    ).toEqual(["admin", "editor"]);
+  });
+
+  it("cognito:groups がカンマ区切り文字列の場合は配列に分割する", () => {
+    expect(
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": "admin,editor" } }))
+    ).toEqual(["admin", "editor"]);
+  });
+
+  it("cognito:groups の文字列分割時に前後の空白をトリムする", () => {
+    expect(
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": " admin , editor " } }))
+    ).toEqual(["admin", "editor"]);
+  });
+});
+
+describe("isAdmin", () => {
+  it("admin が含まれている場合は true を返す", () => {
+    expect(isAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin"] } }))).toBe(true);
+  });
+
+  it("admin がカンマ区切り文字列に含まれる場合は true を返す", () => {
+    expect(isAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": "editor,admin" } }))).toBe(
+      true
+    );
+  });
+
+  it("admin が含まれていない場合は false を返す", () => {
+    expect(isAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["editor"] } }))).toBe(false);
+  });
+
+  it("cognito:groups が未設定の場合は false を返す", () => {
+    expect(isAdmin(makeEvent({ claims: { sub: "u" } }))).toBe(false);
+  });
+
+  it("authorizer が null の場合は false を返す", () => {
+    expect(isAdmin(makeEvent(null))).toBe(false);
+  });
+});
+
+describe("requireAdmin", () => {
+  it("admin グループに所属している場合は throw しない", () => {
+    expect(() =>
+      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin"] } }))
+    ).not.toThrow();
+  });
+
+  it("admin グループに所属していない場合は 403 を投げる", () => {
+    expect(() =>
+      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["editor"] } }))
+    ).toThrow("Admin privilege required");
+  });
+
+  it("cognito:groups が未設定の場合は 403 を投げる", () => {
+    expect(() => requireAdmin(makeEvent({ claims: { sub: "u" } }))).toThrow(
+      "Admin privilege required"
+    );
+  });
+
+  it("authorizer が null の場合は 403 を投げる", () => {
+    expect(() => requireAdmin(makeEvent(null))).toThrow("Admin privilege required");
   });
 });

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -4,15 +4,44 @@ import type { APIGatewayProxyEvent } from "aws-lambda";
 type CognitoAuthorizerContext = {
   claims: {
     sub: string;
-    [key: string]: string;
+    [key: string]: unknown;
   };
 };
 
+export const ADMIN_GROUP_NAME = "admin";
+
+const getAuthorizerContext = (event: APIGatewayProxyEvent): CognitoAuthorizerContext | null =>
+  event.requestContext.authorizer as unknown as CognitoAuthorizerContext | null;
+
 export const getUserId = (event: APIGatewayProxyEvent): string => {
-  const authorizer = event.requestContext.authorizer as unknown as CognitoAuthorizerContext | null;
+  const authorizer = getAuthorizerContext(event);
   const userId = authorizer?.claims?.sub;
-  if (userId === undefined || userId === "") {
+  if (typeof userId !== "string" || userId === "") {
     throw new createError.Unauthorized("User not authenticated");
   }
   return userId;
+};
+
+// Cognito の cognito:groups クレームは所属グループによって配列・カンマ区切り文字列のいずれかで渡る
+export const getUserGroups = (event: APIGatewayProxyEvent): string[] => {
+  const raw = getAuthorizerContext(event)?.claims?.["cognito:groups"];
+  if (Array.isArray(raw)) {
+    return raw.filter((v): v is string => typeof v === "string");
+  }
+  if (typeof raw === "string" && raw !== "") {
+    return raw
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+  }
+  return [];
+};
+
+export const isAdmin = (event: APIGatewayProxyEvent): boolean =>
+  getUserGroups(event).includes(ADMIN_GROUP_NAME);
+
+export const requireAdmin = (event: APIGatewayProxyEvent): void => {
+  if (!isAdmin(event)) {
+    throw new createError.Forbidden("Admin privilege required");
+  }
 };

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -552,18 +552,20 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     listeningLogResource.addMethod("DELETE", integ(listeningLogsDelete), withAuth);
 
     // 認証不要エンドポイント用オプション
-    const withoutAuth = { authorizationType: apigateway.AuthorizationType.NONE }; // NOSONAR: /pieces/* と /auth/* は意図的に公開エンドポイントとして設計
+    const withoutAuth = { authorizationType: apigateway.AuthorizationType.NONE }; // NOSONAR: /pieces の参照系と /auth/* は意図的に公開エンドポイントとして設計
 
     // /pieces
+    // 参照系（GET）は公開。書き込み系（POST/PUT/DELETE）は withAuth でトークン検証し、
+    // ハンドラ側で admin グループ判定を実施する
     const piecesResource = api.root.addResource("pieces");
     piecesResource.addMethod("GET", integ(listPieces), withoutAuth);
-    piecesResource.addMethod("POST", integ(createPiece), withoutAuth);
+    piecesResource.addMethod("POST", integ(createPiece), withAuth);
 
     // /pieces/{id}
     const pieceResource = piecesResource.addResource("{id}");
     pieceResource.addMethod("GET", integ(getPiece), withoutAuth);
-    pieceResource.addMethod("PUT", integ(updatePiece), withoutAuth);
-    pieceResource.addMethod("DELETE", integ(deletePiece), withoutAuth);
+    pieceResource.addMethod("PUT", integ(updatePiece), withAuth);
+    pieceResource.addMethod("DELETE", integ(deletePiece), withAuth);
 
     // /auth
     const authResource = api.root.addResource("auth");
@@ -644,8 +646,13 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       ["GET", "PUT", "DELETE", "OPTIONS"],
       ["Content-Type", "Authorization"]
     );
-    this.addCors(piecesResource, ["GET", "POST", "OPTIONS"]);
-    this.addCors(pieceResource, ["GET", "PUT", "DELETE", "OPTIONS"]);
+    // 書き込み系（POST/PUT/DELETE）は Authorization ヘッダーが必要
+    this.addCors(piecesResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
+    this.addCors(
+      pieceResource,
+      ["GET", "PUT", "DELETE", "OPTIONS"],
+      ["Content-Type", "Authorization"]
+    );
     this.addCors(authRegisterResource, ["POST", "OPTIONS"]);
     this.addCors(authLoginResource, ["POST", "OPTIONS"]);
     this.addCors(authVerifyEmailResource, ["POST", "OPTIONS"]);

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -231,8 +231,8 @@ interface ConcertLog {
 
 - **ベースURL**: `https://{api-gateway-url}/prod`
 - **認証**: AWS Cognito User Pool (Bearer Token)
-  - 認証が必要なエンドポイント: `/listening-logs/*`、`/concert-logs/*`（読み取り・書き込み）
-  - 公開エンドポイント: `/auth/*`、`/pieces/*`
+  - 認証が必要なエンドポイント: `/listening-logs/*`、`/concert-logs/*`（読み取り・書き込み）、`/pieces` の書き込み系（`POST` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`）。書き込み系はさらに `admin` グループ必須
+  - 公開エンドポイント: `/auth/*`、`/pieces` の参照系（`GET /pieces` / `GET /pieces/{id}`）
 - **CORS**: CloudFront URL のみ許可（プリフライト・GatewayResponse の両方で設定）
 
 ### 4.2 認証API
@@ -658,7 +658,7 @@ Authorization: Bearer {accessToken}
 
 ### 4.5 楽曲マスタAPI
 
-> **認証不要**: 楽曲マスタは全ユーザ共通のマスタデータのため、公開エンドポイント。
+> **認可ルール**: 参照系（`GET /pieces` / `GET /pieces/{id}`）は認証不要で公開。書き込み系（`POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`）は `admin` グループに所属する認証済みユーザーのみ実行可能。
 
 #### `GET /pieces`
 
@@ -713,9 +713,24 @@ GET /pieces?limit=50&cursor={opaque}
 - 形式（文字レベル）は Zod の `z.base64url()` で検証し、デコード後の JSON 不正・未知バージョンは `decodeCursor` で検出して 400 を返す。
 - 改ざん検出（HMAC）は行わない。楽曲マスタは全ユーザ共通のためテナント境界を越えるリスクが無いため。
 
-#### `POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}` / `GET /pieces/{id}`
+#### `GET /pieces/{id}`
 
-従来どおり（Piece オブジェクトの単件操作）。本仕様書ではデータ構造（3.2 節）とバリデーション（本節）を参照。
+従来どおり（Piece オブジェクトの単件取得）。認証不要。データ構造は 3.2 節を参照。
+
+#### `POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`
+
+楽曲マスタの単件作成・更新・削除（Piece オブジェクト）。データ構造とバリデーションは 3.2 節と本節 4.7 を参照。
+
+**認可ルール**
+
+- `Authorization: Bearer {idToken}` ヘッダーが必須（API Gateway Cognito Authorizer で検証）
+- ID Token の `cognito:groups` クレームに `admin` が含まれていること
+- 認可は Cognito Authorizer（トークン検証）と Lambda ハンドラ（グループ判定）の二段構えで強制する
+
+**エラーレスポンス**
+
+- 認証ヘッダーなし・無効/期限切れトークン: `401 Unauthorized`（API Gateway Authorizer が返却）
+- 認証済みだが `admin` 非所属: `403 Forbidden` + `{ "message": "Admin privilege required" }`
 
 ### 4.6 エラーレスポンス一覧
 
@@ -727,11 +742,13 @@ GET /pieces?limit=50&cursor={opaque}
 }
 ```
 
-| ステータスコード            | 意味               | 発生条件                                       |
-| --------------------------- | ------------------ | ---------------------------------------------- |
-| `400 Bad Request`           | リクエスト不正     | リクエストボディが空、またはパスパラメータ不正 |
-| `404 Not Found`             | リソース未存在     | 指定IDの視聴ログが存在しない                   |
-| `500 Internal Server Error` | サーバー内部エラー | DynamoDB接続エラーなど予期しないエラー         |
+| ステータスコード            | 意味               | 発生条件                                                                               |
+| --------------------------- | ------------------ | -------------------------------------------------------------------------------------- |
+| `400 Bad Request`           | リクエスト不正     | リクエストボディが空、またはパスパラメータ不正                                         |
+| `401 Unauthorized`          | 未認証             | 認証必須エンドポイントで認証ヘッダー・トークンが不正（API Gateway Authorizer）         |
+| `403 Forbidden`             | 権限不足           | 認証済みだが権限不足（例: 楽曲マスタ書き込み API への `admin` 非所属ユーザーアクセス） |
+| `404 Not Found`             | リソース未存在     | 指定IDの視聴ログが存在しない                                                           |
+| `500 Internal Server Error` | サーバー内部エラー | DynamoDB接続エラーなど予期しないエラー                                                 |
 
 ### 4.7 データバリデーションルール
 
@@ -831,6 +848,10 @@ GET /pieces?limit=50&cursor={opaque}
 - **名前**: `classical-music-lake`
 - **ステージ**: `prod`
 - **CORS**: カスタムドメイン URL を許可（プリフライト・GatewayResponse の両方で設定）
+- **Cognito Authorizer 適用範囲**:
+  - 認証必須: `/listening-logs/*`、`/concert-logs/*`、`/pieces` の書き込み系（`POST` / `PUT` / `DELETE`）
+  - 認証不要: `/pieces` の参照系（`GET`）と `/auth/*`
+  - 楽曲マスタの書き込み系はさらに Lambda ハンドラ内で `admin` グループ判定を行い、非管理者には `403 Forbidden` を返す
 
 #### S3
 

--- a/docs/features/015-admin-role/checklist.md
+++ b/docs/features/015-admin-role/checklist.md
@@ -7,7 +7,7 @@
 | #      | Work                                                                      | 設計 | 設計レビュー | 実装 | 受け入れ |
 | ------ | ------------------------------------------------------------------------- | ---- | ------------ | ---- | -------- |
 | 015-01 | [admin-group-provisioning](./015-01-admin-group-provisioning/work.md)     | ✅   | ✅           | ✅   | ✅       |
-| 015-02 | [piece-write-admin-only-api](./015-02-piece-write-admin-only-api/work.md) | ✅   | ☐            | ☐    | ☐        |
+| 015-02 | [piece-write-admin-only-api](./015-02-piece-write-admin-only-api/work.md) | ✅   | ☐            | ✅   | 🛠       |
 | 015-03 | [admin-ui-gating](./015-03-admin-ui-gating/work.md)                       | ☐    | ☐            | ☐    | ☐        |
 
 ## 凡例


### PR DESCRIPTION
## Summary

ワーク 015-02「楽曲マスタ書き込み API の管理者限定化」の実装。

- `backend/src/utils/auth.ts` に `ADMIN_GROUP_NAME` / `getUserGroups` / `isAdmin` / `requireAdmin` を追加。`cognito:groups` クレームの配列 / カンマ区切り文字列の両形式に対応
- `POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}` の各ハンドラ先頭で `requireAdmin(event)` を呼び出し、非管理者には `403 Forbidden` + `{ "message": "Admin privilege required" }` を返却
- CDK の該当 3 メソッドを `withoutAuth` → `withAuth`（Cognito Authorizer）に切替。`/pieces` / `/pieces/{id}` の CORS `allowHeaders` に `Authorization` を追加
- 参照系（`GET /pieces` / `GET /pieces/{id}`）は認証不要のまま据え置き
- `docs/SPEC.md` の 4.1 / 4.5 / 4.6 / 5.1 を更新し、認可仕様・401 / 403 レスポンスを反映
- `docs/features/015-admin-role/checklist.md` を更新

## Test plan

- [x] `pnpm run test:backend` — 442 テストがパス
- [x] `pnpm run test:frontend` — 561 テストがパス（pre-push hook で確認済）
- [x] `pnpm run lint` / `pnpm run format:check` がパス
- [x] `pnpm -C cdk run build` がパス
- [ ] `admin` グループのトークンで `POST`/`PUT`/`DELETE /pieces` が 2xx を返すこと（デプロイ後に検証）
- [ ] 一般ユーザートークンで 403 が返り、データが変更されていないこと（デプロイ後に検証）
- [ ] 未認証で書き込み API を叩くと 401（Authorizer）が返ること（デプロイ後に検証）
- [ ] `GET /pieces` / `GET /pieces/{id}` が従来どおり未認証で取得できること（デプロイ後に検証）

## 設計ドキュメント

`docs/features/015-admin-role/015-02-piece-write-admin-only-api/design.md`

https://claude.ai/code/session_01UH4jga32h6K5WvedCkZ9tF