### PR TITLE
refactor(backend): 削除ハンドラーで noContent ヘルパーを共通利用

### DIFF
--- a/backend/src/handlers/concert-logs/delete.ts
+++ b/backend/src/handlers/concert-logs/delete.ts
@@ -1,8 +1,7 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
+import { noContent } from "../../utils/response";
 import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
@@ -11,5 +10,5 @@ export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const userId = getUserId(event);
   await usecase.delete(id, userId);
-  return { statusCode: StatusCodes.NO_CONTENT, body: "" };
+  return noContent();
 });

--- a/backend/src/handlers/listening-logs/delete.ts
+++ b/backend/src/handlers/listening-logs/delete.ts
@@ -1,8 +1,7 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
+import { noContent } from "../../utils/response";
 import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
@@ -11,5 +10,5 @@ export const handler = createHandler(async (event) => {
   const id = getIdParam(event);
   const userId = getUserId(event);
   await usecase.delete(id, userId);
-  return { statusCode: StatusCodes.NO_CONTENT, body: "" };
+  return noContent();
 });

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,7 +1,7 @@
-import { StatusCodes } from "http-status-codes";
 import { requireAdmin } from "../../utils/auth";
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
+import { noContent } from "../../utils/response";
 import { createPieceUsecase } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
@@ -10,5 +10,5 @@ export const handler = createHandler(async (event) => {
   requireAdmin(event);
   const id = getIdParam(event);
   await usecase.delete(id);
-  return { statusCode: StatusCodes.NO_CONTENT, body: "" };
+  return noContent();
 });

--- a/backend/src/utils/response.ts
+++ b/backend/src/utils/response.ts
@@ -10,6 +10,11 @@ export const created = (body: unknown) => ({
   body,
 });
 
+export const noContent = () => ({
+  statusCode: StatusCodes.NO_CONTENT,
+  body: "",
+});
+
 export const badRequest = (error: string, message: string) => ({
   statusCode: StatusCodes.BAD_REQUEST,
   body: { error, message },


### PR DESCRIPTION
3 つの DELETE ハンドラーで直接記述していた 204 応答を utils/response.ts
に追加した noContent() に集約し、レスポンス生成の一貫性を高める