### PR TITLE
Improve accessibility and semantic HTML in PieceListInfinite

### DIFF
--- a/app/components/organisms/PieceListInfinite.vue
+++ b/app/components/organisms/PieceListInfinite.vue
@@ -61,40 +61,47 @@ watch(sentinel, (el, _prev, onCleanup) => {
 <template>
   <div>
     <PieceList :pieces="props.pieces" :error="props.error" @delete="emit('delete', $event)" />
-    <div class="list-status" role="status" aria-live="polite">
-      <p v-if="props.pending" class="status-text">読み込み中…</p>
-      <div v-else-if="props.error" class="status-error">
-        <p>取得に失敗しました。</p>
+    <output class="list-status" aria-live="polite">
+      <span v-if="props.pending" class="status-text">読み込み中…</span>
+      <span v-else-if="props.error" class="status-error">
+        <span class="status-error-message">取得に失敗しました。</span>
         <button type="button" class="btn-retry" @click="emit('retry')">再試行</button>
-      </div>
-      <p v-else-if="!props.hasMore && props.pieces.length > 0" class="status-text">
+      </span>
+      <span v-else-if="!props.hasMore && props.pieces.length > 0" class="status-text">
         これ以上ありません
-      </p>
-      <div
+      </span>
+      <span
         v-if="props.hasMore && !props.error"
         ref="sentinel"
         class="sentinel"
         aria-hidden="true"
-      ></div>
-    </div>
+      ></span>
+    </output>
   </div>
 </template>
 
 <style scoped>
 .list-status {
+  display: block;
   margin-top: 1rem;
   text-align: center;
 }
 
 .status-text {
+  display: block;
   color: #666;
   font-size: 0.9rem;
   padding: 1rem 0;
 }
 
 .status-error {
+  display: block;
   padding: 1rem 0;
   color: #c33;
+}
+
+.status-error-message {
+  display: block;
 }
 
 .btn-retry {
@@ -112,6 +119,7 @@ watch(sentinel, (el, _prev, onCleanup) => {
 }
 
 .sentinel {
+  display: block;
   height: 1px;
 }
 </style>

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -2,7 +2,8 @@ import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import createError from "http-errors";
 
-import { dynamo, scanAllItems, scanPage, TABLE_PIECES } from "../utils/dynamodb";
+// `scanAllItems` は `findAll`（deprecated・互換用）のみで使用する。`usePiecesAll` 廃止後に一括削除する。
+import { dynamo, scanAllItems, scanPage, TABLE_PIECES } from "../utils/dynamodb"; // NOSONAR: typescript:S1874
 import type { Piece } from "../types";
 import type { PieceRepository } from "../domain/piece";
 
@@ -16,7 +17,7 @@ export class DynamoDBPieceRepository implements PieceRepository {
    * @deprecated {@link findPage} を使うこと。`usePiecesAll` 廃止後に削除予定。
    */
   async findAll(): Promise<Piece[]> {
-    return scanAllItems<Piece>(TABLE_PIECES);
+    return scanAllItems<Piece>(TABLE_PIECES); // NOSONAR: typescript:S1874 — 互換維持のため deprecated API を意図的に使用
   }
 
   async findPage(options: {


### PR DESCRIPTION
## 概要

PieceListInfinite コンポーネントのアクセシビリティを向上させ、セマンティック HTML を改善しました。また、バックエンド側で deprecated API の使用に関する SonarQube 警告を抑制するコメントを追加しました。

## 変更の種類

- [x] リファクタリング

## 変更内容

### フロントエンド（PieceListInfinite.vue）

**セマンティック HTML の改善:**
- ステータスメッセージを含むコンテナを `<div>` から `<output>` 要素に変更
  - `<output>` は計算結果やステータス情報を表示するのに適切なセマンティック要素
  - `role="status"` を削除（`<output>` は暗黙的にステータス情報を表す）

**アクセシビリティの向上:**
- `<p>` タグを `<span>` に変更し、`display: block` CSS を追加
  - より細粒度なセマンティック制御が可能に
- エラーメッセージを専用の `.status-error-message` クラスを持つ `<span>` でラップ
  - スタイリングの柔軟性向上

**CSS の改善:**
- 各要素に `display: block` を明示的に指定
  - レイアウト意図を明確化

### バックエンド（piece-repository.ts）

**SonarQube 警告の抑制:**
- `scanAllItems` の deprecated 使用に対して `// NOSONAR: typescript:S1874` コメントを追加
- deprecated API の使用理由をコメントで明記
  - `usePiecesAll` 廃止後に一括削除予定であることを記載

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] 実装を含む変更の場合、`docs/SPEC.md` を更新した（該当なし）

https://claude.ai/code/session_013zujjiL5hDzbc7TXopNmQQ