### PR TITLE
feat(composer): 作曲家マスタの追加

### DIFF
--- a/app/components/molecules/ComposerCategoryList.stories.ts
+++ b/app/components/molecules/ComposerCategoryList.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerCategoryList from "./ComposerCategoryList.vue";
+
+const meta: Meta<typeof ComposerCategoryList> = {
+  title: "Molecules/ComposerCategoryList",
+  component: ComposerCategoryList,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerCategoryList>;
+
+export const AllCategories: Story = {
+  args: {
+    composer: {
+      era: "ロマン派",
+      region: "ドイツ・オーストリア",
+    },
+  },
+};
+
+export const PartialCategories: Story = {
+  args: {
+    composer: {
+      era: "バロック",
+    },
+  },
+};
+
+export const NoCategories: Story = {
+  args: {
+    composer: {},
+  },
+};

--- a/app/components/molecules/ComposerCategoryList.test.ts
+++ b/app/components/molecules/ComposerCategoryList.test.ts
@@ -1,0 +1,31 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerCategoryList from "./ComposerCategoryList.vue";
+
+describe("ComposerCategoryList", () => {
+  describe("表示", () => {
+    it("era と region の両方が指定されているとバッジを 2 つ表示する", async () => {
+      const wrapper = await mountSuspended(ComposerCategoryList, {
+        props: {
+          composer: { era: "ロマン派", region: "ドイツ・オーストリア" },
+        },
+      });
+      expect(wrapper.findAll(".category-badge")).toHaveLength(2);
+    });
+
+    it("era のみのときはバッジを 1 つ表示する", async () => {
+      const wrapper = await mountSuspended(ComposerCategoryList, {
+        props: {
+          composer: { era: "バロック" },
+        },
+      });
+      expect(wrapper.findAll(".category-badge")).toHaveLength(1);
+    });
+
+    it("カテゴリがなにも指定されていないとリスト自体を描画しない", async () => {
+      const wrapper = await mountSuspended(ComposerCategoryList, {
+        props: { composer: {} },
+      });
+      expect(wrapper.find(".composer-category-list").exists()).toBe(false);
+    });
+  });
+});

--- a/app/components/molecules/ComposerCategoryList.vue
+++ b/app/components/molecules/ComposerCategoryList.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+type Kind = "era" | "region";
+
+const props = defineProps<{
+  composer: Pick<Composer, "era" | "region">;
+}>();
+
+const categories = computed(() =>
+  [
+    { kind: "era" as Kind, label: "時代", value: props.composer.era },
+    { kind: "region" as Kind, label: "地域", value: props.composer.region },
+  ].filter((c): c is { kind: Kind; label: string; value: string } => c.value !== undefined)
+);
+</script>
+
+<template>
+  <div v-if="categories.length" class="composer-category-list">
+    <CategoryBadge
+      v-for="cat in categories"
+      :key="cat.kind"
+      :kind="cat.kind"
+      :label="cat.label"
+      :value="cat.value"
+    />
+  </div>
+</template>
+
+<style scoped>
+.composer-category-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+}
+</style>

--- a/app/components/molecules/ComposerItem.stories.ts
+++ b/app/components/molecules/ComposerItem.stories.ts
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerItem from "./ComposerItem.vue";
+
+const meta: Meta<typeof ComposerItem> = {
+  title: "Molecules/ComposerItem",
+  component: ComposerItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerItem>;
+
+const baseComposer = {
+  id: "1",
+  name: "ベートーヴェン",
+  createdAt: "2024-06-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+};
+
+export const Default: Story = {
+  args: { composer: baseComposer },
+};
+
+export const WithCategories: Story = {
+  args: {
+    composer: {
+      ...baseComposer,
+      era: "古典派",
+      region: "ドイツ・オーストリア",
+    },
+  },
+};

--- a/app/components/molecules/ComposerItem.test.ts
+++ b/app/components/molecules/ComposerItem.test.ts
@@ -1,0 +1,97 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerItem from "./ComposerItem.vue";
+import ButtonSecondary from "../atoms/ButtonSecondary.vue";
+import ButtonDanger from "../atoms/ButtonDanger.vue";
+import type { Composer } from "~/types";
+
+const sampleComposer: Composer = {
+  id: "1",
+  name: "ベートーヴェン",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const sampleComposerWithCategories: Composer = {
+  ...sampleComposer,
+  era: "古典派",
+  region: "ドイツ・オーストリア",
+};
+
+const globalComponents = { global: { components: { ButtonSecondary, ButtonDanger } } };
+
+describe("ComposerItem", () => {
+  describe("表示", () => {
+    it("作曲家名が表示される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+      });
+      expect(wrapper.text()).toContain("ベートーヴェン");
+    });
+
+    it("composer-item クラスが存在する", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+      });
+      expect(wrapper.find(".composer-item").exists()).toBe(true);
+    });
+
+    it("composer-name クラスに作曲家名が含まれる", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+      });
+      expect(wrapper.find(".composer-name").text()).toBe("ベートーヴェン");
+    });
+  });
+
+  describe("イベント", () => {
+    it("編集ボタンクリックで edit イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+        ...globalComponents,
+      });
+      await wrapper.find(".btn-secondary").trigger("click");
+      expect(wrapper.emitted("edit")).toBeDefined();
+    });
+
+    it("削除ボタンクリックで delete イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+        ...globalComponents,
+      });
+      await wrapper.find(".btn-danger").trigger("click");
+      expect(wrapper.emitted("delete")).toBeDefined();
+    });
+
+    it("詳細ボタンクリックで detail イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+        ...globalComponents,
+      });
+      await wrapper.find(".btn-detail").trigger("click");
+      expect(wrapper.emitted("detail")).toBeDefined();
+    });
+  });
+
+  describe("カテゴリ表示", () => {
+    it("era が設定されている場合、時代バッジが表示される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposerWithCategories },
+      });
+      expect(wrapper.find(".kind-era").text()).toBe("古典派");
+    });
+
+    it("region が設定されている場合、地域バッジが表示される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposerWithCategories },
+      });
+      expect(wrapper.find(".kind-region").text()).toBe("ドイツ・オーストリア");
+    });
+
+    it("全カテゴリが未設定の場合、バッジが一切表示されない", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+      });
+      expect(wrapper.find(".composer-category-list").exists()).toBe(false);
+    });
+  });
+});

--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -1,0 +1,95 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+defineProps<{
+  composer: Composer;
+}>();
+
+const emit = defineEmits<{
+  edit: [];
+  delete: [];
+  detail: [];
+}>();
+</script>
+
+<template>
+  <div class="composer-item">
+    <div class="composer-main">
+      <div class="composer-name">{{ composer.name }}</div>
+      <div class="composer-category-wrapper">
+        <ComposerCategoryList :composer="composer" />
+      </div>
+    </div>
+    <div class="composer-actions">
+      <button type="button" class="btn-detail" @click="emit('detail')">詳細</button>
+      <ButtonSecondary label="編集" @click="emit('edit')" />
+      <ButtonDanger label="削除" @click="emit('delete')" />
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.composer-item {
+  background: #fff;
+  border: 1px solid #e0d8cc;
+  border-radius: 10px;
+  padding: 1.2rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.composer-main {
+  flex: 1;
+  min-width: 0;
+}
+
+.composer-name {
+  font-size: 1.1rem;
+  font-weight: bold;
+  margin-bottom: 0.3rem;
+  color: #1e2d5a;
+}
+
+.composer-category-wrapper {
+  margin-top: 0.4rem;
+}
+
+.composer-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-shrink: 0;
+}
+
+.btn-detail {
+  background: #f0ebe0;
+  color: #1e2d5a;
+  padding: 0.6rem 1.2rem;
+  border: 1px solid #c2a878;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-detail:hover {
+  background: #e0d8cc;
+}
+
+@media (max-width: 600px) {
+  .composer-item {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .composer-main {
+    width: 100%;
+  }
+
+  .composer-actions {
+    width: 100%;
+    justify-content: flex-end;
+  }
+}
+</style>

--- a/app/components/organisms/ComposerForm.stories.ts
+++ b/app/components/organisms/ComposerForm.stories.ts
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerForm from "./ComposerForm.vue";
+
+const meta: Meta<typeof ComposerForm> = {
+  title: "Organisms/ComposerForm",
+  component: ComposerForm,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerForm>;
+
+export const Default: Story = {};
+
+export const WithInitialValues: Story = {
+  args: {
+    initialValues: {
+      name: "ベートーヴェン",
+      era: "古典派",
+      region: "ドイツ・オーストリア",
+    },
+  },
+};
+
+export const CustomSubmitLabel: Story = {
+  args: {
+    submitLabel: "登録する",
+  },
+};

--- a/app/components/organisms/ComposerForm.test.ts
+++ b/app/components/organisms/ComposerForm.test.ts
@@ -1,0 +1,84 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerForm from "./ComposerForm.vue";
+import ButtonPrimary from "../atoms/ButtonPrimary.vue";
+
+describe("ComposerForm", () => {
+  describe("デフォルト値でのレンダリング", () => {
+    it("フォームが表示される", async () => {
+      const wrapper = await mountSuspended(ComposerForm);
+      expect(wrapper.find("form.composer-form").exists()).toBe(true);
+    });
+
+    it("作曲家名の入力フィールドが空である", async () => {
+      const wrapper = await mountSuspended(ComposerForm);
+      const nameInput = wrapper.find("#name");
+      expect((nameInput.element as HTMLInputElement).value).toBe("");
+    });
+  });
+
+  describe("initialValues での初期化", () => {
+    it("初期値が入力フィールドに反映される", async () => {
+      const wrapper = await mountSuspended(ComposerForm, {
+        props: {
+          initialValues: {
+            name: "ベートーヴェン",
+            era: "古典派",
+            region: "ドイツ・オーストリア",
+          },
+        },
+      });
+
+      const nameInput = wrapper.find("#name");
+      expect((nameInput.element as HTMLInputElement).value).toBe("ベートーヴェン");
+      expect((wrapper.find("#era").element as HTMLSelectElement).value).toBe("古典派");
+      expect((wrapper.find("#region").element as HTMLSelectElement).value).toBe(
+        "ドイツ・オーストリア"
+      );
+    });
+  });
+
+  describe("submitLabel prop", () => {
+    it("カスタムラベルが反映される", async () => {
+      const wrapper = await mountSuspended(ComposerForm, {
+        props: { submitLabel: "登録する" },
+        global: { components: { ButtonPrimary } },
+      });
+      expect(wrapper.find("button[type='submit']").text()).toBe("登録する");
+    });
+  });
+
+  describe("フォーム送信", () => {
+    it("フォーム送信時に submit イベントが emit される", async () => {
+      const wrapper = await mountSuspended(ComposerForm, {
+        props: { initialValues: { name: "ベートーヴェン" } },
+      });
+      await wrapper.find("form").trigger("submit.prevent");
+      expect(wrapper.emitted("submit")).toBeDefined();
+    });
+
+    it("submit イベントにフォームデータが含まれる", async () => {
+      const wrapper = await mountSuspended(ComposerForm, {
+        props: {
+          initialValues: { name: "ベートーヴェン", era: "古典派" },
+        },
+      });
+      await wrapper.find("form").trigger("submit.prevent");
+      const emitted = wrapper.emitted("submit");
+      expect(emitted).toBeDefined();
+      const emittedData = emitted![0][0] as Record<string, unknown>;
+      expect(emittedData.name).toBe("ベートーヴェン");
+      expect(emittedData.era).toBe("古典派");
+    });
+
+    it("未選択のカテゴリは undefined として送信される", async () => {
+      const wrapper = await mountSuspended(ComposerForm, {
+        props: { initialValues: { name: "モーツァルト" } },
+      });
+      await wrapper.find("form").trigger("submit.prevent");
+      const emitted = wrapper.emitted("submit");
+      const emittedData = emitted![0][0] as Record<string, unknown>;
+      expect(emittedData.era).toBeUndefined();
+      expect(emittedData.region).toBeUndefined();
+    });
+  });
+});

--- a/app/components/organisms/ComposerForm.vue
+++ b/app/components/organisms/ComposerForm.vue
@@ -1,13 +1,10 @@
 <script setup lang="ts">
 import type { CreateComposerInput } from "~/types";
 import { PIECE_ERAS, PIECE_REGIONS } from "~/types";
+import { toSelectOptions } from "~/utils/select-options";
 
-function toOptions<T extends string>(values: readonly T[]): { value: T; label: string }[] {
-  return values.map((v) => ({ value: v, label: v }));
-}
-
-const eraOptions = toOptions(PIECE_ERAS);
-const regionOptions = toOptions(PIECE_REGIONS);
+const eraOptions = toSelectOptions(PIECE_ERAS);
+const regionOptions = toSelectOptions(PIECE_REGIONS);
 
 const props = defineProps<{
   initialValues?: Partial<CreateComposerInput>;

--- a/app/components/organisms/ComposerForm.vue
+++ b/app/components/organisms/ComposerForm.vue
@@ -1,0 +1,81 @@
+<script setup lang="ts">
+import type { CreateComposerInput } from "~/types";
+import { PIECE_ERAS, PIECE_REGIONS } from "~/types";
+
+function toOptions<T extends string>(values: readonly T[]): { value: T; label: string }[] {
+  return values.map((v) => ({ value: v, label: v }));
+}
+
+const eraOptions = toOptions(PIECE_ERAS);
+const regionOptions = toOptions(PIECE_REGIONS);
+
+const props = defineProps<{
+  initialValues?: Partial<CreateComposerInput>;
+  submitLabel?: string;
+}>();
+
+const emit = defineEmits<{
+  submit: [values: CreateComposerInput];
+}>();
+
+const form = reactive({
+  name: "",
+  era: "",
+  region: "",
+});
+
+watch(
+  () => props.initialValues,
+  (initialValues) => {
+    form.name = initialValues?.name ?? "";
+    form.era = initialValues?.era ?? "";
+    form.region = initialValues?.region ?? "";
+  },
+  { immediate: true }
+);
+
+function handleSubmit() {
+  emit("submit", {
+    name: form.name,
+    era: (form.era || undefined) as CreateComposerInput["era"],
+    region: (form.region || undefined) as CreateComposerInput["region"],
+  });
+}
+</script>
+
+<template>
+  <form class="composer-form" @submit.prevent="handleSubmit">
+    <FormGroup label="作曲家名" input-id="name" required>
+      <TextInput id="name" v-model="form.name" required placeholder="例：ベートーヴェン" />
+    </FormGroup>
+
+    <FormGroup label="時代" input-id="era">
+      <SelectInput
+        id="era"
+        v-model="form.era"
+        :options="eraOptions"
+        placeholder="選択してください"
+      />
+    </FormGroup>
+
+    <FormGroup label="地域" input-id="region">
+      <SelectInput
+        id="region"
+        v-model="form.region"
+        :options="regionOptions"
+        placeholder="選択してください"
+      />
+    </FormGroup>
+
+    <FormActions :submit-label="submitLabel" @cancel="$router.push('/composers')" />
+  </form>
+</template>
+
+<style scoped>
+.composer-form {
+  max-width: 480px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+</style>

--- a/app/components/organisms/ComposerList.stories.ts
+++ b/app/components/organisms/ComposerList.stories.ts
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerList from "./ComposerList.vue";
+import type { Composer } from "~/types";
+
+const meta: Meta<typeof ComposerList> = {
+  title: "Organisms/ComposerList",
+  component: ComposerList,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerList>;
+
+const sampleComposers: Composer[] = [
+  {
+    id: "1",
+    name: "ベートーヴェン",
+    era: "古典派",
+    region: "ドイツ・オーストリア",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+  {
+    id: "2",
+    name: "モーツァルト",
+    era: "古典派",
+    region: "ドイツ・オーストリア",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+];
+
+export const Default: Story = {
+  args: { composers: sampleComposers, error: null },
+};
+
+export const Empty: Story = {
+  args: { composers: [], error: null },
+};
+
+export const ErrorState: Story = {
+  args: { composers: [], error: new Error("取得失敗") },
+};

--- a/app/components/organisms/ComposerList.test.ts
+++ b/app/components/organisms/ComposerList.test.ts
@@ -1,0 +1,43 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerList from "./ComposerList.vue";
+import type { Composer } from "~/types";
+
+const sampleComposers: Composer[] = [
+  {
+    id: "1",
+    name: "ベートーヴェン",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+  {
+    id: "2",
+    name: "モーツァルト",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+];
+
+describe("ComposerList", () => {
+  describe("表示", () => {
+    it("作曲家が渡されるとリスト表示される", async () => {
+      const wrapper = await mountSuspended(ComposerList, {
+        props: { composers: sampleComposers, error: null },
+      });
+      expect(wrapper.findAll(".composer-list li")).toHaveLength(2);
+    });
+
+    it("空リストの場合は EmptyState を表示する", async () => {
+      const wrapper = await mountSuspended(ComposerList, {
+        props: { composers: [], error: null },
+      });
+      expect(wrapper.text()).toContain("作曲家が登録されていません");
+    });
+
+    it("error が渡されるとエラーメッセージを表示する", async () => {
+      const wrapper = await mountSuspended(ComposerList, {
+        props: { composers: [], error: new Error("取得失敗") },
+      });
+      expect(wrapper.text()).toContain("作曲家一覧の取得に失敗しました");
+    });
+  });
+});

--- a/app/components/organisms/ComposerList.vue
+++ b/app/components/organisms/ComposerList.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+defineProps<{
+  composers: Composer[];
+  error: Error | null;
+}>();
+
+const emit = defineEmits<{
+  delete: [composer: Composer];
+}>();
+
+const router = useRouter();
+</script>
+
+<template>
+  <div>
+    <ErrorMessage
+      v-if="error"
+      message="作曲家一覧の取得に失敗しました。時間をおいて再度お試しください。"
+      variant="block"
+    />
+    <EmptyState v-else-if="!composers.length"
+      >作曲家が登録されていません。最初の作曲家を追加しましょう。</EmptyState
+    >
+
+    <ul v-else class="composer-list">
+      <li v-for="composer in composers" :key="composer.id">
+        <ComposerItem
+          :composer="composer"
+          @detail="router.push(`/composers/${composer.id}`)"
+          @edit="router.push(`/composers/${composer.id}/edit`)"
+          @delete="emit('delete', composer)"
+        />
+      </li>
+    </ul>
+  </div>
+</template>
+
+<style scoped>
+.composer-list {
+  list-style: none;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem;
+}
+
+@media (min-width: 1024px) {
+  .composer-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+</style>

--- a/app/components/organisms/ComposerList.vue
+++ b/app/components/organisms/ComposerList.vue
@@ -7,10 +7,10 @@ defineProps<{
 }>();
 
 const emit = defineEmits<{
+  detail: [composer: Composer];
+  edit: [composer: Composer];
   delete: [composer: Composer];
 }>();
-
-const router = useRouter();
 </script>
 
 <template>
@@ -28,8 +28,8 @@ const router = useRouter();
       <li v-for="composer in composers" :key="composer.id">
         <ComposerItem
           :composer="composer"
-          @detail="router.push(`/composers/${composer.id}`)"
-          @edit="router.push(`/composers/${composer.id}/edit`)"
+          @detail="emit('detail', composer)"
+          @edit="emit('edit', composer)"
           @delete="emit('delete', composer)"
         />
       </li>

--- a/app/components/organisms/ComposerListInfinite.stories.ts
+++ b/app/components/organisms/ComposerListInfinite.stories.ts
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerListInfinite from "./ComposerListInfinite.vue";
+import type { Composer } from "~/types";
+
+const meta: Meta<typeof ComposerListInfinite> = {
+  title: "Organisms/ComposerListInfinite",
+  component: ComposerListInfinite,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerListInfinite>;
+
+const sampleComposers: Composer[] = [
+  {
+    id: "1",
+    name: "ベートーヴェン",
+    era: "古典派",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+];
+
+export const Default: Story = {
+  args: { composers: sampleComposers, error: null, pending: false, hasMore: true },
+};
+
+export const Pending: Story = {
+  args: { composers: sampleComposers, error: null, pending: true, hasMore: true },
+};
+
+export const NoMore: Story = {
+  args: { composers: sampleComposers, error: null, pending: false, hasMore: false },
+};
+
+export const ErrorState: Story = {
+  args: { composers: [], error: new Error("取得失敗"), pending: false, hasMore: true },
+};

--- a/app/components/organisms/ComposerListInfinite.test.ts
+++ b/app/components/organisms/ComposerListInfinite.test.ts
@@ -1,0 +1,53 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerListInfinite from "./ComposerListInfinite.vue";
+import type { Composer } from "~/types";
+
+const sampleComposers: Composer[] = [
+  {
+    id: "1",
+    name: "ベートーヴェン",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+];
+
+describe("ComposerListInfinite", () => {
+  it("読み込み中のメッセージを表示する", async () => {
+    const wrapper = await mountSuspended(ComposerListInfinite, {
+      props: { composers: sampleComposers, error: null, pending: true, hasMore: true },
+    });
+    expect(wrapper.text()).toContain("読み込み中");
+  });
+
+  it("これ以上ない場合のメッセージを表示する", async () => {
+    const wrapper = await mountSuspended(ComposerListInfinite, {
+      props: { composers: sampleComposers, error: null, pending: false, hasMore: false },
+    });
+    expect(wrapper.text()).toContain("これ以上ありません");
+  });
+
+  it("エラー時に再試行ボタンを表示する", async () => {
+    const wrapper = await mountSuspended(ComposerListInfinite, {
+      props: {
+        composers: [],
+        error: new Error("fail"),
+        pending: false,
+        hasMore: true,
+      },
+    });
+    expect(wrapper.find(".btn-retry").exists()).toBe(true);
+  });
+
+  it("再試行ボタンクリックで retry イベントが emit される", async () => {
+    const wrapper = await mountSuspended(ComposerListInfinite, {
+      props: {
+        composers: [],
+        error: new Error("fail"),
+        pending: false,
+        hasMore: true,
+      },
+    });
+    await wrapper.find(".btn-retry").trigger("click");
+    expect(wrapper.emitted("retry")).toBeDefined();
+  });
+});

--- a/app/components/organisms/ComposerListInfinite.vue
+++ b/app/components/organisms/ComposerListInfinite.vue
@@ -9,6 +9,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
+  detail: [composer: Composer];
+  edit: [composer: Composer];
   delete: [composer: Composer];
   loadMore: [];
   retry: [];
@@ -62,6 +64,8 @@ watch(sentinel, (el, _prev, onCleanup) => {
     <ComposerList
       :composers="props.composers"
       :error="props.error"
+      @detail="emit('detail', $event)"
+      @edit="emit('edit', $event)"
       @delete="emit('delete', $event)"
     />
     <output class="list-status" aria-live="polite">

--- a/app/components/organisms/ComposerListInfinite.vue
+++ b/app/components/organisms/ComposerListInfinite.vue
@@ -1,0 +1,128 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+const props = defineProps<{
+  composers: Composer[];
+  error: Error | null;
+  pending: boolean;
+  hasMore: boolean;
+}>();
+
+const emit = defineEmits<{
+  delete: [composer: Composer];
+  loadMore: [];
+  retry: [];
+}>();
+
+const sentinel = ref<HTMLElement | null>(null);
+let observer: IntersectionObserver | null = null;
+
+const startObserving = (el: HTMLElement) => {
+  if (typeof IntersectionObserver === "undefined") {
+    return;
+  }
+  observer = new IntersectionObserver((entries) => {
+    for (const entry of entries) {
+      if (entry.isIntersecting) {
+        emit("loadMore");
+      }
+    }
+  });
+  observer.observe(el);
+};
+
+onMounted(() => {
+  if (sentinel.value !== null) {
+    startObserving(sentinel.value);
+  }
+});
+
+onUnmounted(() => {
+  observer?.disconnect();
+  observer = null;
+});
+
+watch(sentinel, (el, _prev, onCleanup) => {
+  if (el === null) {
+    return;
+  }
+  if (observer === null) {
+    startObserving(el);
+  } else {
+    observer.observe(el);
+  }
+  onCleanup(() => {
+    observer?.unobserve(el);
+  });
+});
+</script>
+
+<template>
+  <div>
+    <ComposerList
+      :composers="props.composers"
+      :error="props.error"
+      @delete="emit('delete', $event)"
+    />
+    <output class="list-status" aria-live="polite">
+      <span v-if="props.pending" class="status-text">読み込み中…</span>
+      <span v-else-if="props.error" class="status-error">
+        <span class="status-error-message">取得に失敗しました。</span>
+        <button type="button" class="btn-retry" @click="emit('retry')">再試行</button>
+      </span>
+      <span v-else-if="!props.hasMore && props.composers.length > 0" class="status-text">
+        これ以上ありません
+      </span>
+      <span
+        v-if="props.hasMore && !props.error"
+        ref="sentinel"
+        class="sentinel"
+        aria-hidden="true"
+      ></span>
+    </output>
+  </div>
+</template>
+
+<style scoped>
+.list-status {
+  display: block;
+  margin-top: 1rem;
+  text-align: center;
+}
+
+.status-text {
+  display: block;
+  color: #666;
+  font-size: 0.9rem;
+  padding: 1rem 0;
+}
+
+.status-error {
+  display: block;
+  padding: 1rem 0;
+  color: #c33;
+}
+
+.status-error-message {
+  display: block;
+}
+
+.btn-retry {
+  margin-top: 0.5rem;
+  padding: 0.5rem 1rem;
+  border: 1px solid #c33;
+  background: #fff;
+  color: #c33;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.btn-retry:hover {
+  background: #fee;
+}
+
+.sentinel {
+  display: block;
+  height: 1px;
+}
+</style>

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -1,18 +1,15 @@
 <script setup lang="ts">
 import type { CreatePieceInput } from "~/types";
 import { PIECE_ERAS, PIECE_FORMATIONS, PIECE_GENRES, PIECE_REGIONS } from "~/types";
+import { toSelectOptions } from "~/utils/select-options";
 
-function toOptions<T extends string>(values: readonly T[]): { value: T; label: string }[] {
-  return values.map((v) => ({ value: v, label: v }));
-}
+const genreOptions = toSelectOptions(PIECE_GENRES);
 
-const genreOptions = toOptions(PIECE_GENRES);
+const eraOptions = toSelectOptions(PIECE_ERAS);
 
-const eraOptions = toOptions(PIECE_ERAS);
+const formationOptions = toSelectOptions(PIECE_FORMATIONS);
 
-const formationOptions = toOptions(PIECE_FORMATIONS);
-
-const regionOptions = toOptions(PIECE_REGIONS);
+const regionOptions = toSelectOptions(PIECE_REGIONS);
 
 const props = defineProps<{
   initialValues?: Partial<CreatePieceInput>;

--- a/app/components/templates/ComposerDetailTemplate.stories.ts
+++ b/app/components/templates/ComposerDetailTemplate.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
+import type { Composer } from "~/types";
+
+const meta: Meta<typeof ComposerDetailTemplate> = {
+  title: "Templates/ComposerDetailTemplate",
+  component: ComposerDetailTemplate,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerDetailTemplate>;
+
+const sample: Composer = {
+  id: "1",
+  name: "ベートーヴェン",
+  era: "古典派",
+  region: "ドイツ・オーストリア",
+  createdAt: "2024-06-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+};
+
+export const AsAdmin: Story = {
+  args: { composer: sample, error: null, isAdmin: true },
+};
+
+export const AsVisitor: Story = {
+  args: { composer: sample, error: null, isAdmin: false },
+};
+
+export const ErrorState: Story = {
+  args: { composer: null, error: new Error("fail"), isAdmin: false },
+};

--- a/app/components/templates/ComposerDetailTemplate.test.ts
+++ b/app/components/templates/ComposerDetailTemplate.test.ts
@@ -1,0 +1,52 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
+import type { Composer } from "~/types";
+
+const sample: Composer = {
+  id: "1",
+  name: "ベートーヴェン",
+  era: "古典派",
+  region: "ドイツ・オーストリア",
+  createdAt: "2024-06-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+};
+
+describe("ComposerDetailTemplate", () => {
+  it("作曲家名が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: sample, error: null, isAdmin: false },
+    });
+    expect(wrapper.find(".composer-name").text()).toBe("ベートーヴェン");
+  });
+
+  it("管理者の場合、編集・削除ボタンが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: sample, error: null, isAdmin: true },
+    });
+    expect(wrapper.find(".btn-secondary").exists()).toBe(true);
+    expect(wrapper.find(".btn-danger").exists()).toBe(true);
+  });
+
+  it("非管理者の場合、編集・削除ボタンが表示されない", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: sample, error: null, isAdmin: false },
+    });
+    expect(wrapper.find(".btn-secondary").exists()).toBe(false);
+    expect(wrapper.find(".btn-danger").exists()).toBe(false);
+  });
+
+  it("削除ボタンクリックで delete イベントが emit される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: sample, error: null, isAdmin: true },
+    });
+    await wrapper.find(".btn-danger").trigger("click");
+    expect(wrapper.emitted("delete")).toBeDefined();
+  });
+
+  it("error 状態の場合、エラーメッセージが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: null, error: new Error("fail"), isAdmin: false },
+    });
+    expect(wrapper.text()).toContain("作曲家の取得に失敗しました");
+  });
+});

--- a/app/components/templates/ComposerDetailTemplate.vue
+++ b/app/components/templates/ComposerDetailTemplate.vue
@@ -1,0 +1,111 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+defineProps<{
+  composer: Composer | null;
+  error: Error | null;
+  isAdmin: boolean;
+}>();
+
+const emit = defineEmits<{
+  delete: [composer: Composer];
+}>();
+</script>
+
+<template>
+  <div>
+    <NuxtLink to="/composers" class="back-link">← 作曲家一覧</NuxtLink>
+
+    <ErrorMessage
+      v-if="error"
+      message="作曲家の取得に失敗しました。時間をおいて再度お試しください。"
+      variant="block"
+    />
+
+    <template v-else-if="composer">
+      <div class="composer-header">
+        <div class="composer-name">{{ composer.name }}</div>
+        <div class="composer-category-wrapper">
+          <ComposerCategoryList :composer="composer" />
+        </div>
+        <div v-if="isAdmin" class="admin-actions">
+          <NuxtLink :to="`/composers/${composer.id}/edit`" class="btn-secondary">編集</NuxtLink>
+          <button class="btn-danger" @click="emit('delete', composer)">削除</button>
+        </div>
+      </div>
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.back-link {
+  display: inline-block;
+  color: #666;
+  text-decoration: none;
+  font-size: 0.9rem;
+  margin-bottom: 1.5rem;
+}
+
+.back-link:hover {
+  color: #333;
+}
+
+.composer-header {
+  margin-bottom: 1.5rem;
+}
+
+.composer-name {
+  font-size: 1.5rem;
+  font-weight: bold;
+  color: #1e2d5a;
+  margin-bottom: 0.3rem;
+}
+
+.composer-category-wrapper {
+  margin-top: 0.5rem;
+}
+
+.admin-actions {
+  display: flex;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+.btn-secondary {
+  display: inline-block;
+  padding: 0.4rem 1rem;
+  background: #fff;
+  border: 1px solid #1e2d5a;
+  color: #1e2d5a;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  text-decoration: none;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.btn-secondary:hover {
+  background: #1e2d5a;
+  color: #fff;
+}
+
+.btn-danger {
+  padding: 0.4rem 1rem;
+  background: #fff;
+  border: 1px solid #c0392b;
+  color: #c0392b;
+  border-radius: 4px;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition:
+    background-color 0.2s,
+    color 0.2s;
+}
+
+.btn-danger:hover {
+  background: #c0392b;
+  color: #fff;
+}
+</style>

--- a/app/components/templates/ComposerEditTemplate.stories.ts
+++ b/app/components/templates/ComposerEditTemplate.stories.ts
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerEditTemplate from "./ComposerEditTemplate.vue";
+import type { Composer } from "~/types";
+
+const meta: Meta<typeof ComposerEditTemplate> = {
+  title: "Templates/ComposerEditTemplate",
+  component: ComposerEditTemplate,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerEditTemplate>;
+
+const sample: Composer = {
+  id: "1",
+  name: "ベートーヴェン",
+  era: "古典派",
+  region: "ドイツ・オーストリア",
+  createdAt: "2024-06-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+};
+
+export const Default: Story = {
+  args: { composer: sample, fetchError: null, errorMessage: "" },
+};
+
+export const WithError: Story = {
+  args: { composer: sample, fetchError: null, errorMessage: "更新に失敗しました" },
+};
+
+export const FetchError: Story = {
+  args: { composer: null, fetchError: new Error("fail"), errorMessage: "" },
+};

--- a/app/components/templates/ComposerEditTemplate.test.ts
+++ b/app/components/templates/ComposerEditTemplate.test.ts
@@ -1,0 +1,43 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerEditTemplate from "./ComposerEditTemplate.vue";
+import type { Composer } from "~/types";
+
+const sample: Composer = {
+  id: "1",
+  name: "ベートーヴェン",
+  era: "古典派",
+  createdAt: "2024-06-01T00:00:00.000Z",
+  updatedAt: "2024-06-01T00:00:00.000Z",
+};
+
+describe("ComposerEditTemplate", () => {
+  it("タイトルが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerEditTemplate, {
+      props: { composer: sample, fetchError: null, errorMessage: "" },
+    });
+    expect(wrapper.text()).toContain("作曲家を編集");
+  });
+
+  it("fetchError が渡されるとエラーが表示されフォームが表示されない", async () => {
+    const wrapper = await mountSuspended(ComposerEditTemplate, {
+      props: { composer: null, fetchError: new Error("fail"), errorMessage: "" },
+    });
+    expect(wrapper.text()).toContain("作曲家の取得に失敗しました");
+    expect(wrapper.find("form.composer-form").exists()).toBe(false);
+  });
+
+  it("errorMessage があるとフォーム上部にエラーメッセージが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerEditTemplate, {
+      props: { composer: sample, fetchError: null, errorMessage: "更新に失敗" },
+    });
+    expect(wrapper.text()).toContain("更新に失敗");
+  });
+
+  it("composer の値が初期値としてフォームに入る", async () => {
+    const wrapper = await mountSuspended(ComposerEditTemplate, {
+      props: { composer: sample, fetchError: null, errorMessage: "" },
+    });
+    const nameInput = wrapper.find("#name");
+    expect((nameInput.element as HTMLInputElement).value).toBe("ベートーヴェン");
+  });
+});

--- a/app/components/templates/ComposerEditTemplate.vue
+++ b/app/components/templates/ComposerEditTemplate.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import type { Composer, UpdateComposerInput } from "~/types";
+
+defineProps<{
+  composer: Composer | null;
+  fetchError: Error | null;
+  errorMessage: string;
+}>();
+
+const emit = defineEmits<{
+  submit: [values: UpdateComposerInput];
+}>();
+</script>
+
+<template>
+  <div>
+    <h1 class="page-title">作曲家を編集</h1>
+
+    <ErrorMessage v-if="fetchError" message="作曲家の取得に失敗しました。" variant="block" />
+
+    <template v-else>
+      <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+      <ComposerForm
+        :initial-values="{
+          name: composer?.name,
+          era: composer?.era,
+          region: composer?.region,
+        }"
+        submit-label="更新する"
+        @submit="emit('submit', $event)"
+      />
+    </template>
+  </div>
+</template>
+
+<style scoped>
+.page-title {
+  font-size: 1.6rem;
+  color: #1e2d5a;
+  margin-bottom: 1.5rem;
+}
+</style>

--- a/app/components/templates/ComposerNewTemplate.stories.ts
+++ b/app/components/templates/ComposerNewTemplate.stories.ts
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposerNewTemplate from "./ComposerNewTemplate.vue";
+
+const meta: Meta<typeof ComposerNewTemplate> = {
+  title: "Templates/ComposerNewTemplate",
+  component: ComposerNewTemplate,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposerNewTemplate>;
+
+export const Default: Story = {
+  args: { errorMessage: "" },
+};
+
+export const WithError: Story = {
+  args: { errorMessage: "登録に失敗しました。入力内容を確認してください。" },
+};

--- a/app/components/templates/ComposerNewTemplate.test.ts
+++ b/app/components/templates/ComposerNewTemplate.test.ts
@@ -1,0 +1,25 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerNewTemplate from "./ComposerNewTemplate.vue";
+
+describe("ComposerNewTemplate", () => {
+  it("タイトルが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    expect(wrapper.text()).toContain("作曲家を追加");
+  });
+
+  it("errorMessage が渡されるとエラーメッセージが表示される", async () => {
+    const wrapper = await mountSuspended(ComposerNewTemplate, {
+      props: { errorMessage: "登録に失敗しました" },
+    });
+    expect(wrapper.text()).toContain("登録に失敗しました");
+  });
+
+  it("errorMessage が空文字列のときはエラーメッセージを表示しない", async () => {
+    const wrapper = await mountSuspended(ComposerNewTemplate, {
+      props: { errorMessage: "" },
+    });
+    expect(wrapper.find(".error-message").exists()).toBe(false);
+  });
+});

--- a/app/components/templates/ComposerNewTemplate.vue
+++ b/app/components/templates/ComposerNewTemplate.vue
@@ -1,0 +1,29 @@
+<script setup lang="ts">
+import type { CreateComposerInput } from "~/types";
+
+defineProps<{
+  errorMessage: string;
+}>();
+
+const emit = defineEmits<{
+  submit: [values: CreateComposerInput];
+}>();
+</script>
+
+<template>
+  <div>
+    <h1 class="page-title">作曲家を追加</h1>
+
+    <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+
+    <ComposerForm submit-label="登録する" @submit="emit('submit', $event)" />
+  </div>
+</template>
+
+<style scoped>
+.page-title {
+  font-size: 1.6rem;
+  color: #1e2d5a;
+  margin-bottom: 1.5rem;
+}
+</style>

--- a/app/components/templates/ComposersTemplate.stories.ts
+++ b/app/components/templates/ComposersTemplate.stories.ts
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import ComposersTemplate from "./ComposersTemplate.vue";
+import type { Composer } from "~/types";
+
+const meta: Meta<typeof ComposersTemplate> = {
+  title: "Templates/ComposersTemplate",
+  component: ComposersTemplate,
+};
+
+export default meta;
+type Story = StoryObj<typeof ComposersTemplate>;
+
+const sample: Composer[] = [
+  {
+    id: "1",
+    name: "ベートーヴェン",
+    era: "古典派",
+    createdAt: "2024-06-01T00:00:00.000Z",
+    updatedAt: "2024-06-01T00:00:00.000Z",
+  },
+];
+
+export const AsAdmin: Story = {
+  args: { composers: sample, error: null, pending: false, hasMore: false, isAdmin: true },
+};
+
+export const AsVisitor: Story = {
+  args: { composers: sample, error: null, pending: false, hasMore: false, isAdmin: false },
+};
+
+export const Empty: Story = {
+  args: { composers: [], error: null, pending: false, hasMore: false, isAdmin: true },
+};

--- a/app/components/templates/ComposersTemplate.test.ts
+++ b/app/components/templates/ComposersTemplate.test.ts
@@ -1,0 +1,25 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposersTemplate from "./ComposersTemplate.vue";
+
+describe("ComposersTemplate", () => {
+  it("管理者の場合 '+ 新しい作曲家' リンクが表示される", async () => {
+    const wrapper = await mountSuspended(ComposersTemplate, {
+      props: { composers: [], error: null, pending: false, hasMore: false, isAdmin: true },
+    });
+    expect(wrapper.text()).toContain("新しい作曲家");
+  });
+
+  it("非管理者の場合 '+ 新しい作曲家' リンクが表示されない", async () => {
+    const wrapper = await mountSuspended(ComposersTemplate, {
+      props: { composers: [], error: null, pending: false, hasMore: false, isAdmin: false },
+    });
+    expect(wrapper.find("a[href='/composers/new']").exists()).toBe(false);
+  });
+
+  it("タイトルが '作曲家マスタ' と表示される", async () => {
+    const wrapper = await mountSuspended(ComposersTemplate, {
+      props: { composers: [], error: null, pending: false, hasMore: false, isAdmin: true },
+    });
+    expect(wrapper.text()).toContain("作曲家マスタ");
+  });
+});

--- a/app/components/templates/ComposersTemplate.vue
+++ b/app/components/templates/ComposersTemplate.vue
@@ -10,6 +10,8 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
+  detail: [composer: Composer];
+  edit: [composer: Composer];
   delete: [composer: Composer];
   loadMore: [];
   retry: [];
@@ -26,6 +28,8 @@ const emit = defineEmits<{
       :error="props.error"
       :pending="props.pending"
       :has-more="props.hasMore"
+      @detail="emit('detail', $event)"
+      @edit="emit('edit', $event)"
       @delete="emit('delete', $event)"
       @load-more="emit('loadMore')"
       @retry="emit('retry')"

--- a/app/components/templates/ComposersTemplate.vue
+++ b/app/components/templates/ComposersTemplate.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+const props = defineProps<{
+  composers: Composer[];
+  error: Error | null;
+  pending: boolean;
+  hasMore: boolean;
+  isAdmin: boolean;
+}>();
+
+const emit = defineEmits<{
+  delete: [composer: Composer];
+  loadMore: [];
+  retry: [];
+}>();
+</script>
+
+<template>
+  <div>
+    <PageHeader title="作曲家マスタ" :new-page-path="props.isAdmin ? '/composers/new' : undefined"
+      >+ 新しい作曲家</PageHeader
+    >
+    <ComposerListInfinite
+      :composers="props.composers"
+      :error="props.error"
+      :pending="props.pending"
+      :has-more="props.hasMore"
+      @delete="emit('delete', $event)"
+      @load-more="emit('loadMore')"
+      @retry="emit('retry')"
+    />
+  </div>
+</template>

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -129,6 +129,10 @@ defineProps<{
           <h3>楽曲マスタ追加</h3>
           <p>新しい楽曲を登録する</p>
         </NuxtLink>
+        <NuxtLink to="/composers/new" class="admin-card">
+          <h3>作曲家マスタ追加</h3>
+          <p>新しい作曲家を登録する</p>
+        </NuxtLink>
       </div>
     </section>
   </div>

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,0 +1,102 @@
+import { COMPOSERS_PAGE_SIZE_DEFAULT } from "~/types";
+import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
+
+/**
+ * GET /composers のレスポンス形式。
+ */
+export type PaginatedComposersResponse = { items: Composer[]; nextCursor: string | null };
+
+const fetchPage = async (
+  apiBase: string,
+  options: { limit: number; cursor?: string }
+): Promise<PaginatedComposersResponse> => {
+  const query: { limit: number; cursor?: string } = { limit: options.limit };
+  if (options.cursor !== undefined) {
+    query.cursor = options.cursor;
+  }
+  return $fetch<PaginatedComposersResponse>(`${apiBase}/composers`, { query });
+};
+
+const postComposer = (apiBase: string, input: CreateComposerInput): Promise<Composer> =>
+  $fetch<Composer>(`${apiBase}/composers`, { method: "POST", body: input });
+
+const putComposer = (apiBase: string, id: string, input: UpdateComposerInput): Promise<Composer> =>
+  $fetch<Composer>(`${apiBase}/composers/${id}`, { method: "PUT", body: input });
+
+/**
+ * 作曲家マスタ一覧の無限スクロール / カーソル型ページング用 composable。
+ */
+export const useComposersPaginated = () => {
+  const apiBase = useApiBase();
+  const items = ref<Composer[]>([]);
+  const nextCursor = ref<string | null>(null);
+  const pending = ref<boolean>(false);
+  const error = ref<Error | null>(null);
+  const hasMore = ref<boolean>(true);
+
+  const loadMore = async () => {
+    if (pending.value === true) {
+      return;
+    }
+    if (hasMore.value === false) {
+      return;
+    }
+    pending.value = true;
+    error.value = null;
+    try {
+      const res = await fetchPage(apiBase, {
+        limit: COMPOSERS_PAGE_SIZE_DEFAULT,
+        cursor: nextCursor.value ?? undefined,
+      });
+      items.value = [...items.value, ...res.items];
+      nextCursor.value = res.nextCursor;
+      hasMore.value = res.nextCursor !== null;
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      pending.value = false;
+    }
+  };
+
+  const reset = () => {
+    items.value = [];
+    nextCursor.value = null;
+    hasMore.value = true;
+    error.value = null;
+  };
+
+  const retry = async () => {
+    error.value = null;
+    await loadMore();
+  };
+
+  const createComposer = async (input: CreateComposerInput) => {
+    const result = await postComposer(apiBase, input);
+    reset();
+    return result;
+  };
+
+  const updateComposer = async (id: string, input: UpdateComposerInput) => {
+    const result = await putComposer(apiBase, id, input);
+    reset();
+    return result;
+  };
+
+  return {
+    items,
+    nextCursor,
+    pending,
+    error,
+    hasMore,
+    loadMore,
+    reset,
+    retry,
+    createComposer,
+    updateComposer,
+  };
+};
+
+export const useComposer = (id: () => string) => {
+  const apiBase = useApiBase();
+  return useFetch<Composer>(() => `${apiBase}/composers/${id()}`);
+};

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -23,6 +23,9 @@ const postComposer = (apiBase: string, input: CreateComposerInput): Promise<Comp
 const putComposer = (apiBase: string, id: string, input: UpdateComposerInput): Promise<Composer> =>
   $fetch<Composer>(`${apiBase}/composers/${id}`, { method: "PUT", body: input });
 
+const deleteComposerRequest = (apiBase: string, id: string): Promise<void> =>
+  $fetch(`${apiBase}/composers/${id}`, { method: "DELETE" });
+
 /**
  * 作曲家マスタ一覧の無限スクロール / カーソル型ページング用 composable。
  */
@@ -82,6 +85,11 @@ export const useComposersPaginated = () => {
     return result;
   };
 
+  const deleteComposer = async (id: string) => {
+    await deleteComposerRequest(apiBase, id);
+    reset();
+  };
+
   return {
     items,
     nextCursor,
@@ -93,6 +101,7 @@ export const useComposersPaginated = () => {
     retry,
     createComposer,
     updateComposer,
+    deleteComposer,
   };
 };
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -21,6 +21,7 @@ watch(
         <ul class="nav-links">
           <li><NuxtLink to="/listening-logs">鑑賞記録</NuxtLink></li>
           <li><NuxtLink to="/pieces">楽曲マスタ</NuxtLink></li>
+          <li><NuxtLink to="/composers">作曲家マスタ</NuxtLink></li>
           <li><NuxtLink to="/concert-logs">コンサート記録</NuxtLink></li>
         </ul>
         <ul v-if="!isLoggedIn" class="auth-links">

--- a/app/pages/composers/[id]/edit.test.ts
+++ b/app/pages/composers/[id]/edit.test.ts
@@ -24,6 +24,7 @@ vi.mock("~/composables/useComposers", () => ({
     retry: vi.fn(),
     createComposer: vi.fn(),
     updateComposer: mockUpdateComposer,
+    deleteComposer: vi.fn(),
   }),
   useComposer: () => ({ data: ref(sampleComposer), error: ref(null) }),
 }));

--- a/app/pages/composers/[id]/edit.test.ts
+++ b/app/pages/composers/[id]/edit.test.ts
@@ -1,0 +1,63 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import ComposerEditPage from "./edit.vue";
+import type { Composer, UpdateComposerInput } from "~/types";
+
+const mockUpdateComposer = vi.fn();
+
+const sampleComposer: Composer = {
+  id: "composer-1",
+  name: "ベートーヴェン",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+vi.mock("~/composables/useComposers", () => ({
+  useComposersPaginated: () => ({
+    items: ref([]),
+    nextCursor: ref(null),
+    pending: ref(false),
+    error: ref(null),
+    hasMore: ref(true),
+    loadMore: vi.fn(),
+    reset: vi.fn(),
+    retry: vi.fn(),
+    createComposer: vi.fn(),
+    updateComposer: mockUpdateComposer,
+  }),
+  useComposer: () => ({ data: ref(sampleComposer), error: ref(null) }),
+}));
+
+beforeEach(() => {
+  mockUpdateComposer.mockClear();
+});
+
+describe("ComposerEditPage", () => {
+  it("ComposerEditTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerEditPage);
+    expect(wrapper.find("form.composer-form").exists()).toBe(true);
+  });
+
+  it("更新成功時に updateComposer が呼ばれる", async () => {
+    mockUpdateComposer.mockResolvedValue({ ...sampleComposer, name: "モーツァルト" });
+    const wrapper = await mountSuspended(ComposerEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdateComposerInput) => Promise<void>;
+    };
+    await vm.handleSubmit({ name: "モーツァルト" });
+    await flushPromises();
+    expect(mockUpdateComposer).toHaveBeenCalled();
+  });
+
+  it("更新失敗時にエラーメッセージを設定する", async () => {
+    mockUpdateComposer.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(ComposerEditPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: UpdateComposerInput) => Promise<void>;
+      errorMessage: string;
+    };
+    await vm.handleSubmit({ name: "モーツァルト" });
+    await flushPromises();
+    expect(vm.errorMessage).toContain("失敗");
+  });
+});

--- a/app/pages/composers/[id]/edit.vue
+++ b/app/pages/composers/[id]/edit.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import type { UpdateComposerInput } from "~/types";
+
+definePageMeta({ middleware: ["admin"] });
+
+const route = useRoute();
+const id = computed(() => route.params.id as string);
+
+const { data: composer, error } = await useComposer(() => id.value);
+const { updateComposer } = useComposersPaginated();
+const errorMessage = ref("");
+
+async function handleSubmit(values: UpdateComposerInput) {
+  errorMessage.value = "";
+  try {
+    await updateComposer(id.value, values);
+    await navigateTo("/composers");
+  } catch {
+    errorMessage.value = "更新に失敗しました。入力内容を確認してください。";
+  }
+}
+</script>
+
+<template>
+  <ComposerEditTemplate
+    :composer="composer ?? null"
+    :fetch-error="error"
+    :error-message="errorMessage"
+    @submit="handleSubmit"
+  />
+</template>

--- a/app/pages/composers/[id]/index.test.ts
+++ b/app/pages/composers/[id]/index.test.ts
@@ -1,0 +1,28 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import ComposerDetailPage from "./index.vue";
+import type { Composer } from "~/types";
+
+const sampleComposer: Composer = {
+  id: "composer-1",
+  name: "ベートーヴェン",
+  era: "古典派",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+vi.mock("~/composables/useComposers", () => ({
+  useComposersPaginated: vi.fn(),
+  useComposer: () => ({ data: ref(sampleComposer), error: ref(null) }),
+}));
+
+describe("ComposerDetailPage", () => {
+  it("ComposerDetailTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailPage);
+    expect(wrapper.findComponent({ name: "ComposerDetailTemplate" }).exists()).toBe(true);
+  });
+
+  it("作曲家名が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailPage);
+    expect(wrapper.text()).toContain("ベートーヴェン");
+  });
+});

--- a/app/pages/composers/[id]/index.test.ts
+++ b/app/pages/composers/[id]/index.test.ts
@@ -11,7 +11,19 @@ const sampleComposer: Composer = {
 };
 
 vi.mock("~/composables/useComposers", () => ({
-  useComposersPaginated: vi.fn(),
+  useComposersPaginated: () => ({
+    items: ref([]),
+    nextCursor: ref(null),
+    pending: ref(false),
+    error: ref(null),
+    hasMore: ref(true),
+    loadMore: vi.fn(),
+    reset: vi.fn(),
+    retry: vi.fn(),
+    createComposer: vi.fn(),
+    updateComposer: vi.fn(),
+    deleteComposer: vi.fn(),
+  }),
   useComposer: () => ({ data: ref(sampleComposer), error: ref(null) }),
 }));
 

--- a/app/pages/composers/[id]/index.vue
+++ b/app/pages/composers/[id]/index.vue
@@ -2,8 +2,8 @@
 import type { Composer } from "~/types";
 
 const route = useRoute();
-const apiBase = useApiBase();
 const { data: composer, error } = await useComposer(() => route.params.id as string);
+const { deleteComposer } = useComposersPaginated();
 const { isAdmin } = useAuth();
 const isAdminUser = isAdmin();
 
@@ -12,7 +12,7 @@ async function handleDelete(target: Composer) {
     return;
   }
   try {
-    await $fetch(`${apiBase}/composers/${target.id}`, { method: "DELETE" });
+    await deleteComposer(target.id);
     await navigateTo("/composers");
   } catch {
     alert("削除に失敗しました。もう一度お試しください。");

--- a/app/pages/composers/[id]/index.vue
+++ b/app/pages/composers/[id]/index.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+const route = useRoute();
+const apiBase = useApiBase();
+const { data: composer, error } = await useComposer(() => route.params.id as string);
+const { isAdmin } = useAuth();
+const isAdminUser = isAdmin();
+
+async function handleDelete(target: Composer) {
+  if (!confirm(`「${target.name}」を削除しますか？`)) {
+    return;
+  }
+  try {
+    await $fetch(`${apiBase}/composers/${target.id}`, { method: "DELETE" });
+    await navigateTo("/composers");
+  } catch {
+    alert("削除に失敗しました。もう一度お試しください。");
+  }
+}
+</script>
+
+<template>
+  <ComposerDetailTemplate
+    :composer="composer ?? null"
+    :error="error"
+    :is-admin="isAdminUser"
+    @delete="handleDelete"
+  />
+</template>

--- a/app/pages/composers/index.test.ts
+++ b/app/pages/composers/index.test.ts
@@ -3,22 +3,25 @@ import { flushPromises } from "@vue/test-utils";
 import ComposersPage from "./index.vue";
 import type { Composer } from "~/types";
 
-const { sampleComposers, mockLoadMore, mockReset, mockRetry } = vi.hoisted(() => {
-  const sampleComposers: Composer[] = [
-    {
-      id: "composer-1",
-      name: "ベートーヴェン",
-      createdAt: "2024-01-01T00:00:00.000Z",
-      updatedAt: "2024-01-01T00:00:00.000Z",
-    },
-  ];
-  return {
-    sampleComposers,
-    mockLoadMore: vi.fn(),
-    mockReset: vi.fn(),
-    mockRetry: vi.fn(),
-  };
-});
+const { sampleComposers, mockLoadMore, mockReset, mockRetry, mockDeleteComposer } = vi.hoisted(
+  () => {
+    const sampleComposers: Composer[] = [
+      {
+        id: "composer-1",
+        name: "ベートーヴェン",
+        createdAt: "2024-01-01T00:00:00.000Z",
+        updatedAt: "2024-01-01T00:00:00.000Z",
+      },
+    ];
+    return {
+      sampleComposers,
+      mockLoadMore: vi.fn(),
+      mockReset: vi.fn(),
+      mockRetry: vi.fn(),
+      mockDeleteComposer: vi.fn(),
+    };
+  }
+);
 
 const composersItems = ref<Composer[]>([]);
 const composersPending = ref<boolean>(false);
@@ -37,6 +40,7 @@ mockNuxtImport("useComposersPaginated", () =>
     retry: mockRetry,
     createComposer: vi.fn(),
     updateComposer: vi.fn(),
+    deleteComposer: mockDeleteComposer,
   }))
 );
 
@@ -58,6 +62,7 @@ beforeEach(() => {
   mockLoadMore.mockClear();
   mockReset.mockClear();
   mockRetry.mockClear();
+  mockDeleteComposer.mockClear();
   mockFetch.mockClear();
   composersItems.value = [...sampleComposers];
   composersPending.value = false;
@@ -103,16 +108,16 @@ describe("ComposersPage", () => {
   });
 
   describe("削除", () => {
-    it("削除確認で OK を選ぶと $fetch が呼ばれる", async () => {
-      mockFetch.mockResolvedValue(undefined);
+    it("削除確認で OK を選ぶと deleteComposer が呼ばれる", async () => {
+      mockDeleteComposer.mockResolvedValue(undefined);
       const wrapper = await mountSuspended(ComposersPage);
       await flushPromises();
       await wrapper.find(".btn-danger").trigger("click");
       await flushPromises();
-      expect(mockFetch).toHaveBeenCalled();
+      expect(mockDeleteComposer).toHaveBeenCalledWith("composer-1");
     });
 
-    it("削除キャンセル時は $fetch が呼ばれない", async () => {
+    it("削除キャンセル時は deleteComposer が呼ばれない", async () => {
       vi.stubGlobal(
         "confirm",
         vi.fn(() => false)
@@ -120,7 +125,7 @@ describe("ComposersPage", () => {
       const wrapper = await mountSuspended(ComposersPage);
       await flushPromises();
       await wrapper.find(".btn-danger").trigger("click");
-      expect(mockFetch).not.toHaveBeenCalled();
+      expect(mockDeleteComposer).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/pages/composers/index.test.ts
+++ b/app/pages/composers/index.test.ts
@@ -1,0 +1,126 @@
+import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import ComposersPage from "./index.vue";
+import type { Composer } from "~/types";
+
+const { sampleComposers, mockLoadMore, mockReset, mockRetry } = vi.hoisted(() => {
+  const sampleComposers: Composer[] = [
+    {
+      id: "composer-1",
+      name: "ベートーヴェン",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    },
+  ];
+  return {
+    sampleComposers,
+    mockLoadMore: vi.fn(),
+    mockReset: vi.fn(),
+    mockRetry: vi.fn(),
+  };
+});
+
+const composersItems = ref<Composer[]>([]);
+const composersPending = ref<boolean>(false);
+const composersError = ref<Error | null>(null);
+const composersHasMore = ref<boolean>(true);
+
+mockNuxtImport("useComposersPaginated", () =>
+  vi.fn(() => ({
+    items: composersItems,
+    nextCursor: ref(null),
+    pending: composersPending,
+    error: composersError,
+    hasMore: composersHasMore,
+    loadMore: mockLoadMore,
+    reset: mockReset,
+    retry: mockRetry,
+    createComposer: vi.fn(),
+    updateComposer: vi.fn(),
+  }))
+);
+
+const mockFetch = vi.fn();
+
+const observeCallbacks: Array<(entries: Array<{ isIntersecting: boolean }>) => void> = [];
+class MockIntersectionObserver {
+  callback: (entries: Array<{ isIntersecting: boolean }>) => void;
+  constructor(callback: (entries: Array<{ isIntersecting: boolean }>) => void) {
+    this.callback = callback;
+    observeCallbacks.push(callback);
+  }
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+}
+
+beforeEach(() => {
+  mockLoadMore.mockClear();
+  mockReset.mockClear();
+  mockRetry.mockClear();
+  mockFetch.mockClear();
+  composersItems.value = [...sampleComposers];
+  composersPending.value = false;
+  composersError.value = null;
+  composersHasMore.value = true;
+  observeCallbacks.length = 0;
+  vi.stubGlobal("$fetch", mockFetch);
+  vi.stubGlobal(
+    "confirm",
+    vi.fn(() => true)
+  );
+  vi.stubGlobal("alert", vi.fn());
+  vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
+});
+
+describe("ComposersPage", () => {
+  describe("表示", () => {
+    it("作曲家一覧が表示される", async () => {
+      const wrapper = await mountSuspended(ComposersPage);
+      await flushPromises();
+      expect(wrapper.findAllComponents({ name: "ComposerItem" })).toHaveLength(1);
+    });
+
+    it("マウント時に loadMore が呼ばれる（初回ロード）", async () => {
+      await mountSuspended(ComposersPage);
+      await flushPromises();
+      expect(mockLoadMore).toHaveBeenCalled();
+    });
+
+    it("hasMore=false 時は末尾到達メッセージが表示される", async () => {
+      composersHasMore.value = false;
+      const wrapper = await mountSuspended(ComposersPage);
+      await flushPromises();
+      expect(wrapper.text()).toContain("これ以上ありません");
+    });
+
+    it("pending=true 時はローディングが表示される", async () => {
+      composersPending.value = true;
+      const wrapper = await mountSuspended(ComposersPage);
+      await flushPromises();
+      expect(wrapper.text()).toContain("読み込み中");
+    });
+  });
+
+  describe("削除", () => {
+    it("削除確認で OK を選ぶと $fetch が呼ばれる", async () => {
+      mockFetch.mockResolvedValue(undefined);
+      const wrapper = await mountSuspended(ComposersPage);
+      await flushPromises();
+      await wrapper.find(".btn-danger").trigger("click");
+      await flushPromises();
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it("削除キャンセル時は $fetch が呼ばれない", async () => {
+      vi.stubGlobal(
+        "confirm",
+        vi.fn(() => false)
+      );
+      const wrapper = await mountSuspended(ComposersPage);
+      await flushPromises();
+      await wrapper.find(".btn-danger").trigger("click");
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/pages/composers/index.vue
+++ b/app/pages/composers/index.vue
@@ -2,11 +2,20 @@
 import type { Composer } from "~/types";
 
 const apiBase = useApiBase();
+const router = useRouter();
 const { items, pending, error, hasMore, loadMore, reset, retry } = useComposersPaginated();
 const { isAdmin } = useAuth();
 const isAdminUser = isAdmin();
 
 void loadMore();
+
+function handleDetail(composer: Composer) {
+  router.push(`/composers/${composer.id}`);
+}
+
+function handleEdit(composer: Composer) {
+  router.push(`/composers/${composer.id}/edit`);
+}
 
 async function handleDelete(composer: Composer) {
   if (!confirm(`「${composer.name}」を削除しますか？`)) {
@@ -31,6 +40,8 @@ async function handleDelete(composer: Composer) {
     :pending="pending"
     :has-more="hasMore"
     :is-admin="isAdminUser"
+    @detail="handleDetail"
+    @edit="handleEdit"
     @delete="handleDelete"
     @load-more="loadMore"
     @retry="retry"

--- a/app/pages/composers/index.vue
+++ b/app/pages/composers/index.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { Composer } from "~/types";
+
+const apiBase = useApiBase();
+const { items, pending, error, hasMore, loadMore, reset, retry } = useComposersPaginated();
+const { isAdmin } = useAuth();
+const isAdminUser = isAdmin();
+
+void loadMore();
+
+async function handleDelete(composer: Composer) {
+  if (!confirm(`「${composer.name}」を削除しますか？`)) {
+    return;
+  }
+  try {
+    await $fetch(`${apiBase}/composers/${composer.id}`, { method: "DELETE" });
+    reset();
+    await loadMore();
+  } catch (err) {
+    const message =
+      err instanceof Error ? err.message : "削除に失敗しました。もう一度お試しください。";
+    alert(message);
+  }
+}
+</script>
+
+<template>
+  <ComposersTemplate
+    :composers="items"
+    :error="error"
+    :pending="pending"
+    :has-more="hasMore"
+    :is-admin="isAdminUser"
+    @delete="handleDelete"
+    @load-more="loadMore"
+    @retry="retry"
+  />
+</template>

--- a/app/pages/composers/index.vue
+++ b/app/pages/composers/index.vue
@@ -1,9 +1,8 @@
 <script setup lang="ts">
 import type { Composer } from "~/types";
 
-const apiBase = useApiBase();
 const router = useRouter();
-const { items, pending, error, hasMore, loadMore, reset, retry } = useComposersPaginated();
+const { items, pending, error, hasMore, loadMore, retry, deleteComposer } = useComposersPaginated();
 const { isAdmin } = useAuth();
 const isAdminUser = isAdmin();
 
@@ -22,8 +21,7 @@ async function handleDelete(composer: Composer) {
     return;
   }
   try {
-    await $fetch(`${apiBase}/composers/${composer.id}`, { method: "DELETE" });
-    reset();
+    await deleteComposer(composer.id);
     await loadMore();
   } catch (err) {
     const message =

--- a/app/pages/composers/new.test.ts
+++ b/app/pages/composers/new.test.ts
@@ -1,0 +1,56 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import { flushPromises } from "@vue/test-utils";
+import ComposerNewPage from "./new.vue";
+import type { CreateComposerInput } from "~/types";
+
+const mockCreateComposer = vi.fn();
+
+vi.mock("~/composables/useComposers", () => ({
+  useComposersPaginated: () => ({
+    items: ref([]),
+    nextCursor: ref(null),
+    pending: ref(false),
+    error: ref(null),
+    hasMore: ref(true),
+    loadMore: vi.fn(),
+    reset: vi.fn(),
+    retry: vi.fn(),
+    createComposer: mockCreateComposer,
+    updateComposer: vi.fn(),
+  }),
+  useComposer: () => ({ data: ref(null), error: ref(null) }),
+}));
+
+beforeEach(() => {
+  mockCreateComposer.mockClear();
+});
+
+describe("ComposerNewPage", () => {
+  it("ComposerNewTemplate が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerNewPage);
+    expect(wrapper.find("form.composer-form").exists()).toBe(true);
+  });
+
+  it("登録成功時に createComposer が呼ばれる", async () => {
+    mockCreateComposer.mockResolvedValue({ id: "new-1" });
+    const wrapper = await mountSuspended(ComposerNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreateComposerInput) => Promise<void>;
+    };
+    await vm.handleSubmit({ name: "ベートーヴェン" });
+    await flushPromises();
+    expect(mockCreateComposer).toHaveBeenCalledWith({ name: "ベートーヴェン" });
+  });
+
+  it("登録失敗時にエラーメッセージを設定する", async () => {
+    mockCreateComposer.mockRejectedValue(new Error("failed"));
+    const wrapper = await mountSuspended(ComposerNewPage);
+    const vm = wrapper.vm as {
+      handleSubmit: (values: CreateComposerInput) => Promise<void>;
+      errorMessage: string;
+    };
+    await vm.handleSubmit({ name: "ベートーヴェン" });
+    await flushPromises();
+    expect(vm.errorMessage).toContain("失敗");
+  });
+});

--- a/app/pages/composers/new.test.ts
+++ b/app/pages/composers/new.test.ts
@@ -17,6 +17,7 @@ vi.mock("~/composables/useComposers", () => ({
     retry: vi.fn(),
     createComposer: mockCreateComposer,
     updateComposer: vi.fn(),
+    deleteComposer: vi.fn(),
   }),
   useComposer: () => ({ data: ref(null), error: ref(null) }),
 }));

--- a/app/pages/composers/new.vue
+++ b/app/pages/composers/new.vue
@@ -1,0 +1,22 @@
+<script setup lang="ts">
+import type { CreateComposerInput } from "~/types";
+
+definePageMeta({ middleware: ["admin"] });
+
+const { createComposer } = useComposersPaginated();
+const errorMessage = ref("");
+
+async function handleSubmit(values: CreateComposerInput) {
+  errorMessage.value = "";
+  try {
+    await createComposer(values);
+    await navigateTo("/composers");
+  } catch {
+    errorMessage.value = "登録に失敗しました。入力内容を確認してください。";
+  }
+}
+</script>
+
+<template>
+  <ComposerNewTemplate :error-message="errorMessage" @submit="handleSubmit" />
+</template>

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -10,6 +10,9 @@ export {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_ALL_MAX_TOTAL,
   PIECES_ALL_MAX_EMPTY_PAGES,
+  COMPOSERS_PAGE_SIZE_MIN,
+  COMPOSERS_PAGE_SIZE_MAX,
+  COMPOSERS_PAGE_SIZE_DEFAULT,
 } from "../../shared/constants";
 export type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "../../shared/constants";
 export type { Paginated } from "../../shared/constants";
@@ -72,3 +75,16 @@ export interface ConcertLog {
 
 export type CreateConcertLogInput = Omit<ConcertLog, "id" | "userId" | "createdAt" | "updatedAt">;
 export type UpdateConcertLogInput = Partial<CreateConcertLogInput>;
+
+// 作曲家マスタ
+export interface Composer {
+  id: string;
+  name: string; // 作曲家名（例: ベートーヴェン）
+  era?: PieceEra; // 時代（楽曲マスタと共通の定数を流用）
+  region?: PieceRegion; // 地域（楽曲マスタと共通の定数を流用）
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateComposerInput = Omit<Composer, "id" | "createdAt" | "updatedAt">;
+export type UpdateComposerInput = Partial<CreateComposerInput>;

--- a/app/utils/select-options.test.ts
+++ b/app/utils/select-options.test.ts
@@ -1,0 +1,24 @@
+import { toSelectOptions } from "./select-options";
+
+describe("toSelectOptions", () => {
+  it("文字列配列を { value, label } 配列に変換する", () => {
+    const result = toSelectOptions(["A", "B"] as const);
+    expect(result).toEqual([
+      { value: "A", label: "A" },
+      { value: "B", label: "B" },
+    ]);
+  });
+
+  it("空配列を渡すと空配列を返す", () => {
+    const result = toSelectOptions([] as const);
+    expect(result).toEqual([]);
+  });
+
+  it("日本語文字列でも value と label が同じ値になる", () => {
+    const result = toSelectOptions(["古典派", "ロマン派"] as const);
+    expect(result).toEqual([
+      { value: "古典派", label: "古典派" },
+      { value: "ロマン派", label: "ロマン派" },
+    ]);
+  });
+});

--- a/app/utils/select-options.ts
+++ b/app/utils/select-options.ts
@@ -1,0 +1,9 @@
+/**
+ * 文字列の readonly 配列を SelectInput の options 形式（{ value, label }）に変換する。
+ * Piece / Composer など、列挙型の定数配列をフォームの選択肢に流し込むときに使う。
+ */
+export function toSelectOptions<T extends string>(
+  values: readonly T[]
+): { value: T; label: string }[] {
+  return values.map((v) => ({ value: v, label: v }));
+}

--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -1,0 +1,53 @@
+import { randomUUID } from "node:crypto";
+
+import type { Composer, CreateComposerInput, UpdateComposerInput } from "../types";
+
+const CLEARABLE_FIELDS = ["era", "region"] as const;
+
+export type ComposerRepository = {
+  findById(id: string): Promise<Composer | undefined>;
+  findPage(options: {
+    limit: number;
+    exclusiveStartKey?: Record<string, unknown>;
+  }): Promise<{ items: Composer[]; lastEvaluatedKey?: Record<string, unknown> }>;
+  save(item: Composer): Promise<void>;
+  saveWithOptimisticLock(item: Composer, prevUpdatedAt: string): Promise<void>;
+  remove(id: string): Promise<void>;
+};
+
+export class ComposerEntity {
+  private constructor(private readonly props: Composer) {}
+
+  static create(input: CreateComposerInput): ComposerEntity {
+    const now = new Date().toISOString();
+    return new ComposerEntity({ ...input, id: randomUUID(), createdAt: now, updatedAt: now });
+  }
+
+  static reconstruct(data: Composer): ComposerEntity {
+    return new ComposerEntity(data);
+  }
+
+  get updatedAt(): string {
+    return this.props.updatedAt;
+  }
+
+  mergeUpdate(input: UpdateComposerInput): ComposerEntity {
+    const merged: Composer = {
+      ...this.props,
+      ...input,
+      id: this.props.id,
+      createdAt: this.props.createdAt,
+      updatedAt: new Date().toISOString(),
+    };
+    const cleared = Object.fromEntries(
+      Object.entries(merged).filter(
+        ([key, value]) => !(CLEARABLE_FIELDS as readonly string[]).includes(key) || value !== ""
+      )
+    ) as Composer;
+    return new ComposerEntity(cleared);
+  }
+
+  toPlain(): Composer {
+    return { ...this.props };
+  }
+}

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+import { handler } from "./create";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
+
+const mockRepo = vi.hoisted(() => ({
+  save: vi.fn(),
+  findById: vi.fn(),
+  findPage: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../../repositories/composer-repository", () => ({
+  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+const validInput = {
+  name: "ベートーヴェン",
+};
+
+describe("POST /composers (create)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/composers" }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
+  });
+
+  it("name がない場合は 400 を返す", async () => {
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify({}),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("name is required");
+  });
+
+  it.each(["   ", "\t", "\n"])(
+    "name が空白のみ（%j）の場合は 400 を返す",
+    async (whitespaceName) => {
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({ name: whitespaceName }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("name is required");
+    }
+  );
+
+  it("name が 100 文字を超える場合は 400 を返す", async () => {
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify({ name: "あ".repeat(101) }),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be 100 characters or less");
+  });
+
+  it("必須項目のみで正常に作成して 201 を返す", async () => {
+    mockRepo.save.mockResolvedValueOnce();
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(201);
+
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.id).toBeDefined();
+    expect(body.name).toBe("ベートーヴェン");
+    expect(body.createdAt).toBeDefined();
+    expect(body.updatedAt).toBeDefined();
+    expect(body.era).toBeUndefined();
+    expect(body.region).toBeUndefined();
+  });
+
+  it("作成アイテムに UUID が付与される", async () => {
+    mockRepo.save.mockResolvedValueOnce();
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.id).toBeUUID();
+  });
+
+  it("createdAt と updatedAt が同じ値かつ現在時刻で設定される", async () => {
+    const now = new Date("2026-03-08T00:00:00.000Z");
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    mockRepo.save.mockResolvedValueOnce();
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.createdAt).toBe(now.toISOString());
+    expect(body.updatedAt).toBe(now.toISOString());
+    expect(body.createdAt).toBe(body.updatedAt);
+  });
+
+  describe("カテゴリフィールド", () => {
+    it("era と region を指定して作成できる", async () => {
+      mockRepo.save.mockResolvedValueOnce();
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({
+            ...validInput,
+            era: "古典派",
+            region: "ドイツ・オーストリア",
+          }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(201);
+      const body = JSON.parse(result?.body ?? "{}");
+      expect(body.era).toBe("古典派");
+      expect(body.region).toBe("ドイツ・オーストリア");
+    });
+
+    it("era に不正な値を指定すると 400 を返す", async () => {
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({ ...validInput, era: "不正な値" }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("region に不正な値を指定すると 400 を返す", async () => {
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({ ...validInput, region: "不正な値" }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+  });
+
+  it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const result = await handler(
+      makeAdminEvent(TEST_USER_ID, {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/composers",
+      }),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(500);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、データを保存しない", async () => {
+      const result = await handler(
+        makeAuthEvent(TEST_USER_ID, {
+          body: JSON.stringify(validInput),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、データを保存しない", async () => {
+      const result = await handler(
+        makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/composers" }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.save).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/handlers/composers/create.ts
+++ b/backend/src/handlers/composers/create.ts
@@ -1,0 +1,15 @@
+import { requireAdmin } from "../../utils/auth";
+import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { parseRequestBody } from "../../utils/parsing";
+import { createComposerSchema } from "../../utils/schemas";
+import { created } from "../../utils/response";
+import { createComposerUsecase } from "../../usecases/composer-usecase";
+
+const usecase = createComposerUsecase();
+
+export const handler = createHandler(async (event) => {
+  requireAdmin(event);
+  const input = parseRequestBody(event.body as unknown, createComposerSchema);
+  const composer = await usecase.create(input);
+  return created(composer);
+}).use(jsonBodyParser);

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent } from "aws-lambda";
+
+import { handler } from "./delete";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent as makeBaseEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
+
+const mockRepo = vi.hoisted(() => ({
+  save: vi.fn(),
+  findById: vi.fn(),
+  findPage: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../../repositories/composer-repository", () => ({
+  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+type AuthMode = "admin" | "non-admin" | "none";
+
+function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxyEvent {
+  const overrides: Partial<APIGatewayProxyEvent> = {
+    httpMethod: "DELETE",
+    path: `/composers/${id ?? ""}`,
+    pathParameters: id === null ? null : { id },
+  };
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeBaseEvent(overrides);
+}
+
+describe("DELETE /composers/{id} (delete)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("id がない場合は 400 を返す", async () => {
+    const result = await handler(makeEvent(null), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
+  });
+
+  it("正常に削除して 204 を返す", async () => {
+    mockRepo.remove.mockResolvedValueOnce();
+    const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(204);
+    expect(result?.body).toBe("");
+  });
+
+  it("正しい id で Repository.remove を呼び出す", async () => {
+    mockRepo.remove.mockResolvedValueOnce();
+    await handler(makeEvent("test-id-123"), mockContext, mockCallback);
+
+    expect(mockRepo.remove).toHaveBeenCalledWith("test-id-123");
+  });
+
+  it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.remove.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(500);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、削除しない", async () => {
+      const result = await handler(
+        makeEvent("test-id-123", "non-admin"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、削除しない", async () => {
+      const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.remove).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/handlers/composers/delete.ts
+++ b/backend/src/handlers/composers/delete.ts
@@ -1,0 +1,14 @@
+import { requireAdmin } from "../../utils/auth";
+import { createHandler } from "../../utils/middleware";
+import { getIdParam } from "../../utils/path-params";
+import { noContent } from "../../utils/response";
+import { createComposerUsecase } from "../../usecases/composer-usecase";
+
+const usecase = createComposerUsecase();
+
+export const handler = createHandler(async (event) => {
+  requireAdmin(event);
+  const id = getIdParam(event);
+  await usecase.delete(id);
+  return noContent();
+});

--- a/backend/src/handlers/composers/get.test.ts
+++ b/backend/src/handlers/composers/get.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+import type { Composer } from "../../types";
+
+import { handler } from "./get";
+
+const mockRepo = vi.hoisted(() => ({
+  save: vi.fn(),
+  findById: vi.fn(),
+  findPage: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../../repositories/composer-repository", () => ({
+  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+const mockContext = {} as Context;
+const mockCallback = { signal: new AbortController().signal };
+
+function makeEvent(id?: string): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: "GET",
+    isBase64Encoded: false,
+    path: `/composers/${id ?? ""}`,
+    pathParameters: id === undefined ? null : { id },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent["requestContext"],
+    resource: "",
+  };
+}
+
+const testComposer: Composer = {
+  id: "abc-123",
+  name: "ベートーヴェン",
+  createdAt: "2024-01-15T21:00:00.000Z",
+  updatedAt: "2024-01-15T21:00:00.000Z",
+};
+
+describe("GET /composers/{id} (get)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("id がない場合は 400 を返す", async () => {
+    const result = await handler(makeEvent(), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
+  });
+
+  it("アイテムが存在しない場合は 404 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(undefined);
+    const result = await handler(makeEvent("not-found-id"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(404);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("Composer not found");
+  });
+
+  it("正常に取得して 200 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(testComposer);
+    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(200);
+
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.id).toBe("abc-123");
+    expect(body.name).toBe("ベートーヴェン");
+  });
+
+  it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/composers/get.ts
+++ b/backend/src/handlers/composers/get.ts
@@ -1,0 +1,12 @@
+import { createHandler } from "../../utils/middleware";
+import { getIdParam } from "../../utils/path-params";
+import { ok } from "../../utils/response";
+import { createComposerUsecase } from "../../usecases/composer-usecase";
+
+const usecase = createComposerUsecase();
+
+export const handler = createHandler(async (event) => {
+  const id = getIdParam(event);
+  const composer = await usecase.get(id);
+  return ok(composer);
+});

--- a/backend/src/handlers/composers/list.test.ts
+++ b/backend/src/handlers/composers/list.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { handler } from "./list";
+import { makeEvent, makeComposer, mockContext, mockCallback } from "../../test/fixtures";
+import { encodeCursor } from "../../utils/cursor";
+import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "../../types";
+import type { Composer, Paginated } from "../../types";
+
+const mockRepo = vi.hoisted(() => ({
+  save: vi.fn(),
+  findById: vi.fn(),
+  findPage: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../../repositories/composer-repository", () => ({
+  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+const parseBody = (result: { body?: string } | null | undefined): Paginated<Composer> =>
+  JSON.parse(result?.body ?? '{"items":[],"nextCursor":null}') as Paginated<Composer>;
+
+describe("GET /composers (list)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("正常系", () => {
+    it("空の場合は items=[], nextCursor=null を返す", async () => {
+      mockRepo.findPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+
+      const result = await handler(makeEvent(), mockContext, mockCallback);
+
+      expect(result?.statusCode).toBe(200);
+      const body = parseBody(result);
+      expect(body.items).toEqual([]);
+      expect(body.nextCursor).toBeNull();
+    });
+
+    it("Repository から取得したアイテムを items に入れて返す", async () => {
+      const composers = [makeComposer("1", "ベートーヴェン"), makeComposer("2", "モーツァルト")];
+      mockRepo.findPage.mockResolvedValueOnce({ items: composers, lastEvaluatedKey: undefined });
+
+      const result = await handler(makeEvent(), mockContext, mockCallback);
+
+      expect(result?.statusCode).toBe(200);
+      const body = parseBody(result);
+      expect(body.items).toEqual(composers);
+      expect(body.nextCursor).toBeNull();
+    });
+
+    it("limit 未指定の場合は既定値で findPage を呼ぶ", async () => {
+      mockRepo.findPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+
+      await handler(makeEvent(), mockContext, mockCallback);
+
+      expect(mockRepo.findPage).toHaveBeenCalledWith({
+        limit: COMPOSERS_PAGE_SIZE_DEFAULT,
+        exclusiveStartKey: undefined,
+      });
+    });
+
+    it("limit クエリを指定すると数値変換して findPage に渡す", async () => {
+      mockRepo.findPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+
+      await handler(
+        makeEvent({ queryStringParameters: { limit: "20" } }),
+        mockContext,
+        mockCallback
+      );
+
+      expect(mockRepo.findPage).toHaveBeenCalledWith({
+        limit: 20,
+        exclusiveStartKey: undefined,
+      });
+    });
+
+    it("cursor クエリを指定するとデコードして exclusiveStartKey として findPage に渡す", async () => {
+      mockRepo.findPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      const cursor = encodeCursor({ id: "composer-prev" });
+
+      await handler(makeEvent({ queryStringParameters: { cursor } }), mockContext, mockCallback);
+
+      expect(mockRepo.findPage).toHaveBeenCalledWith({
+        limit: COMPOSERS_PAGE_SIZE_DEFAULT,
+        exclusiveStartKey: { id: "composer-prev" },
+      });
+    });
+
+    it("LastEvaluatedKey がある場合はエンコードして nextCursor に入れて返す", async () => {
+      mockRepo.findPage.mockResolvedValueOnce({
+        items: [makeComposer("1", "a")],
+        lastEvaluatedKey: { id: "composer-1" },
+      });
+
+      const result = await handler(makeEvent(), mockContext, mockCallback);
+      const body = parseBody(result);
+
+      expect(body.nextCursor).not.toBeNull();
+      expect(typeof body.nextCursor).toBe("string");
+    });
+  });
+
+  describe("異常系", () => {
+    it("limit が 0 の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({ queryStringParameters: { limit: "0" } }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("limit が 上限超過の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({ queryStringParameters: { limit: String(COMPOSERS_PAGE_SIZE_MAX + 1) } }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("limit が数値でない場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({ queryStringParameters: { limit: "abc" } }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("cursor が不正な base64url 文字の場合は 400 を返す", async () => {
+      const result = await handler(
+        makeEvent({ queryStringParameters: { cursor: "!!!invalid!!!" } }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+    });
+
+    it("Repository エラー時に 500 を返す", async () => {
+      mockRepo.findPage.mockRejectedValueOnce(new Error("DynamoDB error"));
+      const result = await handler(makeEvent(), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(500);
+    });
+  });
+});

--- a/backend/src/handlers/composers/list.ts
+++ b/backend/src/handlers/composers/list.ts
@@ -1,0 +1,32 @@
+import createError from "http-errors";
+
+import { decodeCursor, InvalidCursorError } from "../../utils/cursor";
+import { createHandler } from "../../utils/middleware";
+import { ok } from "../../utils/response";
+import { listComposersQuerySchema } from "../../utils/schemas";
+import { createComposerUsecase } from "../../usecases/composer-usecase";
+
+const usecase = createComposerUsecase();
+
+export const handler = createHandler(async (event) => {
+  const parsed = listComposersQuerySchema.safeParse(event.queryStringParameters ?? {});
+  if (!parsed.success) {
+    throw new createError.BadRequest(parsed.error.issues[0]?.message ?? "Invalid query parameter");
+  }
+  const { limit, cursor } = parsed.data;
+
+  let exclusiveStartKey: Record<string, unknown> | undefined;
+  if (cursor !== undefined) {
+    try {
+      exclusiveStartKey = decodeCursor(cursor);
+    } catch (err) {
+      if (err instanceof InvalidCursorError) {
+        throw new createError.BadRequest(err.message);
+      }
+      throw err;
+    }
+  }
+
+  const page = await usecase.list({ limit, exclusiveStartKey });
+  return ok(page);
+});

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent } from "aws-lambda";
+import createError from "http-errors";
+import type { Composer } from "../../types";
+
+import { handler } from "./update";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent as makeBaseEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "../../test/fixtures";
+
+const mockRepo = vi.hoisted(() => ({
+  save: vi.fn(),
+  findById: vi.fn(),
+  findPage: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+}));
+
+vi.mock("../../repositories/composer-repository", () => ({
+  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+type AuthMode = "admin" | "non-admin" | "none";
+
+function makeEvent(
+  id?: string,
+  body?: string | null,
+  auth: AuthMode = "admin"
+): APIGatewayProxyEvent {
+  const overrides: Partial<APIGatewayProxyEvent> = {
+    body: body === undefined ? null : body,
+    httpMethod: "PUT",
+    path: `/composers/${id ?? ""}`,
+    pathParameters: id === undefined ? null : { id },
+  };
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeBaseEvent(overrides);
+}
+
+const existingComposer: Composer = {
+  id: "abc-123",
+  name: "ベートーヴェン",
+  createdAt: "2024-01-15T21:00:00.000Z",
+  updatedAt: "2024-01-15T21:00:00.000Z",
+};
+
+describe("PUT /composers/{id} (update)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("id がない場合は 400 を返す", async () => {
+    const result = await handler(
+      makeEvent(undefined, JSON.stringify({ name: "新しい名前" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
+  });
+
+  it.each(["", "   ", "\t"])(
+    "name が空または空白のみ（%j）の場合は 400 を返す",
+    async (invalidName) => {
+      const result = await handler(
+        makeEvent("abc-123", JSON.stringify({ name: invalidName })),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be a non-empty string");
+    }
+  );
+
+  it("name が 100 文字を超える場合は 400 を返す", async () => {
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ name: "あ".repeat(101) })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be 100 characters or less");
+  });
+
+  it("アイテムが存在しない場合は 404 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(undefined);
+    const result = await handler(
+      makeEvent("not-found-id", JSON.stringify({ name: "新しい名前" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(404);
+  });
+
+  it("正常更新して 200 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(existingComposer);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(200);
+
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.id).toBe("abc-123");
+    expect(body.name).toBe("モーツァルト");
+  });
+
+  it("createdAt は上書きされない", async () => {
+    mockRepo.findById.mockResolvedValueOnce(existingComposer);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
+      mockContext,
+      mockCallback
+    );
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.createdAt).toBe(existingComposer.createdAt);
+  });
+
+  it("era と region を追加して更新できる", async () => {
+    mockRepo.findById.mockResolvedValueOnce(existingComposer);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ era: "古典派", region: "ドイツ・オーストリア" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.era).toBe("古典派");
+    expect(body.region).toBe("ドイツ・オーストリア");
+  });
+
+  it("era を空文字で送信すると削除される", async () => {
+    const existing: Composer = {
+      ...existingComposer,
+      era: "古典派",
+      region: "ドイツ・オーストリア",
+    };
+    mockRepo.findById.mockResolvedValueOnce(existing);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ era: "", region: "" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.era).toBeUndefined();
+    expect(body.region).toBeUndefined();
+  });
+
+  it("楽観的ロック競合時に 409 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(existingComposer);
+    mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(
+      new createError.Conflict("Composer was updated by another request")
+    );
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(409);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、データを更新しない", async () => {
+      const result = await handler(
+        makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "non-admin"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.findById).not.toHaveBeenCalled();
+      expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返し、データを更新しない", async () => {
+      const result = await handler(
+        makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "none"),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.findById).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/handlers/composers/update.ts
+++ b/backend/src/handlers/composers/update.ts
@@ -1,0 +1,17 @@
+import { requireAdmin } from "../../utils/auth";
+import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { parseRequestBody } from "../../utils/parsing";
+import { updateComposerSchema } from "../../utils/schemas";
+import { getIdParam } from "../../utils/path-params";
+import { ok } from "../../utils/response";
+import { createComposerUsecase } from "../../usecases/composer-usecase";
+
+const usecase = createComposerUsecase();
+
+export const handler = createHandler(async (event) => {
+  requireAdmin(event);
+  const id = getIdParam(event);
+  const input = parseRequestBody(event.body as unknown, updateComposerSchema);
+  const composer = await usecase.update(id, input);
+  return ok(composer);
+}).use(jsonBodyParser);

--- a/backend/src/repositories/composer-repository.ts
+++ b/backend/src/repositories/composer-repository.ts
@@ -1,0 +1,47 @@
+import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
+import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import createError from "http-errors";
+
+import { dynamo, scanPage, TABLE_COMPOSERS } from "../utils/dynamodb";
+import type { Composer } from "../types";
+import type { ComposerRepository } from "../domain/composer";
+
+export class DynamoDBComposerRepository implements ComposerRepository {
+  async findById(id: string): Promise<Composer | undefined> {
+    const result = await dynamo.send(new GetCommand({ TableName: TABLE_COMPOSERS, Key: { id } }));
+    return result.Item as Composer | undefined;
+  }
+
+  async findPage(options: {
+    limit: number;
+    exclusiveStartKey?: Record<string, unknown>;
+  }): Promise<{ items: Composer[]; lastEvaluatedKey?: Record<string, unknown> }> {
+    return scanPage<Composer>(TABLE_COMPOSERS, options);
+  }
+
+  async save(item: Composer): Promise<void> {
+    await dynamo.send(new PutCommand({ TableName: TABLE_COMPOSERS, Item: item }));
+  }
+
+  async saveWithOptimisticLock(item: Composer, prevUpdatedAt: string): Promise<void> {
+    try {
+      await dynamo.send(
+        new PutCommand({
+          TableName: TABLE_COMPOSERS,
+          Item: item,
+          ConditionExpression: "updatedAt = :prevUpdatedAt",
+          ExpressionAttributeValues: { ":prevUpdatedAt": prevUpdatedAt },
+        })
+      );
+    } catch (err) {
+      if (err instanceof ConditionalCheckFailedException) {
+        throw new createError.Conflict("Composer was updated by another request");
+      }
+      throw err;
+    }
+  }
+
+  async remove(id: string): Promise<void> {
+    await dynamo.send(new DeleteCommand({ TableName: TABLE_COMPOSERS, Key: { id } }));
+  }
+}

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { ListeningLog, Piece } from "../types";
+import type { Composer, ListeningLog, Piece } from "../types";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 export const makeLog = (
@@ -23,6 +23,13 @@ export const makePiece = (id: string, title: string): Piece => ({
   id,
   title,
   composer: "モーツァルト",
+  createdAt: "2024-06-01T09:00:00.000Z",
+  updatedAt: "2024-06-01T09:00:00.000Z",
+});
+
+export const makeComposer = (id: string, name: string): Composer => ({
+  id,
+  name,
   createdAt: "2024-06-01T09:00:00.000Z",
   updatedAt: "2024-06-01T09:00:00.000Z",
 });

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -10,6 +10,9 @@ export {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_ALL_MAX_TOTAL,
   PIECES_ALL_MAX_EMPTY_PAGES,
+  COMPOSERS_PAGE_SIZE_MIN,
+  COMPOSERS_PAGE_SIZE_MAX,
+  COMPOSERS_PAGE_SIZE_DEFAULT,
 } from "../../../shared/constants";
 export type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "../../../shared/constants";
 export type { Paginated } from "../../../shared/constants";
@@ -82,3 +85,16 @@ export interface ConcertLog {
 
 export type CreateConcertLogInput = Omit<ConcertLog, "id" | "userId" | "createdAt" | "updatedAt">;
 export type UpdateConcertLogInput = Partial<CreateConcertLogInput>;
+
+// 作曲家マスタ
+export interface Composer {
+  id: string;
+  name: string; // 作曲家名（例: ベートーヴェン）
+  era?: PieceEra; // 時代（楽曲マスタと共通の定数を流用）
+  region?: PieceRegion; // 地域（楽曲マスタと共通の定数を流用）
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type CreateComposerInput = Omit<Composer, "id" | "createdAt" | "updatedAt">;
+export type UpdateComposerInput = Partial<CreateComposerInput>;

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -1,0 +1,55 @@
+import createError from "http-errors";
+
+import { ComposerEntity } from "../domain/composer";
+import type { ComposerRepository } from "../domain/composer";
+import { DynamoDBComposerRepository } from "../repositories/composer-repository";
+import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "../types";
+import { encodeCursor } from "../utils/cursor";
+
+export class ComposerUsecase {
+  constructor(private readonly repo: ComposerRepository) {}
+
+  async create(input: CreateComposerInput): Promise<Composer> {
+    const entity = ComposerEntity.create(input);
+    const plain = entity.toPlain();
+    await this.repo.save(plain);
+    return plain;
+  }
+
+  async list(options: {
+    limit: number;
+    exclusiveStartKey?: Record<string, unknown>;
+  }): Promise<Paginated<Composer>> {
+    const { items, lastEvaluatedKey } = await this.repo.findPage(options);
+    return {
+      items,
+      nextCursor: lastEvaluatedKey === undefined ? null : encodeCursor(lastEvaluatedKey),
+    };
+  }
+
+  async get(id: string): Promise<Composer> {
+    const item = await this.repo.findById(id);
+    if (item === undefined) {
+      throw new createError.NotFound("Composer not found");
+    }
+    return item;
+  }
+
+  async update(id: string, input: UpdateComposerInput): Promise<Composer> {
+    const current = await this.repo.findById(id);
+    if (current === undefined) {
+      throw new createError.NotFound("Composer not found");
+    }
+    const entity = ComposerEntity.reconstruct(current);
+    const updated = entity.mergeUpdate(input);
+    const plain = updated.toPlain();
+    await this.repo.saveWithOptimisticLock(plain, current.updatedAt);
+    return plain;
+  }
+
+  async delete(id: string): Promise<void> {
+    await this.repo.remove(id);
+  }
+}
+
+export const createComposerUsecase = () => new ComposerUsecase(new DynamoDBComposerRepository());

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -22,6 +22,8 @@ export const TABLE_PIECES = getEnv().dynamoTablePieces;
 
 export const TABLE_CONCERT_LOGS = getEnv().dynamoTableConcertLogs;
 
+export const TABLE_COMPOSERS = getEnv().dynamoTableComposers;
+
 export async function queryItemsByUserId<T>(tableName: string, userId: string): Promise<T[]> {
   const items: T[] = [];
   let lastEvaluatedKey: Record<string, unknown> | undefined;

--- a/backend/src/utils/env.ts
+++ b/backend/src/utils/env.ts
@@ -5,6 +5,7 @@ export class AppEnv {
   readonly dynamoTableListeningLogs: string;
   readonly dynamoTablePieces: string;
   readonly dynamoTableConcertLogs: string;
+  readonly dynamoTableComposers: string;
 
   constructor() {
     const cognitoClientId = process.env.COGNITO_CLIENT_ID;
@@ -19,6 +20,7 @@ export class AppEnv {
     this.dynamoTablePieces = process.env.DYNAMO_TABLE_PIECES ?? "classical-music-pieces";
     this.dynamoTableConcertLogs =
       process.env.DYNAMO_TABLE_CONCERT_LOGS ?? "classical-music-concert-logs";
+    this.dynamoTableComposers = process.env.DYNAMO_TABLE_COMPOSERS ?? "classical-music-composers";
   }
 }
 

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -7,6 +7,9 @@ import {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_PAGE_SIZE_MAX,
   PIECES_PAGE_SIZE_MIN,
+  COMPOSERS_PAGE_SIZE_DEFAULT,
+  COMPOSERS_PAGE_SIZE_MAX,
+  COMPOSERS_PAGE_SIZE_MIN,
 } from "../types/index.js";
 
 const ratingSchema = z
@@ -139,6 +142,46 @@ export const createConcertLogSchema = z.object({
 });
 
 export const updateConcertLogSchema = createConcertLogSchema.partial();
+
+export const createComposerSchema = z.object({
+  name: z
+    .string({ error: () => "name is required" })
+    .trim()
+    .min(1, "name is required")
+    .max(100, "name must be 100 characters or less"),
+  era: pieceEraSchema.optional(),
+  region: pieceRegionSchema.optional(),
+});
+
+export const updateComposerSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "name must be a non-empty string")
+    .max(100, "name must be 100 characters or less")
+    .optional(),
+  era: z.union([pieceEraSchema, z.literal("")]).optional(),
+  region: z.union([pieceRegionSchema, z.literal("")]).optional(),
+});
+
+/**
+ * GET /composers のクエリパラメータを検証するスキーマ。
+ * - `limit`: 省略時は {@link COMPOSERS_PAGE_SIZE_DEFAULT}。範囲は {@link COMPOSERS_PAGE_SIZE_MIN} 〜 {@link COMPOSERS_PAGE_SIZE_MAX}。
+ * - `cursor`: 省略可。指定時は base64url 形式の文字列。
+ */
+export const listComposersQuerySchema = z.object({
+  limit: z.coerce
+    .number({ error: () => "limit must be a number" })
+    .int({ message: "limit must be an integer" })
+    .min(COMPOSERS_PAGE_SIZE_MIN, {
+      message: `limit must be at least ${COMPOSERS_PAGE_SIZE_MIN}`,
+    })
+    .max(COMPOSERS_PAGE_SIZE_MAX, {
+      message: `limit must be at most ${COMPOSERS_PAGE_SIZE_MAX}`,
+    })
+    .default(COMPOSERS_PAGE_SIZE_DEFAULT),
+  cursor: z.base64url({ message: "cursor must be a base64url string" }).min(1).optional(),
+});
 
 /**
  * GET /pieces のクエリパラメータを検証するスキーマ。

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -81,6 +81,20 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     });
 
     // -------------------------
+    // DynamoDB テーブル（作曲家マスタ）
+    // -------------------------
+    const composersTableName = isProd
+      ? "classical-music-composers"
+      : `classical-music-composers-${stageName}`;
+
+    const composersTable = new dynamodb.Table(this, "ComposersTable", {
+      tableName: composersTableName,
+      partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    // -------------------------
     // AWS Cognito User Pool
     // -------------------------
     const userPoolName = isProd ? "classical-music-lake" : `classical-music-lake-${stageName}`;
@@ -333,6 +347,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       DYNAMO_TABLE_LISTENING_LOGS: listeningLogsTable.tableName,
       DYNAMO_TABLE_PIECES: piecesTable.tableName,
       DYNAMO_TABLE_CONCERT_LOGS: concertLogsTable.tableName,
+      DYNAMO_TABLE_COMPOSERS: composersTable.tableName,
     };
 
     const commonFnProps: Omit<lambdaNodejs.NodejsFunctionProps, "entry" | "logGroup"> = {
@@ -394,6 +409,12 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const concertLogsGet = fn("ConcertLogsGet", "handlers/concert-logs/get.ts");
     const concertLogsUpdate = fn("ConcertLogsUpdate", "handlers/concert-logs/update.ts");
     const concertLogsDelete = fn("ConcertLogsDelete", "handlers/concert-logs/delete.ts");
+
+    const listComposers = fn("ListComposers", "handlers/composers/list.ts");
+    const createComposer = fn("CreateComposer", "handlers/composers/create.ts");
+    const getComposer = fn("GetComposer", "handlers/composers/get.ts");
+    const updateComposer = fn("UpdateComposer", "handlers/composers/update.ts");
+    const deleteComposer = fn("DeleteComposer", "handlers/composers/delete.ts");
 
     // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
     // いる場合に自動でアカウントリンクを行う
@@ -470,6 +491,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     concertLogsTable.grantReadData(concertLogsGet);
     concertLogsTable.grantReadWriteData(concertLogsUpdate);
     concertLogsTable.grantReadWriteData(concertLogsDelete);
+    composersTable.grantReadData(listComposers);
+    composersTable.grantWriteData(createComposer);
+    composersTable.grantReadData(getComposer);
+    composersTable.grantReadWriteData(updateComposer);
+    composersTable.grantWriteData(deleteComposer);
 
     // -------------------------
     // API Gateway
@@ -567,6 +593,19 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     pieceResource.addMethod("PUT", integ(updatePiece), withAuth);
     pieceResource.addMethod("DELETE", integ(deletePiece), withAuth);
 
+    // /composers
+    // 参照系（GET）は公開。書き込み系（POST/PUT/DELETE）は withAuth でトークン検証し、
+    // ハンドラ側で admin グループ判定を実施する
+    const composersResource = api.root.addResource("composers");
+    composersResource.addMethod("GET", integ(listComposers), withoutAuth);
+    composersResource.addMethod("POST", integ(createComposer), withAuth);
+
+    // /composers/{id}
+    const composerResource = composersResource.addResource("{id}");
+    composerResource.addMethod("GET", integ(getComposer), withoutAuth);
+    composerResource.addMethod("PUT", integ(updateComposer), withAuth);
+    composerResource.addMethod("DELETE", integ(deleteComposer), withAuth);
+
     // /auth
     const authResource = api.root.addResource("auth");
 
@@ -611,6 +650,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       concertLogsGet,
       concertLogsUpdate,
       concertLogsDelete,
+      listComposers,
+      createComposer,
+      getComposer,
+      updateComposer,
+      deleteComposer,
     ];
 
     authExcludedFunctions.forEach((fn) => {
@@ -650,6 +694,12 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     this.addCors(piecesResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
     this.addCors(
       pieceResource,
+      ["GET", "PUT", "DELETE", "OPTIONS"],
+      ["Content-Type", "Authorization"]
+    );
+    this.addCors(composersResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
+    this.addCors(
+      composerResource,
       ["GET", "PUT", "DELETE", "OPTIONS"],
       ["Content-Type", "Authorization"]
     );
@@ -754,6 +804,11 @@ function handler(event) {
       concertLogsGet,
       concertLogsUpdate,
       concertLogsDelete,
+      listComposers,
+      createComposer,
+      getComposer,
+      updateComposer,
+      deleteComposer,
     ];
 
     // Lambda エラー監視：各関数ごとにアラーム作成

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -54,11 +54,17 @@ classical-music-lake/
 │   │   │   └── [id]/
 │   │   │       ├── index.vue     # 詳細
 │   │   │       └── edit.vue      # 編集
-│   │   └── pieces/               # 楽曲マスタ関連ページ
+│   │   ├── pieces/               # 楽曲マスタ関連ページ
+│   │   │   ├── index.vue         # 一覧
+│   │   │   ├── new.vue           # 新規作成
+│   │   │   └── [id]/
+│   │   │       ├── index.vue     # 詳細（動画再生 + クイックログ記録）
+│   │   │       └── edit.vue      # 編集
+│   │   └── composers/            # 作曲家マスタ関連ページ
 │   │       ├── index.vue         # 一覧
 │   │       ├── new.vue           # 新規作成
 │   │       └── [id]/
-│   │           ├── index.vue     # 詳細（動画再生 + クイックログ記録）
+│   │           ├── index.vue     # 詳細
 │   │           └── edit.vue      # 編集
 │   ├── components/               # 共通UIコンポーネント（Atomic Design: atoms / molecules / organisms / templates）
 │   ├── composables/              # Vue Composables（共通ロジック）
@@ -87,6 +93,12 @@ classical-music-lake/
 │       │   ├── update.ts
 │       │   └── delete.ts
 │       ├── pieces/               # 楽曲マスタ Lambda 関数
+│       │   ├── create.ts
+│       │   ├── list.ts
+│       │   ├── get.ts
+│       │   ├── update.ts
+│       │   └── delete.ts
+│       ├── composers/             # 作曲家マスタ Lambda 関数
 │       │   ├── create.ts
 │       │   ├── list.ts
 │       │   ├── get.ts

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -10,6 +10,8 @@
 
 - **視聴ログ管理**: CD・配信サービス等で聴いた録音の記録
 - **コンサート記録管理**: 実際に聴いたコンサートの記録（会場・指揮者・オーケストラ・ソリスト）
+- **楽曲マスタ管理**: 楽曲の登録・編集・削除（管理者のみ）
+- **作曲家マスタ管理**: 作曲家の登録・編集・削除（管理者のみ）
 - **ユーザー登録**: メールアドレスとパスワードによるアカウント作成（メール確認付き）
 
 ### 1.3 スコープ
@@ -51,23 +53,25 @@
 
 #### フロントエンド Composables
 
-| Composable         | 役割                                                                                                                                          |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useApiBase`       | API Gateway のベース URL を返す                                                                                                               |
-| `useCognitoConfig` | Cognito Hosted UI のドメインとクライアント ID を返す                                                                                          |
-| `useAuth`          | 認証処理（register・login・logout・isAuthenticated・refreshTokens・isTokenExpired・loginWithGoogle・handleOAuthCallback）                     |
-| `usePieces`        | 曲一覧を取得する                                                                                                                              |
-| `useRatingDisplay` | 評価値（0〜5）を星文字列に変換する (`ratingStars`)                                                                                            |
-| `useConcertLogs`   | コンサート記録の一覧取得（`list`）・作成（`create`）・更新（`update`）・削除（`deleteLog`）を行う。401 時にトークンリフレッシュを自動試行する |
-| `useConcertLog`    | 特定のコンサート記録を id で取得する（詳細ページ用）                                                                                          |
-| `useSubmitHandler` | フォーム送信時の `try/catch` とエラーメッセージ設定・成功後の `navigateTo` 遷移を共通化する。new/edit 系ページで使用                          |
+| Composable              | 役割                                                                                                                                          |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useApiBase`            | API Gateway のベース URL を返す                                                                                                               |
+| `useCognitoConfig`      | Cognito Hosted UI のドメインとクライアント ID を返す                                                                                          |
+| `useAuth`               | 認証処理（register・login・logout・isAuthenticated・refreshTokens・isTokenExpired・loginWithGoogle・handleOAuthCallback）                     |
+| `usePieces`             | 曲一覧を取得する                                                                                                                              |
+| `useRatingDisplay`      | 評価値（0〜5）を星文字列に変換する (`ratingStars`)                                                                                            |
+| `useConcertLogs`        | コンサート記録の一覧取得（`list`）・作成（`create`）・更新（`update`）・削除（`deleteLog`）を行う。401 時にトークンリフレッシュを自動試行する |
+| `useConcertLog`         | 特定のコンサート記録を id で取得する（詳細ページ用）                                                                                          |
+| `useComposersPaginated` | 作曲家マスタ一覧のカーソル型ページング / 無限スクロール取得・作成（`createComposer`）・更新（`updateComposer`）                               |
+| `useComposer`           | 特定の作曲家を id で取得する（詳細ページ用）                                                                                                  |
+| `useSubmitHandler`      | フォーム送信時の `try/catch` とエラーメッセージ設定・成功後の `navigateTo` 遷移を共通化する。new/edit 系ページで使用                          |
 
 #### フロントエンド レイアウト
 
-| レイアウト         | 役割                                                                                                                                                                                                                                    |
-| ------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `default` (layout) | グローバルヘッダーを含む基本レイアウト。ナビゲーションリンクは「鑑賞記録」「楽曲マスタ」「コンサート記録」。認証状態に応じて右側リンクを切り替える（未ログイン時: 新規登録・ログインリンク表示 / ログイン済み時: ログアウトボタン表示） |
-| `auth` (layout)    | 認証ページ（`/auth/login`・`/auth/user-register`・`/auth/verify-email`）用レイアウト。ホームへ戻れるロゴ付きの最小ヘッダーとフォーム用の中央寄せメイン領域を提供                                                                        |
+| レイアウト         | 役割                                                                                                                                                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default` (layout) | グローバルヘッダーを含む基本レイアウト。ナビゲーションリンクは「鑑賞記録」「楽曲マスタ」「作曲家マスタ」「コンサート記録」。認証状態に応じて右側リンクを切り替える（未ログイン時: 新規登録・ログインリンク表示 / ログイン済み時: ログアウトボタン表示） |
+| `auth` (layout)    | 認証ページ（`/auth/login`・`/auth/user-register`・`/auth/verify-email`）用レイアウト。ホームへ戻れるロゴ付きの最小ヘッダーとフォーム用の中央寄せメイン領域を提供                                                                                        |
 
 #### フロントエンド ユーティリティ
 
@@ -185,7 +189,38 @@ interface Piece {
 
 ---
 
-### 3.3 コンサート記録 (ConcertLog)
+### 3.3 作曲家マスタ (Composer)
+
+#### DynamoDBテーブル
+
+- **テーブル名**: `classical-music-composers`
+- **パーティションキー**: `id` (String)
+- **課金モード**: オンデマンド
+
+#### データ構造
+
+```typescript
+interface Composer {
+  id: string; // UUID (自動生成)
+  name: string; // 作曲家名
+  era?: PieceEra; // 時代（任意、楽曲マスタと共通の定数を流用）
+  region?: PieceRegion; // 地域（任意、楽曲マスタと共通の定数を流用）
+  createdAt: string; // 作成日時 (ISO 8601形式)
+  updatedAt: string; // 更新日時 (ISO 8601形式)
+}
+```
+
+#### バリデーション
+
+- `name`: 空文字・空白のみ不可、最大100文字
+- `era`: 任意項目。指定する場合は固定の選択肢から選択。更新時に空文字を送信するとフィールドが削除される
+- `region`: 任意項目。指定する場合は固定の選択肢から選択。更新時に空文字を送信するとフィールドが削除される
+
+> バリデーションは `utils/schemas.ts` に定義した Zod スキーマで実施する。
+
+---
+
+### 3.4 コンサート記録 (ConcertLog)
 
 #### DynamoDBテーブル
 
@@ -233,8 +268,8 @@ interface ConcertLog {
 
 - **ベースURL**: `https://{api-gateway-url}/prod`
 - **認証**: AWS Cognito User Pool (Bearer Token)
-  - 認証が必要なエンドポイント: `/listening-logs/*`、`/concert-logs/*`（読み取り・書き込み）、`/pieces` の書き込み系（`POST` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`）。書き込み系はさらに `admin` グループ必須
-  - 公開エンドポイント: `/auth/*`、`/pieces` の参照系（`GET /pieces` / `GET /pieces/{id}`）
+  - 認証が必要なエンドポイント: `/listening-logs/*`、`/concert-logs/*`（読み取り・書き込み）、`/pieces` と `/composers` の書き込み系（`POST` / `PUT /{id}` / `DELETE /{id}`）。書き込み系はさらに `admin` グループ必須
+  - 公開エンドポイント: `/auth/*`、`/pieces` と `/composers` の参照系（`GET` / `GET /{id}`）
 - **CORS**: CloudFront URL のみ許可（プリフライト・GatewayResponse の両方で設定）
 
 ### 4.2 認証API
@@ -734,7 +769,75 @@ GET /pieces?limit=50&cursor={opaque}
 - 認証ヘッダーなし・無効/期限切れトークン: `401 Unauthorized`（API Gateway Authorizer が返却）
 - 認証済みだが `admin` 非所属: `403 Forbidden` + `{ "message": "Admin privilege required" }`
 
-### 4.6 エラーレスポンス一覧
+### 4.6 作曲家マスタAPI
+
+> **認可ルール**: 参照系（`GET /composers` / `GET /composers/{id}`）は認証不要で公開。書き込み系（`POST /composers` / `PUT /composers/{id}` / `DELETE /composers/{id}`）は `admin` グループに所属する認証済みユーザーのみ実行可能。
+
+#### `GET /composers`
+
+作曲家マスタ一覧をカーソル型ページングで取得する。
+
+**リクエスト**
+
+```http
+GET /composers?limit=50&cursor={opaque}
+```
+
+| クエリパラメータ | 型     | 必須 | 既定 | 説明                                                                         |
+| ---------------- | ------ | ---- | ---- | ---------------------------------------------------------------------------- |
+| `limit`          | number | -    | 50   | 1 ページあたりの件数。最小 1、最大 100。範囲外は `400 Bad Request`           |
+| `cursor`         | string | -    | なし | 前回レスポンスで返却された `nextCursor` を指定して続きを取得。不正値は `400` |
+
+**レスポンス**
+
+- 成功: `200 OK`
+
+  ```json
+  {
+    "items": [
+      {
+        "id": "composer-uuid",
+        "name": "ベートーヴェン",
+        "era": "古典派",
+        "region": "ドイツ・オーストリア",
+        "createdAt": "2024-01-15T20:00:00.000Z",
+        "updatedAt": "2024-01-15T20:00:00.000Z"
+      }
+    ],
+    "nextCursor": "opaque-base64url-string"
+  }
+  ```
+
+- バリデーションエラー: `400 Bad Request`
+
+**ソート順**: DynamoDB Scan の戻り順（順不同）。
+
+#### `GET /composers/{id}`
+
+特定の作曲家を取得。認証不要。データ構造は 3.3 節を参照。
+
+**レスポンス**
+
+- 成功: `200 OK` + Composer オブジェクト
+- 未存在: `404 Not Found`
+
+#### `POST /composers` / `PUT /composers/{id}` / `DELETE /composers/{id}`
+
+作曲家マスタの単件作成・更新・削除。データ構造とバリデーションは 3.3 節を参照。
+
+**認可ルール**
+
+- `Authorization: Bearer {idToken}` ヘッダーが必須（API Gateway Cognito Authorizer で検証）
+- ID Token の `cognito:groups` クレームに `admin` が含まれていること
+- 認可は Cognito Authorizer（トークン検証）と Lambda ハンドラ（グループ判定）の二段構えで強制する
+
+**エラーレスポンス**
+
+- 認証ヘッダーなし・無効/期限切れトークン: `401 Unauthorized`（API Gateway Authorizer が返却）
+- 認証済みだが `admin` 非所属: `403 Forbidden` + `{ "message": "Admin privilege required" }`
+- 更新時に楽観的ロックが失敗: `409 Conflict` + `{ "message": "Composer was updated by another request" }`
+
+### 4.7 エラーレスポンス一覧
 
 全エラーレスポンスは以下の形式で返される：
 
@@ -752,7 +855,7 @@ GET /pieces?limit=50&cursor={opaque}
 | `404 Not Found`             | リソース未存在     | 指定IDの視聴ログが存在しない                                                           |
 | `500 Internal Server Error` | サーバー内部エラー | DynamoDB接続エラーなど予期しないエラー                                                 |
 
-### 4.7 データバリデーションルール
+### 4.8 データバリデーションルール
 
 #### 視聴ログ（ListeningLog）
 
@@ -779,6 +882,16 @@ GET /pieces?limit=50&cursor={opaque}
 
 > 更新時（`PUT /concert-logs/{id}`）はすべてのフィールドが任意となる（`updateConcertLogSchema` は `createConcertLogSchema.partial()` で導出）。
 
+#### 作曲家マスタ（Composer）
+
+| フィールド | 型                 | 必須 | バリデーション                    |
+| ---------- | ------------------ | ---- | --------------------------------- |
+| `name`     | string             | ✅   | 空文字・空白のみ不可、最大100文字 |
+| `era`      | PieceEra (enum)    | -    | 指定する場合は固定の選択肢から    |
+| `region`   | PieceRegion (enum) | -    | 指定する場合は固定の選択肢から    |
+
+> 更新時（`PUT /composers/{id}`）はすべてのフィールドが任意となる（`updateComposerSchema`）。`era` / `region` は空文字を送信するとフィールドが削除される。
+
 #### 自動生成フィールド（入力不可）
 
 | フィールド  | 内容                           |
@@ -801,13 +914,16 @@ GET /pieces?limit=50&cursor={opaque}
   - 削除ポリシー: RETAIN（データ保持）
 - **ConcertLogs**: `classical-music-concert-logs`
   - 削除ポリシー: prod は RETAIN、stg/dev は DESTROY
+- **Composers**: `classical-music-composers`
+  - 削除ポリシー: RETAIN（データ保持）
 
 #### Lambda
 
 - **ランタイム**: Node.js 24.x
-- **関数数**: 21個
+- **関数数**: 26個
   - 視聴ログ用 CRUD 操作 × 5
   - 楽曲マスタ用 CRUD 操作 × 5
+  - 作曲家マスタ用 CRUD 操作 × 5
   - 認証系 × 5（register・login・verify-email・resend-verification-code・refresh）
   - PreSignUp トリガー × 1
   - コンサート記録 × 5（list・create・get・update・delete）
@@ -815,6 +931,7 @@ GET /pieces?limit=50&cursor={opaque}
   - `DYNAMO_TABLE_LISTENING_LOGS`
   - `DYNAMO_TABLE_PIECES`
   - `DYNAMO_TABLE_CONCERT_LOGS`
+  - `DYNAMO_TABLE_COMPOSERS`
   - `COGNITO_USER_POOL_ID`（認証系 Lambda で使用）
   - `COGNITO_CLIENT_ID`（認証系 Lambda で使用）
 
@@ -851,9 +968,9 @@ GET /pieces?limit=50&cursor={opaque}
 - **ステージ**: `prod`
 - **CORS**: カスタムドメイン URL を許可（プリフライト・GatewayResponse の両方で設定）
 - **Cognito Authorizer 適用範囲**:
-  - 認証必須: `/listening-logs/*`、`/concert-logs/*`、`/pieces` の書き込み系（`POST` / `PUT` / `DELETE`）
-  - 認証不要: `/pieces` の参照系（`GET`）と `/auth/*`
-  - 楽曲マスタの書き込み系はさらに Lambda ハンドラ内で `admin` グループ判定を行い、非管理者には `403 Forbidden` を返す
+  - 認証必須: `/listening-logs/*`、`/concert-logs/*`、`/pieces` と `/composers` の書き込み系（`POST` / `PUT` / `DELETE`）
+  - 認証不要: `/pieces` と `/composers` の参照系（`GET`）と `/auth/*`
+  - 楽曲マスタ・作曲家マスタの書き込み系はさらに Lambda ハンドラ内で `admin` グループ判定を行い、非管理者には `403 Forbidden` を返す
 
 #### S3
 
@@ -879,6 +996,7 @@ GET /pieces?limit=50&cursor={opaque}
 - `DYNAMO_TABLE_LISTENING_LOGS`: 視聴ログテーブル名（CDK が自動設定）
 - `DYNAMO_TABLE_PIECES`: 楽曲マスタテーブル名（CDK が自動設定）
 - `DYNAMO_TABLE_CONCERT_LOGS`: コンサート記録テーブル名（CDK が自動設定）
+- `DYNAMO_TABLE_COMPOSERS`: 作曲家マスタテーブル名（CDK が自動設定）
 - `CORS_ALLOW_ORIGIN`: 許可する CORS オリジン（CDK がカスタムドメイン URL + CloudFront URL を自動設定。未設定時は `"*"` にフォールバックするが、本番・stg は CDK が必ず設定するため未設定にはならない）
 
 #### CI/CD（GitHub Secrets）
@@ -1075,6 +1193,9 @@ cdk deploy
 | `ConcertLog`              | コンサート記録（`title` は必須フィールド）                 |
 | `CreateConcertLogInput`   | コンサート記録作成入力                                     |
 | `UpdateConcertLogInput`   | コンサート記録更新入力（`Partial<CreateConcertLogInput>`） |
+| `Composer`                | 作曲家マスタ                                               |
+| `CreateComposerInput`     | 作曲家マスタ作成入力                                       |
+| `UpdateComposerInput`     | 作曲家マスタ更新入力（`Partial<CreateComposerInput>`）     |
 
 #### バックエンド固有（`backend/src/types/index.ts` にのみ存在）
 

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -41,6 +41,11 @@ export const PIECES_PAGE_SIZE_DEFAULT = 50;
 export const PIECES_ALL_MAX_TOTAL = 5000;
 export const PIECES_ALL_MAX_EMPTY_PAGES = 3;
 
+// ページネーション設定（作曲家マスタ一覧）
+export const COMPOSERS_PAGE_SIZE_MIN = 1;
+export const COMPOSERS_PAGE_SIZE_MAX = 100;
+export const COMPOSERS_PAGE_SIZE_DEFAULT = 50;
+
 // カーソル型ページング結果
 export interface Paginated<T> {
   items: T[];


### PR DESCRIPTION
- バックエンド: Composer ドメイン・リポジトリ・ユースケース・CRUDハンドラとテストを追加
- インフラ: DynamoDB テーブル・Lambda・API Gateway ルート・IAM・CORS を CDK に追加
- フロントエンド: useComposers composable・一覧/詳細/新規/編集ページ・Atomic Design コンポーネント一式を追加
- ナビゲーション: ヘッダーに「作曲家マスタ」・TOP管理者メニューに「作曲家マスタ追加」を追加
- 仕様書: SPEC.md と ARCHITECTURE.md を更新

Closes #477

https://claude.ai/code/session_01DFwS4j8zrrAEQXLWKpx7AC