### PR TITLE
fix(frontend): 作曲家・楽曲マスタの書き込み API に Authorization ヘッダを付与する

### DIFF
--- a/app/composables/useComposers.test.ts
+++ b/app/composables/useComposers.test.ts
@@ -1,0 +1,174 @@
+import { mockNuxtImport } from "@nuxt/test-utils/runtime";
+import {
+  useComposersPaginated,
+  useComposer,
+  type PaginatedComposersResponse,
+} from "./useComposers";
+import type { Composer } from "~/types";
+import { COMPOSERS_PAGE_SIZE_DEFAULT } from "~/types";
+import { ID_TOKEN_KEY } from "./useAuth";
+
+const { mockUseFetch } = vi.hoisted(() => ({
+  mockUseFetch: vi.fn(),
+}));
+
+mockUseFetch.mockReturnValue({ data: ref(null), error: ref(null), pending: ref(false) });
+
+mockNuxtImport("useApiBase", () => () => "/api");
+mockNuxtImport("useFetch", () => mockUseFetch);
+
+const mockDollarFetch = vi.fn();
+const mockFetch = vi.fn();
+const mockRouterPush = vi.fn();
+const mockRefreshTokens = vi.fn();
+
+vi.mock("#app", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock("./useAuth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./useAuth")>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      refreshTokens: mockRefreshTokens,
+      clearTokens: () => {
+        localStorage.removeItem(actual.ACCESS_TOKEN_KEY);
+        localStorage.removeItem(actual.ID_TOKEN_KEY);
+        localStorage.removeItem(actual.REFRESH_TOKEN_KEY);
+        localStorage.removeItem(actual.TOKEN_EXPIRES_AT_KEY);
+      },
+    }),
+  };
+});
+
+const makeComposer = (id: string, name = `name-${id}`): Composer => ({
+  id,
+  name,
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+});
+
+const jsonResponse = <T>(body: T, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
+beforeEach(() => {
+  vi.stubGlobal("$fetch", mockDollarFetch);
+  vi.stubGlobal("fetch", mockFetch);
+  mockDollarFetch.mockReset();
+  mockFetch.mockReset();
+  mockRouterPush.mockClear();
+  mockRefreshTokens.mockClear();
+  mockRefreshTokens.mockResolvedValue(false);
+  mockUseFetch.mockClear();
+  mockUseFetch.mockReturnValue({ data: ref(null), error: ref(null), pending: ref(false) });
+  localStorage.clear();
+});
+
+describe("useComposersPaginated", () => {
+  describe("loadMore", () => {
+    it("既定の limit を付けて /api/composers を呼ぶ", async () => {
+      mockDollarFetch.mockResolvedValueOnce({
+        items: [],
+        nextCursor: null,
+      } satisfies PaginatedComposersResponse);
+      const c = useComposersPaginated();
+      await c.loadMore();
+      expect(mockDollarFetch).toHaveBeenCalledWith("/api/composers", {
+        query: { limit: COMPOSERS_PAGE_SIZE_DEFAULT },
+      });
+    });
+
+    it("取得した items を反映し、nextCursor が null なら hasMore=false になる", async () => {
+      const composers = [makeComposer("1"), makeComposer("2")];
+      mockDollarFetch.mockResolvedValueOnce({ items: composers, nextCursor: null });
+      const c = useComposersPaginated();
+      await c.loadMore();
+      expect(c.items.value).toEqual(composers);
+      expect(c.hasMore.value).toBe(false);
+    });
+  });
+
+  describe("mutation", () => {
+    it("createComposer が正しい URL と body で POST し、Authorization ヘッダを付与する", async () => {
+      localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
+      mockFetch.mockResolvedValueOnce(jsonResponse(makeComposer("new"), 201));
+      const c = useComposersPaginated();
+      await c.createComposer({ name: "ベートーヴェン" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/composers",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ name: "ベートーヴェン" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-id-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+    });
+
+    it("updateComposer が正しい URL と body で PUT し、Authorization ヘッダを付与する", async () => {
+      localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
+      mockFetch.mockResolvedValueOnce(jsonResponse(makeComposer("123", "updated")));
+      const c = useComposersPaginated();
+      await c.updateComposer("123", { name: "updated" });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/composers/123",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ name: "updated" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-id-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+    });
+
+    it("deleteComposer が DELETE を送り Authorization ヘッダを付与する", async () => {
+      localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
+      const c = useComposersPaginated();
+      await c.deleteComposer("123");
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/composers/123",
+        expect.objectContaining({
+          method: "DELETE",
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-id-token",
+          }),
+        })
+      );
+    });
+
+    it("createComposer が 401 を返したら throwResponseError がエラーにする", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 })
+      );
+      const c = useComposersPaginated();
+      await expect(c.createComposer({ name: "x" })).rejects.toThrow();
+    });
+
+    it("createComposer 成功後に items がリセットされる", async () => {
+      mockDollarFetch.mockResolvedValueOnce({ items: [makeComposer("1")], nextCursor: null });
+      mockFetch.mockResolvedValueOnce(jsonResponse(makeComposer("2"), 201));
+      const c = useComposersPaginated();
+      await c.loadMore();
+      expect(c.items.value).toHaveLength(1);
+      await c.createComposer({ name: "x" });
+      expect(c.items.value).toEqual([]);
+      expect(c.hasMore.value).toBe(true);
+    });
+  });
+});
+
+describe("useComposer", () => {
+  it("正しい URL で useFetch を呼び出す", () => {
+    useComposer(() => "composer-123");
+    expect(mockUseFetch).toHaveBeenCalled();
+  });
+});

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,5 +1,6 @@
 import { COMPOSERS_PAGE_SIZE_DEFAULT } from "~/types";
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
+import { useAuthenticatedApi } from "./useAuthenticatedApi";
 
 /**
  * GET /composers のレスポンス形式。
@@ -17,20 +18,46 @@ const fetchPage = async (
   return $fetch<PaginatedComposersResponse>(`${apiBase}/composers`, { query });
 };
 
-const postComposer = (apiBase: string, input: CreateComposerInput): Promise<Composer> =>
-  $fetch<Composer>(`${apiBase}/composers`, { method: "POST", body: input });
-
-const putComposer = (apiBase: string, id: string, input: UpdateComposerInput): Promise<Composer> =>
-  $fetch<Composer>(`${apiBase}/composers/${id}`, { method: "PUT", body: input });
-
-const deleteComposerRequest = (apiBase: string, id: string): Promise<void> =>
-  $fetch(`${apiBase}/composers/${id}`, { method: "DELETE" });
-
 /**
  * 作曲家マスタ一覧の無限スクロール / カーソル型ページング用 composable。
  */
 export const useComposersPaginated = () => {
   const apiBase = useApiBase();
+  const { authenticatedFetch, throwResponseError, parseJsonResponse } = useAuthenticatedApi();
+
+  const postComposer = async (input: CreateComposerInput): Promise<Composer> => {
+    const response = await authenticatedFetch(`${apiBase}/composers`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+    return parseJsonResponse<Composer>(response);
+  };
+
+  const putComposer = async (id: string, input: UpdateComposerInput): Promise<Composer> => {
+    const response = await authenticatedFetch(`${apiBase}/composers/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+    return parseJsonResponse<Composer>(response);
+  };
+
+  const deleteComposerRequest = async (id: string): Promise<void> => {
+    const response = await authenticatedFetch(`${apiBase}/composers/${id}`, {
+      method: "DELETE",
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+  };
+
   const items = ref<Composer[]>([]);
   const nextCursor = ref<string | null>(null);
   const pending = ref<boolean>(false);
@@ -74,19 +101,19 @@ export const useComposersPaginated = () => {
   };
 
   const createComposer = async (input: CreateComposerInput) => {
-    const result = await postComposer(apiBase, input);
+    const result = await postComposer(input);
     reset();
     return result;
   };
 
   const updateComposer = async (id: string, input: UpdateComposerInput) => {
-    const result = await putComposer(apiBase, id, input);
+    const result = await putComposer(id, input);
     reset();
     return result;
   };
 
   const deleteComposer = async (id: string) => {
-    await deleteComposerRequest(apiBase, id);
+    await deleteComposerRequest(id);
     reset();
   };
 

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -1,6 +1,7 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { usePiecesPaginated, usePiecesAll, usePiece, type PaginatedResponse } from "./usePieces";
 import type { Piece } from "~/types";
+import { ID_TOKEN_KEY } from "./useAuth";
 import {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_ALL_MAX_EMPTY_PAGES,
@@ -16,7 +17,30 @@ mockUseFetch.mockReturnValue({ data: ref(null), error: ref(null), pending: ref(f
 mockNuxtImport("useApiBase", () => () => "/api");
 mockNuxtImport("useFetch", () => mockUseFetch);
 
+const mockDollarFetch = vi.fn();
 const mockFetch = vi.fn();
+const mockRouterPush = vi.fn();
+const mockRefreshTokens = vi.fn();
+
+vi.mock("#app", () => ({
+  useRouter: () => ({ push: mockRouterPush }),
+}));
+
+vi.mock("./useAuth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./useAuth")>();
+  return {
+    ...actual,
+    useAuth: () => ({
+      refreshTokens: mockRefreshTokens,
+      clearTokens: () => {
+        localStorage.removeItem(actual.ACCESS_TOKEN_KEY);
+        localStorage.removeItem(actual.ID_TOKEN_KEY);
+        localStorage.removeItem(actual.REFRESH_TOKEN_KEY);
+        localStorage.removeItem(actual.TOKEN_EXPIRES_AT_KEY);
+      },
+    }),
+  };
+});
 
 const makePiece = (id: string, title = `title-${id}`): Piece => ({
   id,
@@ -26,15 +50,27 @@ const makePiece = (id: string, title = `title-${id}`): Piece => ({
   updatedAt: "2024-01-01T00:00:00.000Z",
 });
 
+const jsonResponse = <T>(body: T, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+
 const flush = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
 beforeEach(() => {
-  vi.stubGlobal("$fetch", mockFetch);
+  vi.stubGlobal("$fetch", mockDollarFetch);
+  vi.stubGlobal("fetch", mockFetch);
+  mockDollarFetch.mockReset();
   mockFetch.mockReset();
+  mockRouterPush.mockClear();
+  mockRefreshTokens.mockClear();
+  mockRefreshTokens.mockResolvedValue(false);
   mockUseFetch.mockClear();
   mockUseFetch.mockReturnValue({ data: ref(null), error: ref(null), pending: ref(false) });
+  localStorage.clear();
 });
 
 describe("usePiecesPaginated", () => {
@@ -48,20 +84,20 @@ describe("usePiecesPaginated", () => {
     });
 
     it("loadMore で既定の limit を付けて /api/pieces を呼ぶ", async () => {
-      mockFetch.mockResolvedValueOnce({
+      mockDollarFetch.mockResolvedValueOnce({
         items: [],
         nextCursor: null,
       } satisfies PaginatedResponse<Piece>);
       const p = usePiecesPaginated();
       await p.loadMore();
-      expect(mockFetch).toHaveBeenCalledWith("/api/pieces", {
+      expect(mockDollarFetch).toHaveBeenCalledWith("/api/pieces", {
         query: { limit: PIECES_PAGE_SIZE_DEFAULT },
       });
     });
 
     it("取得した items を反映し、nextCursor が null なら hasMore=false になる", async () => {
       const pieces = [makePiece("1"), makePiece("2")];
-      mockFetch.mockResolvedValueOnce({ items: pieces, nextCursor: null });
+      mockDollarFetch.mockResolvedValueOnce({ items: pieces, nextCursor: null });
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.items.value).toEqual(pieces);
@@ -71,30 +107,30 @@ describe("usePiecesPaginated", () => {
     it("複数回の loadMore で items を追記する", async () => {
       const page1 = [makePiece("1")];
       const page2 = [makePiece("2")];
-      mockFetch
+      mockDollarFetch
         .mockResolvedValueOnce({ items: page1, nextCursor: "cursor-1" })
         .mockResolvedValueOnce({ items: page2, nextCursor: null });
       const p = usePiecesPaginated();
       await p.loadMore();
       await p.loadMore();
       expect(p.items.value).toEqual([...page1, ...page2]);
-      expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/pieces", {
+      expect(mockDollarFetch).toHaveBeenNthCalledWith(2, "/api/pieces", {
         query: { limit: PIECES_PAGE_SIZE_DEFAULT, cursor: "cursor-1" },
       });
     });
 
     it("hasMore=false になったら loadMore を呼んでもリクエストを発行しない", async () => {
-      mockFetch.mockResolvedValueOnce({ items: [], nextCursor: null });
+      mockDollarFetch.mockResolvedValueOnce({ items: [], nextCursor: null });
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.hasMore.value).toBe(false);
       await p.loadMore();
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockDollarFetch).toHaveBeenCalledTimes(1);
     });
 
     it("pending 中に loadMore を呼んでも二重発行しない", async () => {
       let resolvePage: ((value: PaginatedResponse<Piece>) => void) | undefined;
-      mockFetch.mockReturnValueOnce(
+      mockDollarFetch.mockReturnValueOnce(
         new Promise<PaginatedResponse<Piece>>((resolve) => {
           resolvePage = resolve;
         })
@@ -106,13 +142,13 @@ describe("usePiecesPaginated", () => {
       resolvePage?.({ items: [makePiece("1")], nextCursor: null });
       await first;
       await second;
-      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockDollarFetch).toHaveBeenCalledTimes(1);
     });
   });
 
   describe("エラーと retry", () => {
     it("fetch が失敗すると error に反映される", async () => {
-      mockFetch.mockRejectedValueOnce(new Error("network"));
+      mockDollarFetch.mockRejectedValueOnce(new Error("network"));
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.error.value).toBeInstanceOf(Error);
@@ -120,7 +156,7 @@ describe("usePiecesPaginated", () => {
     });
 
     it("retry 後に再度成功すれば items に反映される", async () => {
-      mockFetch
+      mockDollarFetch
         .mockRejectedValueOnce(new Error("network"))
         .mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null });
       const p = usePiecesPaginated();
@@ -134,7 +170,7 @@ describe("usePiecesPaginated", () => {
 
   describe("reset と mutation", () => {
     it("reset を呼ぶと items・nextCursor・error がリセットされる", async () => {
-      mockFetch.mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: "c1" });
+      mockDollarFetch.mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: "c1" });
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.items.value).toHaveLength(1);
@@ -145,9 +181,8 @@ describe("usePiecesPaginated", () => {
     });
 
     it("createPiece 成功後に items が空にリセットされる", async () => {
-      mockFetch
-        .mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null })
-        .mockResolvedValueOnce(makePiece("2"));
+      mockDollarFetch.mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null });
+      mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("2"), 201));
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.items.value).toHaveLength(1);
@@ -157,63 +192,86 @@ describe("usePiecesPaginated", () => {
     });
 
     it("updatePiece 成功後に items が空にリセットされる", async () => {
-      mockFetch
-        .mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null })
-        .mockResolvedValueOnce(makePiece("1", "updated"));
+      mockDollarFetch.mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null });
+      mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("1", "updated")));
       const p = usePiecesPaginated();
       await p.loadMore();
       await p.updatePiece("1", { title: "updated" });
       expect(p.items.value).toEqual([]);
     });
 
-    it("createPiece が正しい URL と body で POST する", async () => {
-      mockFetch.mockResolvedValueOnce(makePiece("new"));
+    it("createPiece が正しい URL と body で POST し、Authorization ヘッダを付与する", async () => {
+      localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
+      mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("new"), 201));
       const p = usePiecesPaginated();
       await p.createPiece({ title: "new", composer: "c" });
-      expect(mockFetch).toHaveBeenCalledWith("/api/pieces", {
-        method: "POST",
-        body: { title: "new", composer: "c" },
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/pieces",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ title: "new", composer: "c" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-id-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
     });
 
-    it("updatePiece が正しい URL と body で PUT する", async () => {
-      mockFetch.mockResolvedValueOnce(makePiece("123", "updated"));
+    it("updatePiece が正しい URL と body で PUT し、Authorization ヘッダを付与する", async () => {
+      localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
+      mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("123", "updated")));
       const p = usePiecesPaginated();
       await p.updatePiece("123", { title: "updated" });
-      expect(mockFetch).toHaveBeenCalledWith("/api/pieces/123", {
-        method: "PUT",
-        body: { title: "updated" },
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/pieces/123",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ title: "updated" }),
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-id-token",
+            "Content-Type": "application/json",
+          }),
+        })
+      );
+    });
+
+    it("createPiece が 401 を返したら throwResponseError がエラーにする", async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 })
+      );
+      const p = usePiecesPaginated();
+      await expect(p.createPiece({ title: "x", composer: "c" })).rejects.toThrow();
     });
   });
 });
 
 describe("usePiecesAll", () => {
   it("auto-paginate で全ページを取得し data に集約する", async () => {
-    mockFetch
+    mockDollarFetch
       .mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: "c1" })
       .mockResolvedValueOnce({ items: [makePiece("2"), makePiece("3")], nextCursor: null });
     const p = usePiecesAll();
     await p.refresh();
     expect(p.data.value).toHaveLength(3);
     expect(p.pending.value).toBe(false);
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockDollarFetch).toHaveBeenCalledTimes(2);
   });
 
   it("nextCursor を次回リクエストに引き継ぐ", async () => {
-    mockFetch
+    mockDollarFetch
       .mockResolvedValueOnce({ items: [], nextCursor: "c1" })
       .mockResolvedValueOnce({ items: [], nextCursor: null });
     const p = usePiecesAll();
     await p.refresh();
-    expect(mockFetch).toHaveBeenNthCalledWith(2, "/api/pieces", {
+    expect(mockDollarFetch).toHaveBeenNthCalledWith(2, "/api/pieces", {
       query: { limit: PIECES_PAGE_SIZE_DEFAULT, cursor: "c1" },
     });
   });
 
   it(`連続 ${PIECES_ALL_MAX_EMPTY_PAGES + 1} 回の空応答が続くと error にする`, async () => {
     for (let i = 0; i <= PIECES_ALL_MAX_EMPTY_PAGES; i += 1) {
-      mockFetch.mockResolvedValueOnce({ items: [], nextCursor: `c${i}` });
+      mockDollarFetch.mockResolvedValueOnce({ items: [], nextCursor: `c${i}` });
     }
     const p = usePiecesAll();
     await p.refresh();
@@ -222,7 +280,7 @@ describe("usePiecesAll", () => {
 
   it(`総件数が上限 ${PIECES_ALL_MAX_TOTAL} を超えると error にする`, async () => {
     const bigPage = Array.from({ length: 2500 }, (_, i) => makePiece(String(i)));
-    mockFetch
+    mockDollarFetch
       .mockResolvedValueOnce({ items: bigPage, nextCursor: "c1" })
       .mockResolvedValueOnce({ items: bigPage, nextCursor: "c2" })
       .mockResolvedValueOnce({ items: bigPage, nextCursor: "c3" });
@@ -232,17 +290,17 @@ describe("usePiecesAll", () => {
   });
 
   it("fetch 失敗時に error が設定される", async () => {
-    mockFetch.mockRejectedValueOnce(new Error("boom"));
+    mockDollarFetch.mockRejectedValueOnce(new Error("boom"));
     const p = usePiecesAll();
     await p.refresh();
     expect(p.error.value).toBeInstanceOf(Error);
   });
 
   it("createPiece が refresh を引き起こす", async () => {
-    mockFetch
+    mockDollarFetch
       .mockResolvedValueOnce({ items: [makePiece("1")], nextCursor: null })
-      .mockResolvedValueOnce(makePiece("2"))
       .mockResolvedValueOnce({ items: [makePiece("1"), makePiece("2")], nextCursor: null });
+    mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("2"), 201));
     const p = usePiecesAll();
     await p.refresh();
     expect(p.data.value).toHaveLength(1);

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -4,6 +4,7 @@ import {
   PIECES_PAGE_SIZE_DEFAULT,
 } from "~/types";
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "~/types";
+import { useAuthenticatedApi } from "./useAuthenticatedApi";
 
 /**
  * GET /pieces のレスポンス形式。
@@ -21,11 +22,36 @@ const fetchPage = async (
   return $fetch<PaginatedResponse<Piece>>(`${apiBase}/pieces`, { query });
 };
 
-const postPiece = (apiBase: string, input: CreatePieceInput): Promise<Piece> =>
-  $fetch<Piece>(`${apiBase}/pieces`, { method: "POST", body: input });
+const usePieceMutations = () => {
+  const apiBase = useApiBase();
+  const { authenticatedFetch, throwResponseError, parseJsonResponse } = useAuthenticatedApi();
 
-const putPiece = (apiBase: string, id: string, input: UpdatePieceInput): Promise<Piece> =>
-  $fetch<Piece>(`${apiBase}/pieces/${id}`, { method: "PUT", body: input });
+  const postPiece = async (input: CreatePieceInput): Promise<Piece> => {
+    const response = await authenticatedFetch(`${apiBase}/pieces`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+    return parseJsonResponse<Piece>(response);
+  };
+
+  const putPiece = async (id: string, input: UpdatePieceInput): Promise<Piece> => {
+    const response = await authenticatedFetch(`${apiBase}/pieces/${id}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(input),
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+    return parseJsonResponse<Piece>(response);
+  };
+
+  return { postPiece, putPiece };
+};
 
 /**
  * 楽曲マスタ一覧の無限スクロール / カーソル型ページング用 composable。
@@ -36,6 +62,7 @@ const putPiece = (apiBase: string, id: string, input: UpdatePieceInput): Promise
  */
 export const usePiecesPaginated = () => {
   const apiBase = useApiBase();
+  const { postPiece, putPiece } = usePieceMutations();
   const items = ref<Piece[]>([]);
   const nextCursor = ref<string | null>(null);
   const pending = ref<boolean>(false);
@@ -79,13 +106,13 @@ export const usePiecesPaginated = () => {
   };
 
   const createPiece = async (input: CreatePieceInput) => {
-    const result = await postPiece(apiBase, input);
+    const result = await postPiece(input);
     reset();
     return result;
   };
 
   const updatePiece = async (id: string, input: UpdatePieceInput) => {
-    const result = await putPiece(apiBase, id, input);
+    const result = await putPiece(id, input);
     reset();
     return result;
   };
@@ -117,6 +144,7 @@ export const usePiecesPaginated = () => {
  */
 export const usePiecesAll = () => {
   const apiBase = useApiBase();
+  const { postPiece, putPiece } = usePieceMutations();
   const data = ref<Piece[] | null>(null);
   const pending = ref<boolean>(false);
   const error = ref<Error | null>(null);
@@ -158,13 +186,13 @@ export const usePiecesAll = () => {
   };
 
   const createPiece = async (input: CreatePieceInput) => {
-    const result = await postPiece(apiBase, input);
+    const result = await postPiece(input);
     await refresh();
     return result;
   };
 
   const updatePiece = async (id: string, input: UpdatePieceInput) => {
-    const result = await putPiece(apiBase, id, input);
+    const result = await putPiece(id, input);
     await refresh();
     return result;
   };


### PR DESCRIPTION
## Summary
- `useComposers.ts` / `usePieces.ts` の POST/PUT/DELETE が素の `$fetch` で呼ばれており、Authorization ヘッダ無しで API に送られていた
- API Gateway の Cognito Authorizer が 401 を返し、stg 環境で作曲家マスタ（例: ベートーヴェン）の追加が常に失敗していた
- `useAuthenticatedApi().authenticatedFetch` 経由に置き換え、ID Token を Bearer 付与。401 時のトークンリフレッシュも乗る
- ユニットテストで Authorization ヘッダ送信を明示的に検証（`useComposers.test.ts` 新規、`usePieces.test.ts` 更新）

## 再現手順（修正前）
1. stg にログイン（admin グループ所属ユーザー）
2. `/composers/new` でベートーヴェンを登録
3. → 「登録に失敗しました。入力内容を確認してください。」と表示
4. ネットワークログ上は `POST /stg/composers` が **401 Unauthorized**、Authorization ヘッダ無し

## Test plan
- [x] `pnpm run test:frontend` → 95 files / 657 tests 緑
- [x] `pnpm run test:backend` → 36 files / 494 tests 緑
- [x] `pnpm run lint` → 通過
- [ ] マージ後に stg へ自動デプロイされた状態で `/composers/new` から実際に登録できることを確認
- [ ] 同様に `/pieces/new` から楽曲追加も確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)