### PR TITLE
refactor(composable): ミューテーションとページング状態を共通ヘルパーへ集約

### DIFF
--- a/app/composables/useAuthenticatedApi.ts
+++ b/app/composables/useAuthenticatedApi.ts
@@ -87,11 +87,37 @@ export const useAuthenticatedApi = () => {
     return response;
   };
 
+  const sendJson = async <T>(method: "POST" | "PUT", url: string, body: unknown): Promise<T> => {
+    const response = await authenticatedFetch(url, {
+      method,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+    return parseJsonResponse<T>(response);
+  };
+
+  const postJson = <T>(url: string, body: unknown): Promise<T> => sendJson<T>("POST", url, body);
+
+  const putJson = <T>(url: string, body: unknown): Promise<T> => sendJson<T>("PUT", url, body);
+
+  const deleteResource = async (url: string): Promise<void> => {
+    const response = await authenticatedFetch(url, { method: "DELETE" });
+    if (!response.ok) {
+      return throwResponseError(response);
+    }
+  };
+
   return {
     getAuthHeaders,
     handleAuthError,
     throwResponseError,
     parseJsonResponse,
     authenticatedFetch,
+    postJson,
+    putJson,
+    deleteResource,
   };
 };

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,6 +1,7 @@
 import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "~/types";
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
+import { usePaginatedList } from "./usePaginatedList";
 
 /**
  * GET /composers のレスポンス形式。
@@ -23,113 +24,36 @@ const fetchPage = async (
  */
 export const useComposersPaginated = () => {
   const apiBase = useApiBase();
-  const { authenticatedFetch, throwResponseError, parseJsonResponse } = useAuthenticatedApi();
+  const { postJson, putJson, deleteResource } = useAuthenticatedApi();
 
-  const postComposer = async (input: CreateComposerInput): Promise<Composer> => {
-    const response = await authenticatedFetch(`${apiBase}/composers`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
-    return parseJsonResponse<Composer>(response);
-  };
+  const postComposer = (input: CreateComposerInput): Promise<Composer> =>
+    postJson<Composer>(`${apiBase}/composers`, input);
 
-  const putComposer = async (id: string, input: UpdateComposerInput): Promise<Composer> => {
-    const response = await authenticatedFetch(`${apiBase}/composers/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
-    return parseJsonResponse<Composer>(response);
-  };
+  const putComposer = (id: string, input: UpdateComposerInput): Promise<Composer> =>
+    putJson<Composer>(`${apiBase}/composers/${id}`, input);
 
-  const deleteComposerRequest = async (id: string): Promise<void> => {
-    const response = await authenticatedFetch(`${apiBase}/composers/${id}`, {
-      method: "DELETE",
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
-  };
-
-  const items = ref<Composer[]>([]);
-  const nextCursor = ref<string | null>(null);
-  const pending = ref<boolean>(false);
-  const error = ref<Error | null>(null);
-  const hasMore = ref<boolean>(true);
-
-  const loadMore = async () => {
-    if (pending.value === true) {
-      return;
-    }
-    if (hasMore.value === false) {
-      return;
-    }
-    pending.value = true;
-    error.value = null;
-    try {
-      const res = await fetchPage(apiBase, {
-        limit: COMPOSERS_PAGE_SIZE_DEFAULT,
-        cursor: nextCursor.value ?? undefined,
-      });
-      items.value = [...items.value, ...res.items];
-      nextCursor.value = res.nextCursor;
-      hasMore.value = res.nextCursor !== null;
-    } catch (err) {
-      error.value = err instanceof Error ? err : new Error(String(err));
-    } finally {
-      pending.value = false;
-    }
-  };
-
-  const reset = () => {
-    items.value = [];
-    nextCursor.value = null;
-    hasMore.value = true;
-    error.value = null;
-  };
-
-  const retry = async () => {
-    error.value = null;
-    await loadMore();
-  };
+  const pagination = usePaginatedList<Composer>((cursor) =>
+    fetchPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_DEFAULT, cursor })
+  );
 
   const createComposer = async (input: CreateComposerInput) => {
     const result = await postComposer(input);
-    reset();
+    pagination.reset();
     return result;
   };
 
   const updateComposer = async (id: string, input: UpdateComposerInput) => {
     const result = await putComposer(id, input);
-    reset();
+    pagination.reset();
     return result;
   };
 
   const deleteComposer = async (id: string) => {
-    await deleteComposerRequest(id);
-    reset();
+    await deleteResource(`${apiBase}/composers/${id}`);
+    pagination.reset();
   };
 
-  return {
-    items,
-    nextCursor,
-    pending,
-    error,
-    hasMore,
-    loadMore,
-    reset,
-    retry,
-    createComposer,
-    updateComposer,
-    deleteComposer,
-  };
+  return { ...pagination, createComposer, updateComposer, deleteComposer };
 };
 
 export const useComposer = (id: () => string) => {

--- a/app/composables/useCrudResource.ts
+++ b/app/composables/useCrudResource.ts
@@ -7,13 +7,8 @@ import { useAuthenticatedApi } from "./useAuthenticatedApi";
  */
 export const useCrudResource = <TEntity, TCreateInput, TUpdateInput>(resourceName: string) => {
   const apiBase = useApiBase();
-  const {
-    getAuthHeaders,
-    handleAuthError,
-    throwResponseError,
-    parseJsonResponse,
-    authenticatedFetch,
-  } = useAuthenticatedApi();
+  const { getAuthHeaders, handleAuthError, postJson, putJson, deleteResource } =
+    useAuthenticatedApi();
 
   const baseUrl = `${apiBase}/${resourceName}`;
 
@@ -29,38 +24,19 @@ export const useCrudResource = <TEntity, TCreateInput, TUpdateInput>(resourceNam
   });
 
   const create = async (input: TCreateInput): Promise<TEntity> => {
-    const response = await authenticatedFetch(baseUrl, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
+    const result = await postJson<TEntity>(baseUrl, input);
     clearNuxtData();
-    return parseJsonResponse<TEntity>(response);
+    return result;
   };
 
   const update = async (id: string, input: TUpdateInput): Promise<TEntity> => {
-    const response = await authenticatedFetch(`${baseUrl}/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
+    const result = await putJson<TEntity>(`${baseUrl}/${id}`, input);
     clearNuxtData();
-    return parseJsonResponse<TEntity>(response);
+    return result;
   };
 
   const deleteItem = async (id: string): Promise<void> => {
-    const response = await authenticatedFetch(`${baseUrl}/${id}`, {
-      method: "DELETE",
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
+    await deleteResource(`${baseUrl}/${id}`);
     clearNuxtData();
   };
 

--- a/app/composables/usePaginatedList.ts
+++ b/app/composables/usePaginatedList.ts
@@ -1,0 +1,49 @@
+/**
+ * 汎用のカーソル型ページング state machine。
+ * `items / nextCursor / pending / error / hasMore` をリアクティブに公開し、
+ * `loadMore / reset / retry` を提供する。個別リソース側は `fetchPage` のみ実装すれば良い。
+ */
+export type PageResult<T> = { items: T[]; nextCursor: string | null };
+
+export const usePaginatedList = <T>(fetchPage: (cursor?: string) => Promise<PageResult<T>>) => {
+  const items = ref<T[]>([]);
+  const nextCursor = ref<string | null>(null);
+  const pending = ref<boolean>(false);
+  const error = ref<Error | null>(null);
+  const hasMore = ref<boolean>(true);
+
+  const loadMore = async () => {
+    if (pending.value === true) {
+      return;
+    }
+    if (hasMore.value === false) {
+      return;
+    }
+    pending.value = true;
+    error.value = null;
+    try {
+      const res = await fetchPage(nextCursor.value ?? undefined);
+      items.value = [...items.value, ...res.items] as typeof items.value;
+      nextCursor.value = res.nextCursor;
+      hasMore.value = res.nextCursor !== null;
+    } catch (err) {
+      error.value = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      pending.value = false;
+    }
+  };
+
+  const reset = () => {
+    items.value = [];
+    nextCursor.value = null;
+    hasMore.value = true;
+    error.value = null;
+  };
+
+  const retry = async () => {
+    error.value = null;
+    await loadMore();
+  };
+
+  return { items, nextCursor, pending, error, hasMore, loadMore, reset, retry };
+};

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -5,6 +5,7 @@ import {
 } from "~/types";
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
+import { usePaginatedList } from "./usePaginatedList";
 
 /**
  * GET /pieces のレスポンス形式。
@@ -24,31 +25,13 @@ const fetchPage = async (
 
 const usePieceMutations = () => {
   const apiBase = useApiBase();
-  const { authenticatedFetch, throwResponseError, parseJsonResponse } = useAuthenticatedApi();
+  const { postJson, putJson } = useAuthenticatedApi();
 
-  const postPiece = async (input: CreatePieceInput): Promise<Piece> => {
-    const response = await authenticatedFetch(`${apiBase}/pieces`, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
-    return parseJsonResponse<Piece>(response);
-  };
+  const postPiece = (input: CreatePieceInput): Promise<Piece> =>
+    postJson<Piece>(`${apiBase}/pieces`, input);
 
-  const putPiece = async (id: string, input: UpdatePieceInput): Promise<Piece> => {
-    const response = await authenticatedFetch(`${apiBase}/pieces/${id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(input),
-    });
-    if (!response.ok) {
-      return throwResponseError(response);
-    }
-    return parseJsonResponse<Piece>(response);
-  };
+  const putPiece = (id: string, input: UpdatePieceInput): Promise<Piece> =>
+    putJson<Piece>(`${apiBase}/pieces/${id}`, input);
 
   return { postPiece, putPiece };
 };
@@ -63,72 +46,23 @@ const usePieceMutations = () => {
 export const usePiecesPaginated = () => {
   const apiBase = useApiBase();
   const { postPiece, putPiece } = usePieceMutations();
-  const items = ref<Piece[]>([]);
-  const nextCursor = ref<string | null>(null);
-  const pending = ref<boolean>(false);
-  const error = ref<Error | null>(null);
-  const hasMore = ref<boolean>(true);
-
-  const loadMore = async () => {
-    if (pending.value === true) {
-      return;
-    }
-    if (hasMore.value === false) {
-      return;
-    }
-    pending.value = true;
-    error.value = null;
-    try {
-      const res = await fetchPage(apiBase, {
-        limit: PIECES_PAGE_SIZE_DEFAULT,
-        cursor: nextCursor.value ?? undefined,
-      });
-      items.value = [...items.value, ...res.items];
-      nextCursor.value = res.nextCursor;
-      hasMore.value = res.nextCursor !== null;
-    } catch (err) {
-      error.value = err instanceof Error ? err : new Error(String(err));
-    } finally {
-      pending.value = false;
-    }
-  };
-
-  const reset = () => {
-    items.value = [];
-    nextCursor.value = null;
-    hasMore.value = true;
-    error.value = null;
-  };
-
-  const retry = async () => {
-    error.value = null;
-    await loadMore();
-  };
+  const pagination = usePaginatedList<Piece>((cursor) =>
+    fetchPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor })
+  );
 
   const createPiece = async (input: CreatePieceInput) => {
     const result = await postPiece(input);
-    reset();
+    pagination.reset();
     return result;
   };
 
   const updatePiece = async (id: string, input: UpdatePieceInput) => {
     const result = await putPiece(id, input);
-    reset();
+    pagination.reset();
     return result;
   };
 
-  return {
-    items,
-    nextCursor,
-    pending,
-    error,
-    hasMore,
-    loadMore,
-    reset,
-    retry,
-    createPiece,
-    updatePiece,
-  };
+  return { ...pagination, createPiece, updatePiece };
 };
 
 /**


### PR DESCRIPTION
- useAuthenticatedApi に postJson/putJson/deleteResource を追加し、POST/PUT/DELETE
  の fetch・エラーハンドリング・JSON パースを一本化
- usePaginatedList を新設し、items/nextCursor/pending/error/hasMore と
  loadMore/reset/retry の状態機械を汎用化
- usePieces・useComposers・useCrudResource を新ヘルパーで書き換え、
  重複していた mutation 実装とページング実装を削減