### PR TITLE
feat(cdk): メンテナンスモードで CloudFront を閉じる機能を追加 (#528)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,11 +20,6 @@ on:
           - dev
           - stg
           - prod
-      maintenance_mode:
-        description: "メンテナンスモード (CloudFront を閉じて 503 を返す)"
-        required: false
-        default: false
-        type: boolean
 
 concurrency:
   group: deploy-${{ github.ref }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,6 +20,11 @@ on:
           - dev
           - stg
           - prod
+      maintenance_mode:
+        description: "メンテナンスモード (CloudFront を閉じて 503 を返す)"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: deploy-${{ github.ref }}
@@ -163,6 +168,9 @@ jobs:
           STAGE_NAME: ${{ env.STAGE_NAME }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          # workflow_dispatch の maintenance_mode 入力が true のときだけ CloudFront を閉じる。
+          # その他のトリガー（push/release）では常に空文字列となり通常デプロイになる。
+          MAINTENANCE_MODE: ${{ github.event.inputs.maintenance_mode }}
 
       # ----------------------------------------
       # CDK デプロイ後にスタック出力を取得

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,9 +163,6 @@ jobs:
           STAGE_NAME: ${{ env.STAGE_NAME }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-          # workflow_dispatch の maintenance_mode 入力が true のときだけ CloudFront を閉じる。
-          # その他のトリガー（push/release）では常に空文字列となり通常デプロイになる。
-          MAINTENANCE_MODE: ${{ github.event.inputs.maintenance_mode }}
 
       # ----------------------------------------
       # CDK デプロイ後にスタック出力を取得

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
     "stryker": "stryker run"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudfront": "^3.1030.0",
     "@aws-sdk/client-cognito-identity-provider": "^3.1030.0",
     "@aws-sdk/client-dynamodb": "^3.1030.0",
     "@aws-sdk/lib-dynamodb": "^3.1030.0",

--- a/backend/src/handlers/maintenance/build-function-code.ts
+++ b/backend/src/handlers/maintenance/build-function-code.ts
@@ -1,0 +1,59 @@
+/**
+ * CloudFront Function (JS 2.0) のソースコードを生成する。
+ *
+ * - `enabled=true`: 全リクエストに 503 メンテナンスページを即時返却する
+ * - `enabled=false`: 通常動作（`/storybook/`・`/storybook` を `/storybook/index.html` にリライト）
+ *
+ * 同一の関数コードを CDK（初期デプロイ）と Toggle Lambda（ランタイム切替）の両方から使うため、
+ * この 1 ファイルに集約する。CDK の tsconfig が `cdk/` 配下しか見ないため、
+ * CDK 側には同等の最小実装を別途用意している（drift に注意）。
+ */
+
+const MAINTENANCE_HTML = `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>メンテナンス中 - Nocturne</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; background: #0f1729; color: #e5e7eb; margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .card { max-width: 480px; text-align: center; }
+  h1 { font-size: 28px; margin: 0 0 16px; color: #fff; }
+  p { line-height: 1.7; color: #cbd5e1; margin: 0; }
+</style>
+</head>
+<body>
+<div class="card">
+<h1>メンテナンス中</h1>
+<p>ただいまシステムメンテナンスを実施しています。<br>ご不便をおかけいたしますが、しばらくお待ちください。</p>
+</div>
+</body>
+</html>`;
+
+export function buildMaintenanceFunctionCode(enabled: boolean): string {
+  return `
+function handler(event) {
+  var MAINTENANCE = ${enabled ? "true" : "false"};
+  var request = event.request;
+  if (MAINTENANCE) {
+    return {
+      statusCode: 503,
+      statusDescription: 'Service Unavailable',
+      headers: {
+        'content-type': { value: 'text/html; charset=utf-8' },
+        'cache-control': { value: 'no-store' }
+      },
+      body: ${JSON.stringify(MAINTENANCE_HTML)}
+    };
+  }
+  if (request.uri === '/storybook/' || request.uri === '/storybook') {
+    request.uri = '/storybook/index.html';
+  }
+  return request;
+}
+`.trim();
+}
+
+export function isMaintenanceEnabled(code: string): boolean {
+  return /var\s+MAINTENANCE\s*=\s*true/.test(code);
+}

--- a/backend/src/handlers/maintenance/toggle.test.ts
+++ b/backend/src/handlers/maintenance/toggle.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  DescribeFunctionCommand,
+  PublishFunctionCommand,
+  UpdateFunctionCommand,
+} from "@aws-sdk/client-cloudfront";
+
+import { buildMaintenanceFunctionCode, isMaintenanceEnabled } from "./build-function-code";
+import { toggleMaintenance } from "./toggle";
+
+const FUNCTION_NAME = "MaintenanceFunction";
+
+function makeDeps(overrides?: Partial<{ send: ReturnType<typeof vi.fn> }>) {
+  const send = overrides?.send ?? vi.fn();
+  return { client: { send } as never, functionName: FUNCTION_NAME, send };
+}
+
+describe("toggleMaintenance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("enabled=true で UpdateFunction/PublishFunction を呼び出し、生成コードが 503 を返す形式になる", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ETag: "etag-describe",
+        FunctionSummary: {
+          FunctionConfig: { Runtime: "cloudfront-js-2.0", Comment: "stored-comment" },
+        },
+      })
+      .mockResolvedValueOnce({ ETag: "etag-update" })
+      .mockResolvedValueOnce({});
+
+    const { client } = makeDeps({ send });
+
+    const result = await toggleMaintenance(
+      { client, functionName: FUNCTION_NAME },
+      { enabled: true }
+    );
+
+    expect(result).toEqual({
+      enabled: true,
+      functionName: FUNCTION_NAME,
+      message: expect.stringContaining("enabled"),
+    });
+
+    expect(send).toHaveBeenCalledTimes(3);
+
+    const describeCall = send.mock.calls[0][0] as DescribeFunctionCommand;
+    expect(describeCall).toBeInstanceOf(DescribeFunctionCommand);
+    expect(describeCall.input).toEqual({ Name: FUNCTION_NAME, Stage: "DEVELOPMENT" });
+
+    const updateCall = send.mock.calls[1][0] as UpdateFunctionCommand;
+    expect(updateCall).toBeInstanceOf(UpdateFunctionCommand);
+    expect(updateCall.input.Name).toBe(FUNCTION_NAME);
+    expect(updateCall.input.IfMatch).toBe("etag-describe");
+    expect(updateCall.input.FunctionConfig).toEqual({
+      Runtime: "cloudfront-js-2.0",
+      Comment: "stored-comment",
+    });
+    const encoded = updateCall.input.FunctionCode as Uint8Array;
+    const decoded = new TextDecoder().decode(encoded);
+    expect(isMaintenanceEnabled(decoded)).toBe(true);
+    expect(decoded).toContain("statusCode: 503");
+
+    const publishCall = send.mock.calls[2][0] as PublishFunctionCommand;
+    expect(publishCall).toBeInstanceOf(PublishFunctionCommand);
+    expect(publishCall.input).toEqual({ Name: FUNCTION_NAME, IfMatch: "etag-update" });
+  });
+
+  it("enabled=false のとき生成コードがストーリーブックリライトを含む通常動作になる", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ETag: "e1",
+        FunctionSummary: { FunctionConfig: { Runtime: "cloudfront-js-2.0", Comment: "c" } },
+      })
+      .mockResolvedValueOnce({ ETag: "e2" })
+      .mockResolvedValueOnce({});
+
+    const { client } = makeDeps({ send });
+
+    await toggleMaintenance({ client, functionName: FUNCTION_NAME }, { enabled: false });
+
+    const updateCall = send.mock.calls[1][0] as UpdateFunctionCommand;
+    const decoded = new TextDecoder().decode(updateCall.input.FunctionCode as Uint8Array);
+    expect(isMaintenanceEnabled(decoded)).toBe(false);
+    expect(decoded).toContain("/storybook/index.html");
+  });
+
+  it("enabled が boolean 以外のとき例外を投げる", async () => {
+    const send = vi.fn();
+    await expect(
+      toggleMaintenance(
+        { client: { send } as never, functionName: FUNCTION_NAME },
+        { enabled: "yes" as never }
+      )
+    ).rejects.toThrow(/enabled: boolean/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("DescribeFunction が ETag を返さない場合は例外を投げる", async () => {
+    const send = vi.fn().mockResolvedValueOnce({ ETag: undefined });
+    await expect(
+      toggleMaintenance(
+        { client: { send } as never, functionName: FUNCTION_NAME },
+        { enabled: true }
+      )
+    ).rejects.toThrow(/ETag/);
+  });
+
+  it("UpdateFunction が ETag を返さない場合は PublishFunction を呼ばず例外を投げる", async () => {
+    const send = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ETag: "e1",
+        FunctionSummary: { FunctionConfig: { Runtime: "cloudfront-js-2.0", Comment: "c" } },
+      })
+      .mockResolvedValueOnce({ ETag: undefined });
+    await expect(
+      toggleMaintenance(
+        { client: { send } as never, functionName: FUNCTION_NAME },
+        { enabled: true }
+      )
+    ).rejects.toThrow(/UpdateFunction/);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("buildMaintenanceFunctionCode", () => {
+  it("enabled=true と enabled=false で出力が異なる", () => {
+    const on = buildMaintenanceFunctionCode(true);
+    const off = buildMaintenanceFunctionCode(false);
+    expect(on).not.toBe(off);
+    expect(isMaintenanceEnabled(on)).toBe(true);
+    expect(isMaintenanceEnabled(off)).toBe(false);
+  });
+
+  it("出力は CloudFront Function のコードサイズ上限（10KB）に収まる", () => {
+    const on = buildMaintenanceFunctionCode(true);
+    const off = buildMaintenanceFunctionCode(false);
+    expect(on.length).toBeLessThan(10 * 1024);
+    expect(off.length).toBeLessThan(10 * 1024);
+  });
+});

--- a/backend/src/handlers/maintenance/toggle.ts
+++ b/backend/src/handlers/maintenance/toggle.ts
@@ -1,0 +1,100 @@
+import {
+  CloudFrontClient,
+  DescribeFunctionCommand,
+  UpdateFunctionCommand,
+  PublishFunctionCommand,
+} from "@aws-sdk/client-cloudfront";
+
+import { buildMaintenanceFunctionCode } from "./build-function-code";
+
+export type ToggleEvent = {
+  enabled: boolean;
+};
+
+export type ToggleResult = {
+  enabled: boolean;
+  functionName: string;
+  message: string;
+};
+
+type CloudFrontFunctionClient = Pick<CloudFrontClient, "send">;
+
+export type ToggleDeps = {
+  client: CloudFrontFunctionClient;
+  functionName: string;
+};
+
+/**
+ * CloudFront Function の LIVE ステージのコードを差し替えてメンテナンスモードを ON/OFF する。
+ *
+ * フロー:
+ * 1. `DescribeFunction(Stage=DEVELOPMENT)` で現在の ETag を取得
+ * 2. `UpdateFunction` で新しいコードをアップロード（DEVELOPMENT ステージ更新）
+ * 3. `PublishFunction` で LIVE に昇格（約 30 秒かけて全エッジに反映される）
+ */
+export async function toggleMaintenance(
+  deps: ToggleDeps,
+  event: ToggleEvent
+): Promise<ToggleResult> {
+  if (typeof event?.enabled !== "boolean") {
+    throw new Error("Event body must include `enabled: boolean`");
+  }
+
+  const describe = await deps.client.send(
+    new DescribeFunctionCommand({
+      Name: deps.functionName,
+      Stage: "DEVELOPMENT",
+    })
+  );
+
+  const describeEtag = describe.ETag;
+  const runtime = describe.FunctionSummary?.FunctionConfig?.Runtime ?? "cloudfront-js-2.0";
+  const comment =
+    describe.FunctionSummary?.FunctionConfig?.Comment ?? "Maintenance toggle function";
+  if (describeEtag === undefined) {
+    throw new Error(`Failed to fetch ETag for function: ${deps.functionName}`);
+  }
+
+  const code = buildMaintenanceFunctionCode(event.enabled);
+  const update = await deps.client.send(
+    new UpdateFunctionCommand({
+      Name: deps.functionName,
+      IfMatch: describeEtag,
+      FunctionConfig: { Runtime: runtime, Comment: comment },
+      FunctionCode: new TextEncoder().encode(code),
+    })
+  );
+  const updateEtag = update.ETag;
+  if (updateEtag === undefined) {
+    throw new Error(`UpdateFunction did not return ETag for: ${deps.functionName}`);
+  }
+
+  await deps.client.send(
+    new PublishFunctionCommand({
+      Name: deps.functionName,
+      IfMatch: updateEtag,
+    })
+  );
+
+  return {
+    enabled: event.enabled,
+    functionName: deps.functionName,
+    message: event.enabled
+      ? "Maintenance mode enabled. Changes will propagate to all edges within ~30 seconds."
+      : "Maintenance mode disabled. Changes will propagate to all edges within ~30 seconds.",
+  };
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`Required environment variable is missing: ${name}`);
+  }
+  return value;
+}
+
+export const handler = async (event: ToggleEvent): Promise<ToggleResult> => {
+  const functionName = requireEnv("MAINTENANCE_FUNCTION_NAME");
+  const client = new CloudFrontClient({});
+  return toggleMaintenance({ client, functionName }, event);
+};

--- a/backend/src/handlers/maintenance/widget.test.ts
+++ b/backend/src/handlers/maintenance/widget.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, vi } from "vitest";
+import { GetFunctionCommand } from "@aws-sdk/client-cloudfront";
+
+import { buildMaintenanceFunctionCode } from "./build-function-code";
+import { renderWidget } from "./widget";
+
+const FUNCTION_NAME = "MaintenanceFunction";
+const TOGGLE_ARN = "arn:aws:lambda:ap-northeast-1:123456789012:function:MaintenanceToggle";
+
+describe("renderWidget", () => {
+  it("describe=true のとき説明文を返し CloudFront を呼ばない", async () => {
+    const send = vi.fn();
+    const html = await renderWidget(
+      { client: { send } as never, functionName: FUNCTION_NAME, toggleArn: TOGGLE_ARN },
+      { describe: true }
+    );
+    expect(html).toMatch(/MaintenanceToggle/);
+    expect(send).not.toHaveBeenCalled();
+  });
+
+  it("LIVE コードがメンテナンス ON のとき ON 状態を表示する", async () => {
+    const code = buildMaintenanceFunctionCode(true);
+    const send = vi.fn().mockResolvedValueOnce({
+      FunctionCode: new TextEncoder().encode(code),
+    });
+
+    const html = await renderWidget(
+      { client: { send } as never, functionName: FUNCTION_NAME, toggleArn: TOGGLE_ARN },
+      {}
+    );
+
+    expect(send).toHaveBeenCalledTimes(1);
+    const cmd = send.mock.calls[0][0] as GetFunctionCommand;
+    expect(cmd).toBeInstanceOf(GetFunctionCommand);
+    expect(cmd.input).toEqual({ Name: FUNCTION_NAME, Stage: "LIVE" });
+    expect(html).toContain("ON");
+    expect(html).toContain(TOGGLE_ARN);
+    expect(html).toContain('{"enabled": true}');
+    expect(html).toContain('{"enabled": false}');
+  });
+
+  it("LIVE コードがメンテナンス OFF のとき OFF 状態を表示する", async () => {
+    const code = buildMaintenanceFunctionCode(false);
+    const send = vi.fn().mockResolvedValueOnce({
+      FunctionCode: new TextEncoder().encode(code),
+    });
+
+    const html = await renderWidget(
+      { client: { send } as never, functionName: FUNCTION_NAME, toggleArn: TOGGLE_ARN },
+      {}
+    );
+    expect(html).toContain("OFF");
+    expect(html).toContain("通常稼働");
+  });
+
+  it("GetFunction が失敗したときエラーメッセージを HTML に含めて完了する", async () => {
+    const send = vi.fn().mockRejectedValueOnce(new Error("no such function"));
+    const html = await renderWidget(
+      { client: { send } as never, functionName: FUNCTION_NAME, toggleArn: TOGGLE_ARN },
+      {}
+    );
+    expect(html).toContain("現状取得に失敗");
+    expect(html).toContain("no such function");
+    // 取得に失敗しても ON/OFF ボタンは出す（運用継続性）
+    expect(html).toContain(TOGGLE_ARN);
+  });
+
+  it("HTML 特殊文字が payload/arn に含まれてもエスケープされる", async () => {
+    const send = vi.fn().mockResolvedValueOnce({ FunctionCode: undefined });
+    const html = await renderWidget(
+      {
+        client: { send } as never,
+        functionName: `<script>alert(1)</script>`,
+        toggleArn: `arn"><img`,
+      },
+      {}
+    );
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain("arn&quot;&gt;&lt;img");
+  });
+});

--- a/backend/src/handlers/maintenance/widget.ts
+++ b/backend/src/handlers/maintenance/widget.ts
@@ -1,0 +1,104 @@
+import { CloudFrontClient, GetFunctionCommand } from "@aws-sdk/client-cloudfront";
+
+import { isMaintenanceEnabled } from "./build-function-code";
+
+export type WidgetEvent = {
+  describe?: boolean;
+  widgetContext?: unknown;
+};
+
+type CloudFrontFunctionClient = Pick<CloudFrontClient, "send">;
+
+export type WidgetDeps = {
+  client: CloudFrontFunctionClient;
+  functionName: string;
+  toggleArn: string;
+};
+
+const DESCRIBE_TEXT =
+  "メンテナンスモードの現在の状態を表示し、ON/OFF ボタンで MaintenanceToggle Lambda を呼び出す。";
+
+/**
+ * CloudWatch Custom Widget の描画ハンドラ。
+ *
+ * - `event.describe === true`: 開発者向け説明文を返す（ダッシュボード作成 UI で利用される）
+ * - それ以外: CloudFront Function の LIVE コードを `GetFunction` で取得して現在の状態を表示し、
+ *   `<cwdb-action>` でラップした ON/OFF ボタンを HTML として返す
+ */
+export async function renderWidget(deps: WidgetDeps, event: WidgetEvent): Promise<string> {
+  if (event?.describe === true) {
+    return DESCRIBE_TEXT;
+  }
+
+  let enabled = false;
+  let fetchError: string | undefined;
+  try {
+    const result = await deps.client.send(
+      new GetFunctionCommand({ Name: deps.functionName, Stage: "LIVE" })
+    );
+    const codeBytes = result.FunctionCode;
+    if (codeBytes instanceof Uint8Array) {
+      const code = new TextDecoder().decode(codeBytes);
+      enabled = isMaintenanceEnabled(code);
+    }
+  } catch (e) {
+    fetchError = e instanceof Error ? e.message : String(e);
+  }
+
+  const statusLabel = enabled ? "ON（メンテナンス中）" : "OFF（通常稼働）";
+  const statusColor = enabled ? "#ef4444" : "#10b981";
+  const errorBlock =
+    fetchError === undefined
+      ? ""
+      : `<p style="color:#ef4444;margin:8px 0;">現状取得に失敗: ${escapeHtml(fetchError)}</p>`;
+
+  return `
+<div style="padding:16px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;">
+  <div style="font-size:13px;color:#64748b;margin-bottom:4px;">Function: ${escapeHtml(deps.functionName)}</div>
+  <div style="font-size:18px;margin-bottom:12px;">
+    現在の状態: <strong style="color:${statusColor};">${statusLabel}</strong>
+  </div>
+  ${errorBlock}
+  <div style="display:flex;gap:8px;">
+    <a class="btn btn-primary">
+      <cwdb-action action="call" endpoint="${escapeHtml(deps.toggleArn)}" display="popout" confirmation="メンテナンスモードを ON にしますか？CloudFront 経由の全アクセスが 503 になります。">
+        {"enabled": true}
+      </cwdb-action>
+      メンテナンス開始（ON）
+    </a>
+    <a class="btn">
+      <cwdb-action action="call" endpoint="${escapeHtml(deps.toggleArn)}" display="popout" confirmation="メンテナンスモードを OFF にして通常稼働に戻しますか？">
+        {"enabled": false}
+      </cwdb-action>
+      メンテナンス解除（OFF）
+    </a>
+  </div>
+  <p style="font-size:12px;color:#64748b;margin-top:16px;">
+    ※ 反映には CloudFront Function の伝搬（約 30 秒〜数分）を要します。状態表示はウィジェット再描画で更新されます。
+  </p>
+</div>`.trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`Required environment variable is missing: ${name}`);
+  }
+  return value;
+}
+
+export const handler = async (event: WidgetEvent): Promise<string> => {
+  const functionName = requireEnv("MAINTENANCE_FUNCTION_NAME");
+  const toggleArn = requireEnv("MAINTENANCE_TOGGLE_ARN");
+  const client = new CloudFrontClient({});
+  return renderWidget({ client, functionName, toggleArn }, event);
+};

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -36,6 +36,9 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const isProd = stageName === "prod";
     const domainName = isProd ? "nocturne-app.com" : `${stageName}.nocturne-app.com`;
 
+    // デプロイ時に MAINTENANCE_MODE=true を指定すると CloudFront を閉じ、全パスで 503 を返す
+    const maintenanceMode = process.env.MAINTENANCE_MODE === "true";
+
     // -------------------------
     // DynamoDB テーブル
     // -------------------------
@@ -194,6 +197,24 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       }
     );
 
+    // メンテナンスモード: 全リクエストに対して CloudFront Function で 503 を即時返却する
+    const maintenanceFunction = maintenanceMode
+      ? new cloudfront.Function(this, "MaintenanceFunction", {
+          code: cloudfront.FunctionCode.fromInline(buildMaintenanceFunctionCode()),
+          runtime: cloudfront.FunctionRuntime.JS_2_0,
+          comment: "Return 503 maintenance page during maintenance mode",
+        })
+      : undefined;
+
+    const maintenanceFunctionAssociations = maintenanceFunction
+      ? [
+          {
+            function: maintenanceFunction,
+            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+          },
+        ]
+      : undefined;
+
     const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
       domainNames: [domainName],
       certificate,
@@ -202,6 +223,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
         responseHeadersPolicy: securityHeadersPolicy,
+        functionAssociations: maintenanceFunctionAssociations,
       },
       // index.html はキャッシュしない（SPA デプロイ後に即反映させるため）
       additionalBehaviors: {
@@ -210,6 +232,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
           responseHeadersPolicy: securityHeadersPolicy,
+          functionAssociations: maintenanceFunctionAssociations,
         },
       },
       defaultRootObject: "index.html",
@@ -735,10 +758,13 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // -------------------------
     // Storybook ホスティング（/storybook/ パス）
     // -------------------------
-    // /storybook/ へのアクセスを /storybook/index.html にリライトする CloudFront Function
-    const storybookRootRewrite = new cloudfront.Function(this, "StorybookRootRewrite", {
-      code: cloudfront.FunctionCode.fromInline(
-        `
+    // メンテナンスモード時は maintenanceFunction を適用し、storybook ルートリライトは作成しない
+    const storybookFunctionAssociations = maintenanceFunctionAssociations ?? [
+      {
+        // /storybook/ へのアクセスを /storybook/index.html にリライトする CloudFront Function
+        function: new cloudfront.Function(this, "StorybookRootRewrite", {
+          code: cloudfront.FunctionCode.fromInline(
+            `
 function handler(event) {
   var request = event.request;
   if (request.uri === '/storybook/' || request.uri === '/storybook') {
@@ -747,9 +773,12 @@ function handler(event) {
   return request;
 }
       `.trim()
-      ),
-      runtime: cloudfront.FunctionRuntime.JS_2_0,
-    });
+          ),
+          runtime: cloudfront.FunctionRuntime.JS_2_0,
+        }),
+        eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+      },
+    ];
 
     // /storybook/* 用の CloudFront behavior を追加
     distribution.addBehavior(
@@ -759,12 +788,7 @@ function handler(event) {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         responseHeadersPolicy: storybookHeadersPolicy,
-        functionAssociations: [
-          {
-            function: storybookRootRewrite,
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          },
-        ],
+        functionAssociations: storybookFunctionAssociations,
       }
     );
 
@@ -913,4 +937,43 @@ function handler(event) {
       allowHeaders,
     });
   }
+}
+
+// CloudFront Function (JS 2.0) で 503 メンテナンスページを返却するハンドラコードを生成する
+// NOTE: CloudFront Functions のコードサイズ上限は 10 KB、実行時間 1 ms のため最小限の HTML に留める
+function buildMaintenanceFunctionCode(): string {
+  const maintenanceHtml = `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>メンテナンス中 - Nocturne</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; background: #0f1729; color: #e5e7eb; margin: 0; min-height: 100vh; display: flex; align-items: center; justify-content: center; padding: 24px; }
+  .card { max-width: 480px; text-align: center; }
+  h1 { font-size: 28px; margin: 0 0 16px; color: #fff; }
+  p { line-height: 1.7; color: #cbd5e1; margin: 0; }
+</style>
+</head>
+<body>
+<div class="card">
+<h1>メンテナンス中</h1>
+<p>ただいまシステムメンテナンスを実施しています。<br>ご不便をおかけいたしますが、しばらくお待ちください。</p>
+</div>
+</body>
+</html>`;
+
+  return `
+function handler(event) {
+  return {
+    statusCode: 503,
+    statusDescription: 'Service Unavailable',
+    headers: {
+      'content-type': { value: 'text/html; charset=utf-8' },
+      'cache-control': { value: 'no-store' }
+    },
+    body: ${JSON.stringify(maintenanceHtml)}
+  };
+}
+`.trim();
 }

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -449,6 +449,40 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       })
     );
 
+    // CloudWatch Custom Widget Lambda（ダッシュボードから ON/OFF ボタンを押すための描画関数）
+    const maintenanceWidget = fn("MaintenanceWidget", "handlers/maintenance/widget.ts");
+    maintenanceWidget.addEnvironment("MAINTENANCE_FUNCTION_NAME", maintenanceFunction.functionName);
+    maintenanceWidget.addEnvironment("MAINTENANCE_TOGGLE_ARN", maintenanceToggle.functionArn);
+    maintenanceWidget.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cloudfront:GetFunction"],
+        resources: [maintenanceFunction.functionArn],
+      })
+    );
+
+    // CloudWatch Dashboard: メンテナンスモード操作用
+    // - Custom Widget が maintenanceWidget を呼び出して現在の状態を表示
+    // - Widget 内の <cwdb-action> が maintenanceToggle を呼び出して ON/OFF 切替
+    // NOTE: ダッシュボードを閲覧・操作するユーザーは以下の IAM 権限が必要:
+    //   - cloudwatch:GetDashboard（ダッシュボード表示）
+    //   - lambda:InvokeFunction (MaintenanceWidget)（ウィジェット描画）
+    //   - lambda:InvokeFunction (MaintenanceToggle)（ON/OFF 実行）
+    const maintenanceDashboard = new cloudwatch.Dashboard(this, "MaintenanceDashboard", {
+      dashboardName: `classical-music-lake-${stageName}-maintenance`,
+    });
+    maintenanceDashboard.addWidgets(
+      new cloudwatch.CustomWidget({
+        functionArn: maintenanceWidget.functionArn,
+        title: `メンテナンスモード切替 (${stageName})`,
+        width: 24,
+        height: 6,
+        updateOnRefresh: true,
+        updateOnResize: false,
+        updateOnTimeRangeChange: false,
+      })
+    );
+
     // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
     // いる場合に自動でアカウントリンクを行う
     userPool.addTrigger(cognito.UserPoolOperation.PRE_SIGN_UP, authPreSignUp);
@@ -824,6 +858,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       updateComposer,
       deleteComposer,
       maintenanceToggle,
+      maintenanceWidget,
     ];
 
     // Lambda エラー監視：各関数ごとにアラーム作成
@@ -921,6 +956,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     new cdk.CfnOutput(this, "MaintenanceCloudFrontFunctionName", {
       value: maintenanceFunction.functionName,
       description: "メンテナンス切替対象の CloudFront Function 名",
+    });
+
+    new cdk.CfnOutput(this, "MaintenanceDashboardUrl", {
+      value: `https://${this.region}.console.aws.amazon.com/cloudwatch/home?region=${this.region}#dashboards:name=${maintenanceDashboard.dashboardName}`,
+      description: "メンテナンス切替ダッシュボード URL（ボタン 1 クリックで ON/OFF）",
     });
   }
 

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -36,9 +36,6 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const isProd = stageName === "prod";
     const domainName = isProd ? "nocturne-app.com" : `${stageName}.nocturne-app.com`;
 
-    // デプロイ時に MAINTENANCE_MODE=true を指定すると CloudFront を閉じ、全パスで 503 を返す
-    const maintenanceMode = process.env.MAINTENANCE_MODE === "true";
-
     // -------------------------
     // DynamoDB テーブル
     // -------------------------
@@ -197,23 +194,21 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       }
     );
 
-    // メンテナンスモード: 全リクエストに対して CloudFront Function で 503 を即時返却する
-    const maintenanceFunction = maintenanceMode
-      ? new cloudfront.Function(this, "MaintenanceFunction", {
-          code: cloudfront.FunctionCode.fromInline(buildMaintenanceFunctionCode()),
-          runtime: cloudfront.FunctionRuntime.JS_2_0,
-          comment: "Return 503 maintenance page during maintenance mode",
-        })
-      : undefined;
+    // メンテナンスモード: Toggle Lambda から CloudFront Function のコードを差し替えて切替する。
+    // 関数は常に全 behavior に紐付いており、初期コードはメンテナンス OFF（通常動作）。
+    // OFF 時は storybook ルートのリライトも兼ねる（`/storybook/` → `/storybook/index.html`）。
+    const maintenanceFunction = new cloudfront.Function(this, "MaintenanceFunction", {
+      code: cloudfront.FunctionCode.fromInline(buildMaintenanceFunctionCode(false)),
+      runtime: cloudfront.FunctionRuntime.JS_2_0,
+      comment: "Maintenance toggle function (503 when enabled, storybook rewrite otherwise)",
+    });
 
-    const maintenanceFunctionAssociations = maintenanceFunction
-      ? [
-          {
-            function: maintenanceFunction,
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          },
-        ]
-      : undefined;
+    const maintenanceFunctionAssociations = [
+      {
+        function: maintenanceFunction,
+        eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+      },
+    ];
 
     const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
       domainNames: [domainName],
@@ -438,6 +433,21 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const getComposer = fn("GetComposer", "handlers/composers/get.ts");
     const updateComposer = fn("UpdateComposer", "handlers/composers/update.ts");
     const deleteComposer = fn("DeleteComposer", "handlers/composers/delete.ts");
+
+    // メンテナンスモード切替 Lambda（API Gateway 未公開、AWS CLI/コンソールから直接 invoke する）
+    const maintenanceToggle = fn("MaintenanceToggle", "handlers/maintenance/toggle.ts");
+    maintenanceToggle.addEnvironment("MAINTENANCE_FUNCTION_NAME", maintenanceFunction.functionName);
+    maintenanceToggle.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          "cloudfront:DescribeFunction",
+          "cloudfront:UpdateFunction",
+          "cloudfront:PublishFunction",
+        ],
+        resources: [maintenanceFunction.functionArn],
+      })
+    );
 
     // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
     // いる場合に自動でアカウントリンクを行う
@@ -758,29 +768,9 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // -------------------------
     // Storybook ホスティング（/storybook/ パス）
     // -------------------------
-    // メンテナンスモード時は maintenanceFunction を適用し、storybook ルートリライトは作成しない
-    const storybookFunctionAssociations = maintenanceFunctionAssociations ?? [
-      {
-        // /storybook/ へのアクセスを /storybook/index.html にリライトする CloudFront Function
-        function: new cloudfront.Function(this, "StorybookRootRewrite", {
-          code: cloudfront.FunctionCode.fromInline(
-            `
-function handler(event) {
-  var request = event.request;
-  if (request.uri === '/storybook/' || request.uri === '/storybook') {
-    request.uri = '/storybook/index.html';
-  }
-  return request;
-}
-      `.trim()
-          ),
-          runtime: cloudfront.FunctionRuntime.JS_2_0,
-        }),
-        eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-      },
-    ];
-
     // /storybook/* 用の CloudFront behavior を追加
+    // 通常時は maintenanceFunction が `/storybook/` → `/storybook/index.html` にリライトし、
+    // メンテナンス時は同じ関数が 503 を返す
     distribution.addBehavior(
       "/storybook/*",
       origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
@@ -788,7 +778,7 @@ function handler(event) {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
         responseHeadersPolicy: storybookHeadersPolicy,
-        functionAssociations: storybookFunctionAssociations,
+        functionAssociations: maintenanceFunctionAssociations,
       }
     );
 
@@ -833,6 +823,7 @@ function handler(event) {
       getComposer,
       updateComposer,
       deleteComposer,
+      maintenanceToggle,
     ];
 
     // Lambda エラー監視：各関数ごとにアラーム作成
@@ -920,6 +911,17 @@ function handler(event) {
       value: distribution.distributionId,
       description: "CloudFront Distribution ID",
     });
+
+    new cdk.CfnOutput(this, "MaintenanceToggleFunctionName", {
+      value: maintenanceToggle.functionName,
+      description:
+        "メンテナンスモード切替 Lambda 関数名（aws lambda invoke で直接呼び出して ON/OFF する）",
+    });
+
+    new cdk.CfnOutput(this, "MaintenanceCloudFrontFunctionName", {
+      value: maintenanceFunction.functionName,
+      description: "メンテナンス切替対象の CloudFront Function 名",
+    });
   }
 
   private removalPolicy(isProd: boolean): cdk.RemovalPolicy {
@@ -939,9 +941,14 @@ function handler(event) {
   }
 }
 
-// CloudFront Function (JS 2.0) で 503 メンテナンスページを返却するハンドラコードを生成する
-// NOTE: CloudFront Functions のコードサイズ上限は 10 KB、実行時間 1 ms のため最小限の HTML に留める
-function buildMaintenanceFunctionCode(): string {
+// CloudFront Function (JS 2.0) のコードを生成する。
+// - `enabled=true`: 全リクエストに 503 メンテナンスページを即時返却
+// - `enabled=false`: `/storybook/` → `/storybook/index.html` のリライトのみ実施し、それ以外は素通し
+//
+// この関数の実装は `backend/src/handlers/maintenance/build-function-code.ts` と同じロジックを持つ。
+// CDK の tsconfig が `cdk/` 配下しか参照できないため重複させている。両者のドリフトに注意すること。
+// NOTE: CloudFront Functions のコードサイズ上限は 10 KB、実行時間 1 ms のため最小限の HTML に留める。
+function buildMaintenanceFunctionCode(enabled: boolean): string {
   const maintenanceHtml = `<!doctype html>
 <html lang="ja">
 <head>
@@ -965,15 +972,23 @@ function buildMaintenanceFunctionCode(): string {
 
   return `
 function handler(event) {
-  return {
-    statusCode: 503,
-    statusDescription: 'Service Unavailable',
-    headers: {
-      'content-type': { value: 'text/html; charset=utf-8' },
-      'cache-control': { value: 'no-store' }
-    },
-    body: ${JSON.stringify(maintenanceHtml)}
-  };
+  var MAINTENANCE = ${enabled ? "true" : "false"};
+  var request = event.request;
+  if (MAINTENANCE) {
+    return {
+      statusCode: 503,
+      statusDescription: 'Service Unavailable',
+      headers: {
+        'content-type': { value: 'text/html; charset=utf-8' },
+        'cache-control': { value: 'no-store' }
+      },
+      body: ${JSON.stringify(maintenanceHtml)}
+    };
+  }
+  if (request.uri === '/storybook/' || request.uri === '/storybook') {
+    request.uri = '/storybook/index.html';
+  }
+  return request;
 }
 `.trim();
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -349,13 +349,22 @@ classical-music-lake/
 - **設定**: prod・stg は CloudFront URL のみ許可。dev 環境のみ `http://localhost:3010` を追加で許可
 - **実装**: CDK が各環境に応じた `CORS_ALLOW_ORIGIN` 環境変数を Lambda に設定し、API Gateway プリフライトも同じオリジンに限定
 
-### メンテナンスモード（CloudFront レベル）
+### メンテナンスモード（CloudFront レベル、ランタイムトグル）
 
-- **目的**: 大規模なデータ移行や障害対応時に、全ユーザーからのアクセスを CloudFront で即時遮断する手段を提供する
-- **実装**: CDK スタックが `MAINTENANCE_MODE=true` 環境変数を検出したときのみ、503 を返す CloudFront Function を `defaultBehavior` / `/index.html` / `/storybook/*` の `VIEWER_REQUEST` に紐付ける。オリジン（S3）には一切リクエストが到達しない
-- **操作**: GitHub Actions の `deploy.yml` に `maintenance_mode` boolean 入力を追加。workflow_dispatch から true にして対象環境（dev/stg/prod）を選んで実行する
-- **設計判断**: Lambda@Edge ではなく CloudFront Function を採用（実行時間 <1ms・料金が約 1/6・us-east-1 に閉じず各エッジで完結）。レスポンスボディは関数コードサイズ制限（10KB）に収まる最小限のインライン HTML とする
-- **トレードオフ**: 切替はディストリビューション変更を伴うため反映に数分を要する。より即時性が必要な場合は S3 上のフラグファイルを Lambda@Edge で読む方式に拡張可能
+- **目的**: 大規模なデータ移行や障害対応時に、全ユーザーからのアクセスを CloudFront で即時遮断する手段を提供する。デプロイを伴わずに任意のタイミングで ON/OFF できることを最優先要件とする
+- **実装**:
+  - **CloudFront Function (`MaintenanceFunction`)**: 全 behavior の `VIEWER_REQUEST` に常時紐付く。コード内に `var MAINTENANCE = true/false;` フラグを埋め込み、true なら 503 を即時返却、false なら `/storybook/` のルートリライトのみ実行して通常通りオリジン（S3）へ流す
+  - **Toggle Lambda (`MaintenanceToggle`)**: `{ enabled: boolean }` を受け取り、`DescribeFunction(DEVELOPMENT)` → `UpdateFunction`（ETag 楽観的ロック）→ `PublishFunction` の 3 ステップで CloudFront Function のコードを差し替え、LIVE ステージに昇格させる。API Gateway には公開せず AWS CLI／コンソールからのみ invoke する
+- **操作**: 運用者は対象環境の `MaintenanceToggleFunctionName` を CloudFormation Outputs から取得し、`aws lambda invoke --payload '{"enabled":true}'` で ON に、`'{"enabled":false}'` で OFF にする
+- **反映時間**: `PublishFunction` 完了から約 30 秒〜数分で全エッジに伝搬する
+- **設計判断**:
+  - Lambda@Edge ではなく CloudFront Function を採用（実行時間 <1ms・料金が約 1/6・us-east-1 に閉じず各エッジで完結）。レスポンスボディは関数コードサイズ制限（10KB）に収まる最小限のインライン HTML とする
+  - 切替をデプロイ時フラグ（`MAINTENANCE_MODE` env 変数）ではなくランタイム Lambda 経由にすることで、障害対応時にインフラデプロイを待たずに即時切替可能とする
+  - 単一 Function に 503 応答ロジックとストーリーブックリライトを統合（CloudFront Function は 1 behavior あたり 1 関数しか紐付けられないため）
+  - `buildMaintenanceFunctionCode(enabled)` は CDK 側（初期コード生成）と Lambda 側（ランタイム差し替え）の双方から呼ばれるが、CDK の tsconfig が `cdk/` 配下しか参照できないため、`backend/src/handlers/maintenance/build-function-code.ts` と `cdk/lib/classical-music-lake-stack.ts` に同等の最小実装を重複させる（ドリフト注意コメントを両方に配置）
+- **トレードオフ**:
+  - デプロイで OFF に戻る: 通常デプロイでは CDK が初期コード（OFF）を投入するため、メンテナンス中に誤ってデプロイすると即座に解除される。運用時は「メンテ中は main への push を避ける」ルールで運用する
+  - `@aws-sdk/client-cloudfront` を Lambda バンドルに追加するため、他の Lambda より若干バンドルサイズが大きくなる（256MB / 10s で十分動作）
 
 ### フロントエンド・バックエンドの型定義が分離
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -354,12 +354,17 @@ classical-music-lake/
 - **目的**: 大規模なデータ移行や障害対応時に、全ユーザーからのアクセスを CloudFront で即時遮断する手段を提供する。デプロイを伴わずに任意のタイミングで ON/OFF できることを最優先要件とする
 - **実装**:
   - **CloudFront Function (`MaintenanceFunction`)**: 全 behavior の `VIEWER_REQUEST` に常時紐付く。コード内に `var MAINTENANCE = true/false;` フラグを埋め込み、true なら 503 を即時返却、false なら `/storybook/` のルートリライトのみ実行して通常通りオリジン（S3）へ流す
-  - **Toggle Lambda (`MaintenanceToggle`)**: `{ enabled: boolean }` を受け取り、`DescribeFunction(DEVELOPMENT)` → `UpdateFunction`（ETag 楽観的ロック）→ `PublishFunction` の 3 ステップで CloudFront Function のコードを差し替え、LIVE ステージに昇格させる。API Gateway には公開せず AWS CLI／コンソールからのみ invoke する
-- **操作**: 運用者は対象環境の `MaintenanceToggleFunctionName` を CloudFormation Outputs から取得し、`aws lambda invoke --payload '{"enabled":true}'` で ON に、`'{"enabled":false}'` で OFF にする
+  - **Toggle Lambda (`MaintenanceToggle`)**: `{ enabled: boolean }` を受け取り、`DescribeFunction(DEVELOPMENT)` → `UpdateFunction`（ETag 楽観的ロック）→ `PublishFunction` の 3 ステップで CloudFront Function のコードを差し替え、LIVE ステージに昇格させる
+  - **Widget Lambda (`MaintenanceWidget`)**: CloudWatch Custom Widget の描画関数。`GetFunction(LIVE)` で CloudFront Function の現在コードを取得して ON/OFF 状態を判定し、`<cwdb-action action="call" endpoint="<MaintenanceToggleArn>">` で ON/OFF ボタンを含む HTML を返す
+  - **CloudWatch Dashboard (`classical-music-lake-{stage}-maintenance`)**: `MaintenanceWidget` を埋め込んだ Custom Widget 1 枚で構成。運用者はこのダッシュボードを開いてボタンをクリックするだけで切替可能
+- **操作**:
+  - **推奨**: CloudFormation Outputs の `MaintenanceDashboardUrl` を開き、ダッシュボード上のボタンをクリック → 確認ダイアログで承認
+  - **代替**: `MaintenanceToggleFunctionName` を取得して `aws lambda invoke --payload '{"enabled":true}'` で CLI から呼ぶ
 - **反映時間**: `PublishFunction` 完了から約 30 秒〜数分で全エッジに伝搬する
 - **設計判断**:
   - Lambda@Edge ではなく CloudFront Function を採用（実行時間 <1ms・料金が約 1/6・us-east-1 に閉じず各エッジで完結）。レスポンスボディは関数コードサイズ制限（10KB）に収まる最小限のインライン HTML とする
   - 切替をデプロイ時フラグ（`MAINTENANCE_MODE` env 変数）ではなくランタイム Lambda 経由にすることで、障害対応時にインフラデプロイを待たずに即時切替可能とする
+  - 操作 UI に CloudWatch Custom Widget を選んだ理由: ①AWS マネジメントコンソール内で完結するため追加のフロントエンドを作らずに済む、②メンテナンス中でも自前 SPA に依存せず切替可能（自前 SPA を CloudFront で閉じるため自分のフロントでは操作不能になる）、③既存の IAM ロール/ポリシーをそのまま利用可能
   - 単一 Function に 503 応答ロジックとストーリーブックリライトを統合（CloudFront Function は 1 behavior あたり 1 関数しか紐付けられないため）
   - `buildMaintenanceFunctionCode(enabled)` は CDK 側（初期コード生成）と Lambda 側（ランタイム差し替え）の双方から呼ばれるが、CDK の tsconfig が `cdk/` 配下しか参照できないため、`backend/src/handlers/maintenance/build-function-code.ts` と `cdk/lib/classical-music-lake-stack.ts` に同等の最小実装を重複させる（ドリフト注意コメントを両方に配置）
 - **トレードオフ**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -349,6 +349,14 @@ classical-music-lake/
 - **設定**: prod・stg は CloudFront URL のみ許可。dev 環境のみ `http://localhost:3010` を追加で許可
 - **実装**: CDK が各環境に応じた `CORS_ALLOW_ORIGIN` 環境変数を Lambda に設定し、API Gateway プリフライトも同じオリジンに限定
 
+### メンテナンスモード（CloudFront レベル）
+
+- **目的**: 大規模なデータ移行や障害対応時に、全ユーザーからのアクセスを CloudFront で即時遮断する手段を提供する
+- **実装**: CDK スタックが `MAINTENANCE_MODE=true` 環境変数を検出したときのみ、503 を返す CloudFront Function を `defaultBehavior` / `/index.html` / `/storybook/*` の `VIEWER_REQUEST` に紐付ける。オリジン（S3）には一切リクエストが到達しない
+- **操作**: GitHub Actions の `deploy.yml` に `maintenance_mode` boolean 入力を追加。workflow_dispatch から true にして対象環境（dev/stg/prod）を選んで実行する
+- **設計判断**: Lambda@Edge ではなく CloudFront Function を採用（実行時間 <1ms・料金が約 1/6・us-east-1 に閉じず各エッジで完結）。レスポンスボディは関数コードサイズ制限（10KB）に収まる最小限のインライン HTML とする
+- **トレードオフ**: 切替はディストリビューション変更を伴うため反映に数分を要する。より即時性が必要な場合は S3 上のフラグファイルを Lambda@Edge で読む方式に拡張可能
+
 ### フロントエンド・バックエンドの型定義が分離
 
 - **理由**: フロントエンド（`types/`）とバックエンド（`backend/src/types/`）が独立したパッケージ構成

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -935,7 +935,7 @@ GET /composers?limit=50&cursor={opaque}
 #### Lambda
 
 - **ランタイム**: Node.js 24.x
-- **関数数**: 27個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
+- **関数数**: 28個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
   - 視聴ログ用 CRUD 操作 × 5
   - 楽曲マスタ用 CRUD 操作 × 5
   - 作曲家マスタ用 CRUD 操作 × 5
@@ -943,6 +943,7 @@ GET /composers?limit=50&cursor={opaque}
   - PreSignUp トリガー × 1
   - コンサート記録 × 5（list・create・get・update・delete）
   - メンテナンスモード切替 × 1（`MaintenanceToggle`、API Gateway 非公開）
+  - メンテナンスウィジェット描画 × 1（`MaintenanceWidget`、CloudWatch Custom Widget 用）
 - **環境変数**:
   - `DYNAMO_TABLE_LISTENING_LOGS`
   - `DYNAMO_TABLE_PIECES`
@@ -950,7 +951,8 @@ GET /composers?limit=50&cursor={opaque}
   - `DYNAMO_TABLE_COMPOSERS`
   - `COGNITO_USER_POOL_ID`（認証系 Lambda で使用）
   - `COGNITO_CLIENT_ID`（認証系 Lambda で使用）
-  - `MAINTENANCE_FUNCTION_NAME`（`MaintenanceToggle` のみ使用、対象 CloudFront Function 名）
+  - `MAINTENANCE_FUNCTION_NAME`（`MaintenanceToggle` / `MaintenanceWidget` で使用、対象 CloudFront Function 名）
+  - `MAINTENANCE_TOGGLE_ARN`（`MaintenanceWidget` のみ使用、`<cwdb-action>` から呼び出す Toggle Lambda の ARN）
 
 #### Cognito
 
@@ -1101,9 +1103,17 @@ CloudFront レベルで全リクエストを閉じ、503 Service Unavailable と
 
 - **構成**:
   - **CloudFront Function (`MaintenanceFunction`)**: 全 behavior（`defaultBehavior` / `/index.html` / `/storybook/*`）の `VIEWER_REQUEST` に常時紐付く。初期コードは OFF（通常動作 + `/storybook/` → `/storybook/index.html` のリライト）
-  - **Toggle Lambda (`MaintenanceToggle`)**: `enabled: boolean` を受け取り、`DescribeFunction` → `UpdateFunction` → `PublishFunction` で CloudFront Function のコードを ON / OFF 版に差し替えて LIVE ステージに昇格させる。API Gateway には公開していない（AWS CLI / マネジメントコンソールからのみ invoke）
+  - **Toggle Lambda (`MaintenanceToggle`)**: `enabled: boolean` を受け取り、`DescribeFunction` → `UpdateFunction` → `PublishFunction` で CloudFront Function のコードを ON / OFF 版に差し替えて LIVE ステージに昇格させる。API Gateway には公開していない
+  - **Widget Lambda (`MaintenanceWidget`)**: CloudWatch Custom Widget の描画関数。`GetFunction(LIVE)` で現在の状態を取得し、HTML 内の `<cwdb-action>` で `MaintenanceToggle` を呼び出すボタンを描画する
+  - **CloudWatch Dashboard (`classical-music-lake-{stage}-maintenance`)**: 上記 Widget を埋め込んだダッシュボード。**ダッシュボード上のボタンを 1 クリックするだけで ON/OFF を切替できる**のが推奨運用
 - **適用範囲**: CloudFront 配下の SPA・Storybook。API Gateway は影響を受けないため、SPA が読み込めないことで実質的にユーザー操作を停止する
-- **有効化手順**（例: stg 環境）
+- **切替方法 A: CloudWatch Dashboard（推奨）**
+  1. CloudFormation Outputs の `MaintenanceDashboardUrl` を開く
+  2. ウィジェット上で現在の状態（ON / OFF）を確認
+  3. 「メンテナンス開始（ON）」または「メンテナンス解除（OFF）」ボタンをクリック
+  4. 確認ダイアログで承認すると `MaintenanceToggle` が呼び出される
+  5. 数秒〜数十秒後にダッシュボードを再読込すると状態表示が更新される
+- **切替方法 B: AWS CLI（コマンドライン運用）**
 
   ```bash
   FN=$(aws cloudformation describe-stacks \
@@ -1115,11 +1125,15 @@ CloudFront レベルで全リクエストを閉じ、503 Service Unavailable と
   cat /tmp/out.json
   ```
 
-- **解除手順**: 上記 payload を `{"enabled":false}` にして再度 invoke する。以降の通常デプロイ（`main` への push・release 公開等）でも、CloudFront Function の初期コードが OFF で上書きされるため自動的に解除される点に注意する
-- **イベント**: `{ "enabled": true | false }` を Lambda の event として渡す。`enabled` が boolean 以外の場合は 400 相当のエラーを投げる
-- **レスポンス**: `503` + `Retry-After` なし、`cache-control: no-store`、`content-type: text/html; charset=utf-8`、最小限のインライン HTML（ダーク系デザイン）
+  解除は `{"enabled":false}` で再度 invoke する。以降の通常デプロイ（`main` への push・release 公開等）でも、CloudFront Function の初期コードが OFF で上書きされるため自動的に解除される点に注意する。
+
+- **イベント**: `MaintenanceToggle` は `{ "enabled": true | false }` を event として受け取る。`enabled` が boolean 以外の場合は 400 相当のエラーを投げる
+- **レスポンス（メンテナンス画面）**: `503` + `Retry-After` なし、`cache-control: no-store`、`content-type: text/html; charset=utf-8`、最小限のインライン HTML（ダーク系デザイン）
 - **反映時間**: `PublishFunction` 後、約 30 秒〜数分で全エッジに伝搬する
-- **IAM**: Toggle Lambda のロールには `cloudfront:DescribeFunction` / `cloudfront:UpdateFunction` / `cloudfront:PublishFunction` を対象 Function の ARN に限定して付与する
+- **IAM**:
+  - `MaintenanceToggle` ロール: `cloudfront:DescribeFunction` / `cloudfront:UpdateFunction` / `cloudfront:PublishFunction` を対象 Function の ARN に限定して付与
+  - `MaintenanceWidget` ロール: `cloudfront:GetFunction` を対象 Function の ARN に限定して付与
+  - ダッシュボード利用者の IAM: `cloudwatch:GetDashboard`、`lambda:InvokeFunction`（`MaintenanceWidget` と `MaintenanceToggle` に対して）が必要
 - **制約**: CloudFront Function のコードサイズ上限は 10 KB、実行時間は最大 1 ms。503 レスポンス用 HTML はインラインで埋め込む最小限のものに留める
 
 ### 6.5 ロールバック戦略

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -935,13 +935,14 @@ GET /composers?limit=50&cursor={opaque}
 #### Lambda
 
 - **ランタイム**: Node.js 24.x
-- **関数数**: 26個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
+- **関数数**: 27個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
   - 視聴ログ用 CRUD 操作 × 5
   - 楽曲マスタ用 CRUD 操作 × 5
   - 作曲家マスタ用 CRUD 操作 × 5
   - 認証系 × 5（register・login・verify-email・resend-verification-code・refresh）
   - PreSignUp トリガー × 1
   - コンサート記録 × 5（list・create・get・update・delete）
+  - メンテナンスモード切替 × 1（`MaintenanceToggle`、API Gateway 非公開）
 - **環境変数**:
   - `DYNAMO_TABLE_LISTENING_LOGS`
   - `DYNAMO_TABLE_PIECES`
@@ -949,6 +950,7 @@ GET /composers?limit=50&cursor={opaque}
   - `DYNAMO_TABLE_COMPOSERS`
   - `COGNITO_USER_POOL_ID`（認証系 Lambda で使用）
   - `COGNITO_CLIENT_ID`（認証系 Lambda で使用）
+  - `MAINTENANCE_FUNCTION_NAME`（`MaintenanceToggle` のみ使用、対象 CloudFront Function 名）
 
 #### Cognito
 
@@ -1095,14 +1097,30 @@ GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
 
 ### 6.4 メンテナンスモード
 
-CloudFront レベルで全リクエストを閉じ、503 Service Unavailable とメンテナンス画面を返す機能。
+CloudFront レベルで全リクエストを閉じ、503 Service Unavailable とメンテナンス画面を返す機能。切替はデプロイ不要で、専用の Lambda を 1 回 invoke するだけで任意のタイミングで ON/OFF できる。
 
-- **実装**: `MAINTENANCE_MODE=true` 環境変数を付けて CDK デプロイすると、CloudFront Function が全 behavior（`defaultBehavior` / `/index.html` / `/storybook/*`）に `VIEWER_REQUEST` として紐付けられ、オリジン（S3）に到達せず即 503 を返す
+- **構成**:
+  - **CloudFront Function (`MaintenanceFunction`)**: 全 behavior（`defaultBehavior` / `/index.html` / `/storybook/*`）の `VIEWER_REQUEST` に常時紐付く。初期コードは OFF（通常動作 + `/storybook/` → `/storybook/index.html` のリライト）
+  - **Toggle Lambda (`MaintenanceToggle`)**: `enabled: boolean` を受け取り、`DescribeFunction` → `UpdateFunction` → `PublishFunction` で CloudFront Function のコードを ON / OFF 版に差し替えて LIVE ステージに昇格させる。API Gateway には公開していない（AWS CLI / マネジメントコンソールからのみ invoke）
 - **適用範囲**: CloudFront 配下の SPA・Storybook。API Gateway は影響を受けないため、SPA が読み込めないことで実質的にユーザー操作を停止する
-- **有効化手順**: `deploy.yml` ワークフローを GitHub Actions の `Run workflow`（workflow_dispatch）から起動し、`maintenance_mode` を `true` にして対象環境を選んで実行する
-- **解除手順**: 同じワークフローを `maintenance_mode=false`（既定）で再度実行し、通常デプロイする。`main` への push や release の公開でも自動的に解除される（それらのトリガーでは `MAINTENANCE_MODE` が未設定のため）
+- **有効化手順**（例: stg 環境）
+
+  ```bash
+  FN=$(aws cloudformation describe-stacks \
+    --stack-name ClassicalMusicLakeStack-stg \
+    --query 'Stacks[0].Outputs[?OutputKey==`MaintenanceToggleFunctionName`].OutputValue' \
+    --output text)
+  aws lambda invoke --function-name "$FN" \
+    --payload '{"enabled":true}' --cli-binary-format raw-in-base64-out /tmp/out.json
+  cat /tmp/out.json
+  ```
+
+- **解除手順**: 上記 payload を `{"enabled":false}` にして再度 invoke する。以降の通常デプロイ（`main` への push・release 公開等）でも、CloudFront Function の初期コードが OFF で上書きされるため自動的に解除される点に注意する
+- **イベント**: `{ "enabled": true | false }` を Lambda の event として渡す。`enabled` が boolean 以外の場合は 400 相当のエラーを投げる
 - **レスポンス**: `503` + `Retry-After` なし、`cache-control: no-store`、`content-type: text/html; charset=utf-8`、最小限のインライン HTML（ダーク系デザイン）
-- **制約**: CloudFront Function の切替はディストリビューションの変更を伴うため、反映に数分かかる。完全にオリジンリクエストを止めるため、S3 のコスト・DynamoDB のアクセスも遮断される
+- **反映時間**: `PublishFunction` 後、約 30 秒〜数分で全エッジに伝搬する
+- **IAM**: Toggle Lambda のロールには `cloudfront:DescribeFunction` / `cloudfront:UpdateFunction` / `cloudfront:PublishFunction` を対象 Function の ARN に限定して付与する
+- **制約**: CloudFront Function のコードサイズ上限は 10 KB、実行時間は最大 1 ms。503 レスポンス用 HTML はインラインで埋め込む最小限のものに留める
 
 ### 6.5 ロールバック戦略
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1093,7 +1093,18 @@ GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
 - **Secrets**:
   - `AWS_ROLE_TO_ASSUME`（prod テーブルへの `dynamodb:Scan`、stg テーブルへの `dynamodb:Scan` / `dynamodb:BatchWriteItem` 権限が必要）
 
-### 6.4 ロールバック戦略
+### 6.4 メンテナンスモード
+
+CloudFront レベルで全リクエストを閉じ、503 Service Unavailable とメンテナンス画面を返す機能。
+
+- **実装**: `MAINTENANCE_MODE=true` 環境変数を付けて CDK デプロイすると、CloudFront Function が全 behavior（`defaultBehavior` / `/index.html` / `/storybook/*`）に `VIEWER_REQUEST` として紐付けられ、オリジン（S3）に到達せず即 503 を返す
+- **適用範囲**: CloudFront 配下の SPA・Storybook。API Gateway は影響を受けないため、SPA が読み込めないことで実質的にユーザー操作を停止する
+- **有効化手順**: `deploy.yml` ワークフローを GitHub Actions の `Run workflow`（workflow_dispatch）から起動し、`maintenance_mode` を `true` にして対象環境を選んで実行する
+- **解除手順**: 同じワークフローを `maintenance_mode=false`（既定）で再度実行し、通常デプロイする。`main` への push や release の公開でも自動的に解除される（それらのトリガーでは `MAINTENANCE_MODE` が未設定のため）
+- **レスポンス**: `503` + `Retry-After` なし、`cache-control: no-store`、`content-type: text/html; charset=utf-8`、最小限のインライン HTML（ダーク系デザイン）
+- **制約**: CloudFront Function の切替はディストリビューションの変更を伴うため、反映に数分かかる。完全にオリジンリクエストを止めるため、S3 のコスト・DynamoDB のアクセスも遮断される
+
+### 6.5 ロールバック戦略
 
 #### バックエンド (Lambda / API Gateway)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,13 +44,13 @@ importers:
         version: 1.15.2(@typescript-eslint/utils@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(@vue/compiler-sfc@3.5.32)(eslint@10.2.0(jiti@2.6.1))(magicast@0.5.2)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@nuxt/test-utils':
         specifier: ^4.0.2
-        version: 4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+        version: 4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4)
       '@nuxtjs/color-mode':
         specifier: ^4.0.0
         version: 4.0.0(magicast@0.5.2)
       '@nuxtjs/storybook':
         specifier: ^9.0.1
-        version: 9.0.1(ud7jf5yye25fgdvjm77dbsla6i)
+        version: 9.0.1(f222fa9f9c6f1f82b2f90215869a2b07)
       '@storybook/addon-a11y':
         specifier: ^10.3.5
         version: 10.3.5(storybook@10.3.5(@testing-library/dom@10.4.1)(prettier@3.8.3)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))
@@ -62,13 +62,13 @@ importers:
         version: 9.6.1(@types/node@25.6.0)
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4)
       '@vitest/coverage-v8':
         specifier: ^4.1.4
         version: 4.1.4(vitest@4.1.4)
       '@vitest/eslint-plugin':
         specifier: ^1.6.16
-        version: 1.6.16(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+        version: 1.6.16(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)
       '@vue/test-utils':
         specifier: ^2.4.6
         version: 2.4.6
@@ -120,6 +120,9 @@ importers:
 
   backend:
     dependencies:
+      '@aws-sdk/client-cloudfront':
+        specifier: ^3.1030.0
+        version: 3.1032.0
       '@aws-sdk/client-cognito-identity-provider':
         specifier: ^3.1030.0
         version: 3.1031.0
@@ -159,7 +162,7 @@ importers:
         version: 9.6.1(@types/node@25.6.0)
       '@stryker-mutator/vitest-runner':
         specifier: ^9.6.1
-        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+        version: 9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4)
       '@types/aws-lambda':
         specifier: ^8.10.0
         version: 8.10.161
@@ -259,6 +262,10 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
+  '@aws-sdk/client-cloudfront@3.1032.0':
+    resolution: {integrity: sha512-/b04ltkCG6EBRPXjwgDHi1l3xZbaVj1TRnNy5VZHo6CjHrX+ObKPZWmTCSnTqQsX24HDDrTnwVqyZ0HikjuI2Q==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-cognito-identity-provider@3.1031.0':
     resolution: {integrity: sha512-P4+Jt5Ove035pIcQCeH0JIOVQvXscW0kbw54Foo0HReExR3DSDHaMmQ3IIMr6Q1Z+DKUlKbEBvW71tBEeI9Waw==}
     engines: {node: '>=20.0.0'}
@@ -275,12 +282,20 @@ packages:
     resolution: {integrity: sha512-8j+dMtyDqNXFmi09CBdz8TY6Ltf2jhfHuP6ZvG4zVjndRc6JF0aeBUbRwQLndbptFCsdctRQgdNWecy4TIfXAw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.974.1':
+    resolution: {integrity: sha512-gy/gffKz0zaHDaqRiLCdIvgHmaAL/HXuAtMcBP7euYSFx4BsbsdlfmUBJag+Gqe62z6/XuloKyQyaiH+kS3Vrg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.25':
     resolution: {integrity: sha512-6QfI0wv4jpG5CrdO/AO0JfZ2ux+tKwJPrUwmvxXF50vI5KIypKVGNF6b4vlkYEnKumDTI1NX2zUBi8JoU5QU3A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.26':
     resolution: {integrity: sha512-WBHAMxyPdgeJY6ZGLvq9mJwzZ+GaNUROQbfdVshtMsDVBrZTj5ZuFjKclSjSHvKSHJ4Y4O2yvI/aA/hrJbYfng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.27':
+    resolution: {integrity: sha512-xfUt2CUZDC+Tf16A6roD1b4pk/nrXdkoLY3TEhv198AXDtBo5xUJP1zd0e8SmuKLN4PpIBX96OizZbmMlcI6oQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.27':
@@ -291,12 +306,20 @@ packages:
     resolution: {integrity: sha512-+1DwCjjpo1WoiZTN08yGitI3nUwZUSQWVWFrW4C46HqZwACjcUQ7C66tnKPBTVxrEYYDOP11A6Afmu1L6ylt3g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.29':
+    resolution: {integrity: sha512-hjNeYb6oLyHgMihra83ie0J/T2y9om3cy1qC90h9DRgvYXEoN4BCFf8bHguZjKhXunnv7YkmZRuYL5Mkk77eCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.29':
     resolution: {integrity: sha512-SiBuAnXecCbT/OpAf3vqyI/AVE3mTaYr9ShXLybxZiPLBiPCCOIWSGAtYYGQWMRvobBTiqOewaB+wcgMMZI2Aw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.30':
     resolution: {integrity: sha512-Fg1oJcoijwOZjTxdbx+ubqbQl8YEQ4Cwhjw6TWzQjuDEvQYNhnCXW2pN7eKtdTrdE4a6+5TVKGSm2I+i2BKIQg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.972.31':
+    resolution: {integrity: sha512-PuQ7e8WYzAPpzvFcajxf8c0LqSzakVHVlKw8M0oubk8Kf347YOCCqT1seQrHs5AdZuIh2RD9LX4O+Xa5ImEBfQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.29':
@@ -307,12 +330,20 @@ packages:
     resolution: {integrity: sha512-nchIrrI/7dgjG1bW/DEWOJc00K9n+kkl6B8Mk0KO6d4GfWBOXlVr9uHp7CJR9FIrjmov5SGjHXG2q9XAtkRw6Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.31':
+    resolution: {integrity: sha512-bBmWDmtSpmLOZR6a0kmowBcVL1hiL8Vlap/RXeMpFd7JbWl87YcwqL6T9LH/0oBVEZXu1dUZAtojgSuZgMO5xw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.30':
     resolution: {integrity: sha512-FMnAnWxc8PG+ZrZ2OBKzY4luCUJhe9CG0B9YwYr4pzrYGLXBS2rl+UoUvjGbAwiptxRL6hyA3lFn03Bv1TLqTw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.31':
     resolution: {integrity: sha512-99OHVQ6eZ5DTxiOWgHdjBMvLqv7xoY4jLK6nZ1NcNSQbAnYZkQNIHi/VqInc9fnmg7of9si/z+waE6YL9OQIlw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.32':
+    resolution: {integrity: sha512-9aj0x9hGYUondBZSD0XkksAdHhOKttFw4BWpLCeggeg40qSJxGrAP++g0GCm0VqWc1WtC/NRFiAVzPCy56vmog==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.25':
@@ -323,6 +354,10 @@ packages:
     resolution: {integrity: sha512-jibxNld3m+vbmQwn98hcQ+fLIVrx3cQuhZlSs1/hix48SjDS5/pjMLwpmtLD/lFnd6ve1AL4o1bZg3X1WRa2SQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.27':
+    resolution: {integrity: sha512-1CZvfb1WzudWWIFAVQkd1OI/T1RxPcSvNWzNsb2BMBVsBJzBtB8dV5f2nymHVU4UqwxipdVt/DAbgdDRf33JDg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.29':
     resolution: {integrity: sha512-HWv4SEq3jZDYPlwryZVef97+U8CxxRos5mK8sgGO1dQaFZpV5giZLzqGE5hkDmh2csYcBO2uf5XHjPTpZcJlig==}
     engines: {node: '>=20.0.0'}
@@ -331,12 +366,20 @@ packages:
     resolution: {integrity: sha512-honYIM17F/+QSWJRE84T4u//ofqEi7rLbnwmIpu7fgFX5PML78wbtdSAy5Xwyve3TLpE9/f9zQx0aBVxSjAOPw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.972.31':
+    resolution: {integrity: sha512-x8Mx18S48XMl9bEEpYwmXDTvjWGPIfDadReN37Lc099/DUrlL4Zs9T9rwwggo6DkKS1aev6v+MTUx7JTa87TZQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.29':
     resolution: {integrity: sha512-PdMBza1WEKEUPFEmMGCfnU2RYCz9MskU2e8JxjyUOsMKku7j9YaDKvbDi2dzC0ihFoM6ods2SbhfAAro+Gwlew==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.972.30':
     resolution: {integrity: sha512-CyL4oWUlONQRN2SsYMVrA9Z3i3QfLWTQctI8tuKbjNGCVVDCnJf/yMbSJCOZgpPFRtxh7dgQwvpqwmJm+iytmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.31':
+    resolution: {integrity: sha512-zfuNMIkGfjYsHis9qytYf74Bcmq6Ji9Xwf4w53baRCI/b2otTwZv3SW1uRiJ5Di7999QzRGhHZ96+eUeo3gSOA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/dynamodb-codec@3.972.28':
@@ -389,12 +432,20 @@ packages:
     resolution: {integrity: sha512-lCz6JfelhjD6Eco1urXM2rOYRaxROSqeoY6IEKx+soegFJOajmIBCMHTAWuJl25Wf9IAST+i0/yOk9G3rMV26A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-user-agent@3.972.31':
+    resolution: {integrity: sha512-L+hXN2HDomlIsWSHW5DVD7ppccCeRnlHXZ5uHG34ePTjF5bm0I1fmrJLbUGiW97xRXWryit5cjdP4Sx2FwiGog==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.996.19':
     resolution: {integrity: sha512-uFkmCDXvmQYLanlYdOFS0+MQWkrj9wPMt/ZCc/0J0fjPim6F5jBVBmEomvGY/j77ILW6GTPwN22Jc174Mhkw6Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.996.20':
     resolution: {integrity: sha512-bzPdsNQnCh6TvvUmTHLZlL8qgyME6mNiUErcRMyJPywIl1BEu2VZRShel3mUoSh89bOBEXEWtjocDMolFxd/9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.996.21':
+    resolution: {integrity: sha512-Me3d/ua2lb2G0bQfFmvCeQQp3+nN6GSPqMxDmi/IQlQ8CrlpQ5C0JJHpz2AnOUkEFI0lBNrAL3Vnt29l44ndkA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/region-config-resolver@3.972.11':
@@ -411,6 +462,10 @@ packages:
 
   '@aws-sdk/token-providers@3.1031.0':
     resolution: {integrity: sha512-zj/PvnbQK/2KJNln5K2QRI9HSsy+B4emz2gbQyUHkk6l7Lidu83P/9tfmC2cJXkcC3vdmyKH2DP3Iw/FDfKQuQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1032.0':
+    resolution: {integrity: sha512-n+PU8Z+gll7p3wDrH+Wo6fkt8sPrVnq30YYM6Ryga95oJlEneNMEbDHj0iqjMX3V7gaGdJo/hJWyPo4lscP+mA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.7':
@@ -456,6 +511,15 @@ packages:
 
   '@aws-sdk/util-user-agent-node@3.973.16':
     resolution: {integrity: sha512-ccvu0FNCI0C6OqmxI/tWn7BD8qGooWuURssiIM+6vbksFO8opXR4JOGtGYPj8QYzN/vfwNYrcK344PPbYuvzRg==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      aws-crt: '>=1.0.0'
+    peerDependenciesMeta:
+      aws-crt:
+        optional: true
+
+  '@aws-sdk/util-user-agent-node@3.973.17':
+    resolution: {integrity: sha512-utF5qjjbuJQuU9VdCkWl7L87sr93cApsrD+uxGfUnlafX8iyEzJrb7EZnufjThURZVTOtelRMXrblWxpefElUg==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       aws-crt: '>=1.0.0'
@@ -2636,10 +2700,6 @@ packages:
     resolution: {integrity: sha512-2+KTsJEwTi63NUv4uR9IQ+IFT1yu6Rf6JuoBK2WKaaJ/TRvOiOVGcXAsEqX/TQN2thR9yII21kPUJq1UV/WI2A==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/util-stream@4.5.22':
-    resolution: {integrity: sha512-3H8iq/0BfQjUs2/4fbHZ9aG9yNzcuZs24LPkcX1Q7Z+qpqaGM8+qbGmE8zo9m2nCRgamyvS98cHdcWvR6YUsew==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/util-stream@4.5.23':
     resolution: {integrity: sha512-N6on1+ngJ3RznZOnDWNveIwnTSlqxNnXuNAh7ez889ZZaRdXoNRTXKgmYOLe6dB0gCmAVtuRScE1hymQFl4hpg==}
     engines: {node: '>=18.0.0'}
@@ -2658,6 +2718,10 @@ packages:
 
   '@smithy/util-waiter@4.2.15':
     resolution: {integrity: sha512-oUt9o7n8hBv3BL56sLSneL0XeigZSuem0Hr78JaoK33D9oKieyCvVP8eTSe3j7g2mm/S1DvzxKieG7JEWNJUNg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-waiter@4.2.16':
+    resolution: {integrity: sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/uuid@1.1.2':
@@ -7004,6 +7068,52 @@ snapshots:
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
+  '@aws-sdk/client-cloudfront@3.1032.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/credential-provider-node': 3.972.32
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.17
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/core': 3.23.15
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-retry': 4.5.3
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.47
+      '@smithy/util-defaults-mode-node': 4.2.52
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
+      '@smithy/util-stream': 4.5.23
+      '@smithy/util-utf8': 4.2.2
+      '@smithy/util-waiter': 4.2.16
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/client-cognito-identity-provider@3.1031.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -7097,17 +7207,17 @@ snapshots:
 
   '@aws-sdk/core@3.973.27':
     dependencies:
-      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/types': 3.973.8
       '@aws-sdk/xml-builder': 3.972.17
-      '@smithy/core': 3.23.14
-      '@smithy/node-config-provider': 4.3.13
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.13
-      '@smithy/protocol-http': 5.3.13
+      '@smithy/protocol-http': 5.3.14
       '@smithy/signature-v4': 5.3.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
-      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-middleware': 4.2.14
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
@@ -7127,12 +7237,28 @@ snapshots:
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.1':
+    dependencies:
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/xml-builder': 3.972.18
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/signature-v4': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/types': 4.14.0
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.26':
@@ -7143,17 +7269,25 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-env@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-http@3.972.27':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/types': 3.973.7
-      '@smithy/fetch-http-handler': 5.3.16
-      '@smithy/node-http-handler': 4.5.2
-      '@smithy/property-provider': 4.2.13
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
-      '@smithy/util-stream': 4.5.22
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.28':
@@ -7169,21 +7303,34 @@ snapshots:
       '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-http@3.972.29':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-ini@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/credential-provider-env': 3.972.25
-      '@aws-sdk/credential-provider-http': 3.972.27
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/credential-provider-env': 3.972.26
+      '@aws-sdk/credential-provider-http': 3.972.28
       '@aws-sdk/credential-provider-login': 3.972.29
-      '@aws-sdk/credential-provider-process': 3.972.25
-      '@aws-sdk/credential-provider-sso': 3.972.29
-      '@aws-sdk/credential-provider-web-identity': 3.972.29
+      '@aws-sdk/credential-provider-process': 3.972.26
+      '@aws-sdk/credential-provider-sso': 3.972.30
+      '@aws-sdk/credential-provider-web-identity': 3.972.30
       '@aws-sdk/nested-clients': 3.996.19
-      '@aws-sdk/types': 3.973.7
-      '@smithy/credential-provider-imds': 4.2.13
-      '@smithy/property-provider': 4.2.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7207,15 +7354,34 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/credential-provider-env': 3.972.27
+      '@aws-sdk/credential-provider-http': 3.972.29
+      '@aws-sdk/credential-provider-login': 3.972.31
+      '@aws-sdk/credential-provider-process': 3.972.27
+      '@aws-sdk/credential-provider-sso': 3.972.31
+      '@aws-sdk/credential-provider-web-identity': 3.972.31
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-login@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/nested-clients': 3.996.19
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/nested-clients': 3.996.20
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7233,6 +7399,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-login@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-node@3.972.30':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.972.25
@@ -7241,11 +7420,11 @@ snapshots:
       '@aws-sdk/credential-provider-process': 3.972.25
       '@aws-sdk/credential-provider-sso': 3.972.29
       '@aws-sdk/credential-provider-web-identity': 3.972.29
-      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/types': 3.973.8
       '@smithy/credential-provider-imds': 4.2.13
       '@smithy/property-provider': 4.2.13
       '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7267,13 +7446,30 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.32':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.27
+      '@aws-sdk/credential-provider-http': 3.972.29
+      '@aws-sdk/credential-provider-ini': 3.972.31
+      '@aws-sdk/credential-provider-process': 3.972.27
+      '@aws-sdk/credential-provider-sso': 3.972.31
+      '@aws-sdk/credential-provider-web-identity': 3.972.31
+      '@aws-sdk/types': 3.973.8
+      '@smithy/credential-provider-imds': 4.2.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-process@3.972.25':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.26':
@@ -7285,15 +7481,24 @@ snapshots:
       '@smithy/types': 4.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-process@3.972.27':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-sso@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/core': 3.974.0
       '@aws-sdk/nested-clients': 3.996.19
       '@aws-sdk/token-providers': 3.1026.0
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7311,14 +7516,27 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/token-providers': 3.1032.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/credential-provider-web-identity@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.973.27
+      '@aws-sdk/core': 3.974.0
       '@aws-sdk/nested-clients': 3.996.19
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7335,12 +7553,24 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-web-identity@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/dynamodb-codec@3.972.28':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@smithy/core': 3.23.14
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
+      '@aws-sdk/core': 3.974.0
+      '@smithy/core': 3.23.15
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -7362,10 +7592,10 @@ snapshots:
   '@aws-sdk/middleware-endpoint-discovery@3.972.10':
     dependencies:
       '@aws-sdk/endpoint-cache': 3.972.5
-      '@aws-sdk/types': 3.973.7
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.10':
@@ -7377,9 +7607,9 @@ snapshots:
 
   '@aws-sdk/middleware-host-header@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.7
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.972.10':
@@ -7390,16 +7620,16 @@ snapshots:
 
   '@aws-sdk/middleware-logger@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.7
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.10':
     dependencies:
-      '@aws-sdk/types': 3.973.7
+      '@aws-sdk/types': 3.973.8
       '@aws/lambda-invoke-store': 0.2.4
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.972.11':
@@ -7412,13 +7642,13 @@ snapshots:
 
   '@aws-sdk/middleware-user-agent@3.972.29':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/types': 3.973.7
-      '@aws-sdk/util-endpoints': 3.996.6
-      '@smithy/core': 3.23.14
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
-      '@smithy/util-retry': 4.3.1
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.2
       tslib: 2.8.1
 
   '@aws-sdk/middleware-user-agent@3.972.30':
@@ -7432,44 +7662,55 @@ snapshots:
       '@smithy/util-retry': 4.3.2
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-user-agent@3.972.31':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-retry': 4.3.2
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.996.19':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/middleware-host-header': 3.972.9
-      '@aws-sdk/middleware-logger': 3.972.9
-      '@aws-sdk/middleware-recursion-detection': 3.972.10
-      '@aws-sdk/middleware-user-agent': 3.972.29
-      '@aws-sdk/region-config-resolver': 3.972.11
-      '@aws-sdk/types': 3.973.7
-      '@aws-sdk/util-endpoints': 3.996.6
-      '@aws-sdk/util-user-agent-browser': 3.972.9
-      '@aws-sdk/util-user-agent-node': 3.973.15
-      '@smithy/config-resolver': 4.4.15
-      '@smithy/core': 3.23.14
-      '@smithy/fetch-http-handler': 5.3.16
-      '@smithy/hash-node': 4.2.13
-      '@smithy/invalid-dependency': 4.2.13
-      '@smithy/middleware-content-length': 4.2.13
-      '@smithy/middleware-endpoint': 4.4.29
-      '@smithy/middleware-retry': 4.5.1
-      '@smithy/middleware-serde': 4.2.17
-      '@smithy/middleware-stack': 4.2.13
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/node-http-handler': 4.5.2
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
-      '@smithy/url-parser': 4.2.13
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.30
+      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.16
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/core': 3.23.15
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-retry': 4.5.3
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
       '@smithy/util-body-length-node': 4.2.3
-      '@smithy/util-defaults-mode-browser': 4.3.45
-      '@smithy/util-defaults-mode-node': 4.2.50
-      '@smithy/util-endpoints': 3.4.0
-      '@smithy/util-middleware': 4.2.13
-      '@smithy/util-retry': 4.3.1
+      '@smithy/util-defaults-mode-browser': 4.3.47
+      '@smithy/util-defaults-mode-node': 4.2.52
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7518,12 +7759,55 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.996.21':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/middleware-host-header': 3.972.10
+      '@aws-sdk/middleware-logger': 3.972.10
+      '@aws-sdk/middleware-recursion-detection': 3.972.11
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/region-config-resolver': 3.972.12
+      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/util-endpoints': 3.996.7
+      '@aws-sdk/util-user-agent-browser': 3.972.10
+      '@aws-sdk/util-user-agent-node': 3.973.17
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/core': 3.23.15
+      '@smithy/fetch-http-handler': 5.3.17
+      '@smithy/hash-node': 4.2.14
+      '@smithy/invalid-dependency': 4.2.14
+      '@smithy/middleware-content-length': 4.2.14
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-retry': 4.5.3
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/node-http-handler': 4.5.3
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.47
+      '@smithy/util-defaults-mode-node': 4.2.52
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/region-config-resolver@3.972.11':
     dependencies:
-      '@aws-sdk/types': 3.973.7
-      '@smithy/config-resolver': 4.4.15
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/config-resolver': 4.4.16
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/region-config-resolver@3.972.12':
@@ -7536,12 +7820,12 @@ snapshots:
 
   '@aws-sdk/token-providers@3.1026.0':
     dependencies:
-      '@aws-sdk/core': 3.973.27
-      '@aws-sdk/nested-clients': 3.996.19
-      '@aws-sdk/types': 3.973.7
-      '@smithy/property-provider': 4.2.13
-      '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@aws-sdk/core': 3.974.0
+      '@aws-sdk/nested-clients': 3.996.20
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -7558,9 +7842,21 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/token-providers@3.1032.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.1
+      '@aws-sdk/nested-clients': 3.996.21
+      '@aws-sdk/types': 3.973.8
+      '@smithy/property-provider': 4.2.14
+      '@smithy/shared-ini-file-loader': 4.4.9
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
   '@aws-sdk/types@3.973.7':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.8':
@@ -7575,10 +7871,10 @@ snapshots:
 
   '@aws-sdk/util-endpoints@3.996.6':
     dependencies:
-      '@aws-sdk/types': 3.973.7
-      '@smithy/types': 4.14.0
-      '@smithy/url-parser': 4.2.13
-      '@smithy/util-endpoints': 3.4.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-endpoints': 3.4.1
       tslib: 2.8.1
 
   '@aws-sdk/util-endpoints@3.996.7':
@@ -7602,17 +7898,17 @@ snapshots:
 
   '@aws-sdk/util-user-agent-browser@3.972.9':
     dependencies:
-      '@aws-sdk/types': 3.973.7
-      '@smithy/types': 4.14.0
+      '@aws-sdk/types': 3.973.8
+      '@smithy/types': 4.14.1
       bowser: 2.14.1
       tslib: 2.8.1
 
   '@aws-sdk/util-user-agent-node@3.973.15':
     dependencies:
-      '@aws-sdk/middleware-user-agent': 3.972.29
-      '@aws-sdk/types': 3.973.7
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/types': 4.14.0
+      '@aws-sdk/middleware-user-agent': 3.972.30
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
@@ -7625,9 +7921,18 @@ snapshots:
       '@smithy/util-config-provider': 4.2.2
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-node@3.973.17':
+    dependencies:
+      '@aws-sdk/middleware-user-agent': 3.972.31
+      '@aws-sdk/types': 3.973.8
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-config-provider': 4.2.2
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.17':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       fast-xml-parser: 5.5.6
       tslib: 2.8.1
 
@@ -8890,7 +9195,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.1.0
 
-  '@nuxt/test-utils@4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
+  '@nuxt/test-utils@4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4)':
     dependencies:
       '@clack/prompts': 1.2.0
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
@@ -8919,7 +9224,7 @@ snapshots:
       tinyexec: 1.1.1
       ufo: 1.6.3
       unplugin: 3.0.0
-      vitest-environment-nuxt: 2.0.0(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      vitest-environment-nuxt: 2.0.0(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4)
       vue: 3.5.32(typescript@6.0.2)
     optionalDependencies:
       '@vue/test-utils': 2.4.6
@@ -9065,11 +9370,11 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxtjs/storybook@9.0.1(ud7jf5yye25fgdvjm77dbsla6i)':
+  '@nuxtjs/storybook@9.0.1(f222fa9f9c6f1f82b2f90215869a2b07)':
     dependencies:
       '@nuxt/devtools-kit': 2.7.0(magicast@0.5.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
-      '@storybook-vue/nuxt': 9.0.1(ud7jf5yye25fgdvjm77dbsla6i)
+      '@storybook-vue/nuxt': 9.0.1(f222fa9f9c6f1f82b2f90215869a2b07)
       chalk: 5.6.2
       consola: 3.4.2
       defu: 6.1.6
@@ -9605,11 +9910,11 @@ snapshots:
 
   '@smithy/config-resolver@4.4.15':
     dependencies:
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-config-provider': 4.2.2
-      '@smithy/util-endpoints': 3.4.0
-      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-endpoints': 3.4.1
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/config-resolver@4.4.16':
@@ -9623,13 +9928,13 @@ snapshots:
 
   '@smithy/core@3.23.14':
     dependencies:
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
-      '@smithy/url-parser': 4.2.13
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       '@smithy/util-base64': 4.3.2
       '@smithy/util-body-length-browser': 4.2.2
-      '@smithy/util-middleware': 4.2.13
-      '@smithy/util-stream': 4.5.22
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-stream': 4.5.23
       '@smithy/util-utf8': 4.2.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
@@ -9649,10 +9954,10 @@ snapshots:
 
   '@smithy/credential-provider-imds@4.2.13':
     dependencies:
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/property-provider': 4.2.13
-      '@smithy/types': 4.14.0
-      '@smithy/url-parser': 4.2.13
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/property-provider': 4.2.14
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
       tslib: 2.8.1
 
   '@smithy/credential-provider-imds@4.2.14':
@@ -9665,9 +9970,9 @@ snapshots:
 
   '@smithy/fetch-http-handler@5.3.16':
     dependencies:
-      '@smithy/protocol-http': 5.3.13
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.13
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       '@smithy/util-base64': 4.3.2
       tslib: 2.8.1
 
@@ -9681,7 +9986,7 @@ snapshots:
 
   '@smithy/hash-node@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       '@smithy/util-buffer-from': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
@@ -9695,7 +10000,7 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/invalid-dependency@4.2.14':
@@ -9713,8 +10018,8 @@ snapshots:
 
   '@smithy/middleware-content-length@4.2.13':
     dependencies:
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/middleware-content-length@4.2.14':
@@ -9725,13 +10030,13 @@ snapshots:
 
   '@smithy/middleware-endpoint@4.4.29':
     dependencies:
-      '@smithy/core': 3.23.14
-      '@smithy/middleware-serde': 4.2.17
-      '@smithy/node-config-provider': 4.3.13
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-serde': 4.2.18
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
-      '@smithy/url-parser': 4.2.13
-      '@smithy/util-middleware': 4.2.13
+      '@smithy/types': 4.14.1
+      '@smithy/url-parser': 4.2.14
+      '@smithy/util-middleware': 4.2.14
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@4.4.30':
@@ -9747,14 +10052,14 @@ snapshots:
 
   '@smithy/middleware-retry@4.5.1':
     dependencies:
-      '@smithy/core': 3.23.14
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/protocol-http': 5.3.13
+      '@smithy/core': 3.23.15
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/protocol-http': 5.3.14
       '@smithy/service-error-classification': 4.2.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
-      '@smithy/util-middleware': 4.2.13
-      '@smithy/util-retry': 4.3.1
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
+      '@smithy/util-middleware': 4.2.14
+      '@smithy/util-retry': 4.3.2
       '@smithy/uuid': 1.1.2
       tslib: 2.8.1
 
@@ -9773,9 +10078,9 @@ snapshots:
 
   '@smithy/middleware-serde@4.2.17':
     dependencies:
-      '@smithy/core': 3.23.14
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/core': 3.23.15
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/middleware-serde@4.2.18':
@@ -9787,7 +10092,7 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/middleware-stack@4.2.14':
@@ -9799,7 +10104,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.13
       '@smithy/shared-ini-file-loader': 4.4.8
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-config-provider@4.3.14':
@@ -9811,9 +10116,9 @@ snapshots:
 
   '@smithy/node-http-handler@4.5.2':
     dependencies:
-      '@smithy/protocol-http': 5.3.13
+      '@smithy/protocol-http': 5.3.14
       '@smithy/querystring-builder': 4.2.13
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.5.3':
@@ -9825,7 +10130,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/property-provider@4.2.14':
@@ -9835,7 +10140,7 @@ snapshots:
 
   '@smithy/protocol-http@5.3.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/protocol-http@5.3.14':
@@ -9845,7 +10150,7 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       '@smithy/util-uri-escape': 4.2.2
       tslib: 2.8.1
 
@@ -9857,7 +10162,7 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/querystring-parser@4.2.14':
@@ -9867,7 +10172,7 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
 
   '@smithy/service-error-classification@4.2.14':
     dependencies:
@@ -9875,7 +10180,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.4.8':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/shared-ini-file-loader@4.4.9':
@@ -9886,10 +10191,10 @@ snapshots:
   '@smithy/signature-v4@5.3.13':
     dependencies:
       '@smithy/is-array-buffer': 4.2.2
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
       '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-middleware': 4.2.13
+      '@smithy/util-middleware': 4.2.14
       '@smithy/util-uri-escape': 4.2.2
       '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
@@ -9917,12 +10222,12 @@ snapshots:
 
   '@smithy/smithy-client@4.12.9':
     dependencies:
-      '@smithy/core': 3.23.14
-      '@smithy/middleware-endpoint': 4.4.29
-      '@smithy/middleware-stack': 4.2.13
-      '@smithy/protocol-http': 5.3.13
-      '@smithy/types': 4.14.0
-      '@smithy/util-stream': 4.5.22
+      '@smithy/core': 3.23.15
+      '@smithy/middleware-endpoint': 4.4.30
+      '@smithy/middleware-stack': 4.2.14
+      '@smithy/protocol-http': 5.3.14
+      '@smithy/types': 4.14.1
+      '@smithy/util-stream': 4.5.23
       tslib: 2.8.1
 
   '@smithy/types@4.14.0':
@@ -9936,7 +10241,7 @@ snapshots:
   '@smithy/url-parser@4.2.13':
     dependencies:
       '@smithy/querystring-parser': 4.2.13
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/url-parser@4.2.14':
@@ -9976,8 +10281,8 @@ snapshots:
   '@smithy/util-defaults-mode-browser@4.3.45':
     dependencies:
       '@smithy/property-provider': 4.2.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-browser@4.3.47':
@@ -9989,12 +10294,12 @@ snapshots:
 
   '@smithy/util-defaults-mode-node@4.2.50':
     dependencies:
-      '@smithy/config-resolver': 4.4.15
+      '@smithy/config-resolver': 4.4.16
       '@smithy/credential-provider-imds': 4.2.13
-      '@smithy/node-config-provider': 4.3.13
+      '@smithy/node-config-provider': 4.3.14
       '@smithy/property-provider': 4.2.13
-      '@smithy/smithy-client': 4.12.9
-      '@smithy/types': 4.14.0
+      '@smithy/smithy-client': 4.12.11
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@4.2.52':
@@ -10009,8 +10314,8 @@ snapshots:
 
   '@smithy/util-endpoints@3.4.0':
     dependencies:
-      '@smithy/node-config-provider': 4.3.13
-      '@smithy/types': 4.14.0
+      '@smithy/node-config-provider': 4.3.14
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-endpoints@3.4.1':
@@ -10025,7 +10330,7 @@ snapshots:
 
   '@smithy/util-middleware@4.2.13':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-middleware@4.2.14':
@@ -10036,24 +10341,13 @@ snapshots:
   '@smithy/util-retry@4.3.1':
     dependencies:
       '@smithy/service-error-classification': 4.2.13
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/util-retry@4.3.2':
     dependencies:
       '@smithy/service-error-classification': 4.2.14
       '@smithy/types': 4.14.1
-      tslib: 2.8.1
-
-  '@smithy/util-stream@4.5.22':
-    dependencies:
-      '@smithy/fetch-http-handler': 5.3.16
-      '@smithy/node-http-handler': 4.5.2
-      '@smithy/types': 4.14.0
-      '@smithy/util-base64': 4.3.2
-      '@smithy/util-buffer-from': 4.2.2
-      '@smithy/util-hex-encoding': 4.2.2
-      '@smithy/util-utf8': 4.2.2
       tslib: 2.8.1
 
   '@smithy/util-stream@4.5.23':
@@ -10083,7 +10377,12 @@ snapshots:
 
   '@smithy/util-waiter@4.2.15':
     dependencies:
-      '@smithy/types': 4.14.0
+      '@smithy/types': 4.14.1
+      tslib: 2.8.1
+
+  '@smithy/util-waiter@4.2.16':
+    dependencies:
+      '@smithy/types': 4.14.1
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.2':
@@ -10094,7 +10393,7 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@storybook-vue/nuxt@9.0.1(ud7jf5yye25fgdvjm77dbsla6i)':
+  '@storybook-vue/nuxt@9.0.1(f222fa9f9c6f1f82b2f90215869a2b07)':
     dependencies:
       '@nuxt/kit': 3.21.2(magicast@0.5.2)
       '@nuxt/schema': 3.21.2
@@ -10277,7 +10576,7 @@ snapshots:
 
   '@stryker-mutator/util@9.6.1': {}
 
-  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
+  '@stryker-mutator/vitest-runner@9.6.1(@stryker-mutator/core@9.6.1(@types/node@25.6.0))(vitest@4.1.4)':
     dependencies:
       '@stryker-mutator/api': 9.6.1
       '@stryker-mutator/core': 9.6.1(@types/node@25.6.0)
@@ -10628,7 +10927,7 @@ snapshots:
       tinyrainbow: 3.1.0
       vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))
 
-  '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))':
+  '@vitest/eslint-plugin@1.6.16(@typescript-eslint/eslint-plugin@8.58.0(@typescript-eslint/parser@8.58.0(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)(vitest@4.1.4)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.2
       '@typescript-eslint/utils': 8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)
@@ -14542,9 +14841,9 @@ snapshots:
       terser: 5.46.1
       yaml: 2.8.3
 
-  vitest-environment-nuxt@2.0.0(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))):
+  vitest-environment-nuxt@2.0.0(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4):
     dependencies:
-      '@nuxt/test-utils': 4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(happy-dom@20.8.9)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3)))
+      '@nuxt/test-utils': 4.0.2(@vue/test-utils@2.4.6)(crossws@0.4.5(srvx@0.11.15))(happy-dom@20.8.9)(magicast@0.5.2)(playwright-core@1.59.1)(typescript@6.0.2)(vite@7.3.1(@types/node@25.6.0)(jiti@2.6.1)(terser@5.46.1)(yaml@2.8.3))(vitest@4.1.4)
     transitivePeerDependencies:
       - '@cucumber/cucumber'
       - '@jest/globals'


### PR DESCRIPTION
MAINTENANCE_MODE=true で CDK デプロイすると、CloudFront Function が全
behavior の VIEWER_REQUEST に紐付き、オリジン到達前に 503 メンテナンス
ページを返す。GitHub Actions の workflow_dispatch で maintenance_mode
トグルを追加し、手動切替運用とする