### PR TITLE
Add composer portrait image support with imageUrl field

### DIFF
--- a/app/components/molecules/ComposerItem.stories.ts
+++ b/app/components/molecules/ComposerItem.stories.ts
@@ -29,3 +29,15 @@ export const WithCategories: Story = {
     },
   },
 };
+
+export const WithImage: Story = {
+  args: {
+    composer: {
+      ...baseComposer,
+      era: "古典派",
+      region: "ドイツ・オーストリア",
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Beethoven.jpg/240px-Beethoven.jpg",
+    },
+  },
+};

--- a/app/components/molecules/ComposerItem.test.ts
+++ b/app/components/molecules/ComposerItem.test.ts
@@ -94,4 +94,25 @@ describe("ComposerItem", () => {
       expect(wrapper.find(".composer-category-list").exists()).toBe(false);
     });
   });
+
+  describe("画像表示", () => {
+    it("imageUrl が設定されている場合、サムネイルが表示される", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: {
+          composer: { ...sampleComposer, imageUrl: "https://example.com/beethoven.jpg" },
+        },
+      });
+      const img = wrapper.find("img.composer-thumb");
+      expect(img.exists()).toBe(true);
+      expect(img.attributes("src")).toBe("https://example.com/beethoven.jpg");
+      expect(img.attributes("alt")).toBe("ベートーヴェン");
+    });
+
+    it("imageUrl が未設定の場合、サムネイルが表示されない", async () => {
+      const wrapper = await mountSuspended(ComposerItem, {
+        props: { composer: sampleComposer },
+      });
+      expect(wrapper.find("img.composer-thumb").exists()).toBe(false);
+    });
+  });
 });

--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -14,6 +14,14 @@ const emit = defineEmits<{
 
 <template>
   <div class="composer-item">
+    <img
+      v-if="composer.imageUrl"
+      :src="composer.imageUrl"
+      :alt="composer.name"
+      class="composer-thumb"
+      loading="lazy"
+      referrerpolicy="no-referrer"
+    />
     <div class="composer-main">
       <div class="composer-name">{{ composer.name }}</div>
       <div class="composer-category-wrapper">
@@ -38,6 +46,15 @@ const emit = defineEmits<{
   justify-content: space-between;
   align-items: center;
   gap: 1rem;
+}
+
+.composer-thumb {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  object-fit: cover;
+  background: var(--color-bg-elevated);
+  flex-shrink: 0;
 }
 
 .composer-main {

--- a/app/components/organisms/ComposerForm.vue
+++ b/app/components/organisms/ComposerForm.vue
@@ -19,6 +19,7 @@ const form = reactive({
   name: "",
   era: "",
   region: "",
+  imageUrl: "",
 });
 
 watch(
@@ -27,6 +28,7 @@ watch(
     form.name = initialValues?.name ?? "";
     form.era = initialValues?.era ?? "";
     form.region = initialValues?.region ?? "";
+    form.imageUrl = initialValues?.imageUrl ?? "";
   },
   { immediate: true }
 );
@@ -36,6 +38,7 @@ function handleSubmit() {
     name: form.name,
     era: (form.era || undefined) as CreateComposerInput["era"],
     region: (form.region || undefined) as CreateComposerInput["region"],
+    imageUrl: form.imageUrl || undefined,
   });
 }
 </script>
@@ -61,6 +64,14 @@ function handleSubmit() {
         v-model="form.region"
         :options="regionOptions"
         placeholder="選択してください"
+      />
+    </FormGroup>
+
+    <FormGroup label="画像 URL" input-id="imageUrl">
+      <TextInput
+        id="imageUrl"
+        v-model="form.imageUrl"
+        placeholder="例：https://upload.wikimedia.org/..."
       />
     </FormGroup>
 

--- a/app/components/templates/ComposerDetailTemplate.stories.ts
+++ b/app/components/templates/ComposerDetailTemplate.stories.ts
@@ -30,3 +30,15 @@ export const AsVisitor: Story = {
 export const ErrorState: Story = {
   args: { composer: null, error: new Error("fail"), isAdmin: false },
 };
+
+export const WithImage: Story = {
+  args: {
+    composer: {
+      ...sample,
+      imageUrl:
+        "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6f/Beethoven.jpg/320px-Beethoven.jpg",
+    },
+    error: null,
+    isAdmin: false,
+  },
+};

--- a/app/components/templates/ComposerDetailTemplate.test.ts
+++ b/app/components/templates/ComposerDetailTemplate.test.ts
@@ -49,4 +49,24 @@ describe("ComposerDetailTemplate", () => {
     });
     expect(wrapper.text()).toContain("作曲家の取得に失敗しました");
   });
+
+  it("imageUrl が設定されている場合、画像が表示される", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: {
+        composer: { ...sample, imageUrl: "https://example.com/beethoven.jpg" },
+        error: null,
+        isAdmin: false,
+      },
+    });
+    const img = wrapper.find("img.composer-image");
+    expect(img.exists()).toBe(true);
+    expect(img.attributes("src")).toBe("https://example.com/beethoven.jpg");
+  });
+
+  it("imageUrl が未設定の場合、画像が表示されない", async () => {
+    const wrapper = await mountSuspended(ComposerDetailTemplate, {
+      props: { composer: sample, error: null, isAdmin: false },
+    });
+    expect(wrapper.find("img.composer-image").exists()).toBe(false);
+  });
 });

--- a/app/components/templates/ComposerDetailTemplate.vue
+++ b/app/components/templates/ComposerDetailTemplate.vue
@@ -24,6 +24,14 @@ const emit = defineEmits<{
 
     <template v-else-if="composer">
       <div class="composer-header">
+        <img
+          v-if="composer.imageUrl"
+          :src="composer.imageUrl"
+          :alt="composer.name"
+          class="composer-image"
+          loading="lazy"
+          referrerpolicy="no-referrer"
+        />
         <div class="composer-name">{{ composer.name }}</div>
         <div class="composer-category-wrapper">
           <ComposerCategoryList :composer="composer" />
@@ -52,6 +60,17 @@ const emit = defineEmits<{
 
 .composer-header {
   margin-bottom: 1.5rem;
+}
+
+.composer-image {
+  max-width: 240px;
+  max-height: 320px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+  background: var(--color-bg-elevated);
 }
 
 .composer-name {

--- a/app/components/templates/ComposerEditTemplate.vue
+++ b/app/components/templates/ComposerEditTemplate.vue
@@ -25,6 +25,7 @@ const emit = defineEmits<{
           name: composer?.name,
           era: composer?.era,
           region: composer?.region,
+          imageUrl: composer?.imageUrl,
         }"
         submit-label="更新する"
         @submit="emit('submit', $event)"

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -82,6 +82,7 @@ export interface Composer {
   name: string; // 作曲家名（例: ベートーヴェン）
   era?: PieceEra; // 時代（楽曲マスタと共通の定数を流用）
   region?: PieceRegion; // 地域（楽曲マスタと共通の定数を流用）
+  imageUrl?: string; // 肖像画像の URL（Wikimedia Commons 等のパブリックドメイン画像を想定）
   createdAt: string;
   updatedAt: string;
 }

--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "../types";
 
-const CLEARABLE_FIELDS = ["era", "region"] as const;
+const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
 
 export type ComposerRepository = {
   findById(id: string): Promise<Composer | undefined>;

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -204,6 +204,41 @@ describe("POST /composers (create)", () => {
       );
       expect(result?.statusCode).toBe(400);
     });
+
+    it("imageUrl を指定して作成できる", async () => {
+      mockRepo.save.mockResolvedValueOnce();
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({
+            ...validInput,
+            imageUrl: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg",
+          }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(201);
+      const body = JSON.parse(result?.body ?? "{}");
+      expect(body.imageUrl).toBe(
+        "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg"
+      );
+    });
+
+    it("imageUrl に不正な値を指定すると 400 を返す", async () => {
+      const result = await handler(
+        makeAdminEvent(TEST_USER_ID, {
+          body: JSON.stringify({ ...validInput, imageUrl: "not-a-url" }),
+          httpMethod: "POST",
+          path: "/composers",
+        }),
+        mockContext,
+        mockCallback
+      );
+      expect(result?.statusCode).toBe(400);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("imageUrl must be a valid URL");
+    });
   });
 
   it("Repository エラー時に 500 を返す", async () => {

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -168,6 +168,53 @@ describe("PUT /composers/{id} (update)", () => {
     expect(body.region).toBeUndefined();
   });
 
+  it("imageUrl を追加して更新できる", async () => {
+    mockRepo.findById.mockResolvedValueOnce(existingComposer);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent(
+        "abc-123",
+        JSON.stringify({
+          imageUrl: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg",
+        })
+      ),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.imageUrl).toBe("https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg");
+  });
+
+  it("imageUrl を空文字で送信すると削除される", async () => {
+    const existing: Composer = {
+      ...existingComposer,
+      imageUrl: "https://example.com/beethoven.jpg",
+    };
+    mockRepo.findById.mockResolvedValueOnce(existing);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ imageUrl: "" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}") as Composer;
+    expect(body.imageUrl).toBeUndefined();
+  });
+
+  it("imageUrl に不正な URL を指定すると 400 を返す", async () => {
+    const result = await handler(
+      makeEvent("abc-123", JSON.stringify({ imageUrl: "not-a-url" })),
+      mockContext,
+      mockCallback
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("imageUrl must be a valid URL");
+  });
+
   it("楽観的ロック競合時に 409 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
     mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -92,6 +92,7 @@ export interface Composer {
   name: string; // 作曲家名（例: ベートーヴェン）
   era?: PieceEra; // 時代（楽曲マスタと共通の定数を流用）
   region?: PieceRegion; // 地域（楽曲マスタと共通の定数を流用）
+  imageUrl?: string; // 肖像画像の URL（Wikimedia Commons 等のパブリックドメイン画像を想定）
   createdAt: string;
   updatedAt: string;
 }

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -142,6 +142,7 @@ export const createComposerSchema = z.object({
     .max(100, "name must be 100 characters or less"),
   era: pieceEraSchema.optional(),
   region: pieceRegionSchema.optional(),
+  imageUrl: z.url("imageUrl must be a valid URL").optional(),
 });
 
 export const updateComposerSchema = z.object({
@@ -153,6 +154,7 @@ export const updateComposerSchema = z.object({
     .optional(),
   era: z.union([pieceEraSchema, z.literal("")]).optional(),
   region: z.union([pieceRegionSchema, z.literal("")]).optional(),
+  imageUrl: z.union([z.url("imageUrl must be a valid URL"), z.literal("")]).optional(),
 });
 
 /**

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -220,6 +220,7 @@ interface Composer {
   name: string; // 作曲家名
   era?: PieceEra; // 時代（任意、楽曲マスタと共通の定数を流用）
   region?: PieceRegion; // 地域（任意、楽曲マスタと共通の定数を流用）
+  imageUrl?: string; // 肖像画像の URL（任意、Wikimedia Commons 等のパブリックドメイン画像を想定）
   createdAt: string; // 作成日時 (ISO 8601形式)
   updatedAt: string; // 更新日時 (ISO 8601形式)
 }
@@ -230,6 +231,7 @@ interface Composer {
 - `name`: 空文字・空白のみ不可、最大100文字
 - `era`: 任意項目。指定する場合は固定の選択肢から選択。更新時に空文字を送信するとフィールドが削除される
 - `region`: 任意項目。指定する場合は固定の選択肢から選択。更新時に空文字を送信するとフィールドが削除される
+- `imageUrl`: 任意項目。指定する場合は有効な URL 形式であること（ドメイン制限なし）。更新時に空文字を送信するとフィールドが削除される
 
 > バリデーションは `utils/schemas.ts` に定義した Zod スキーマで実施する。
 
@@ -815,6 +817,7 @@ GET /composers?limit=50&cursor={opaque}
         "name": "ベートーヴェン",
         "era": "古典派",
         "region": "ドイツ・オーストリア",
+        "imageUrl": "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg",
         "createdAt": "2024-01-15T20:00:00.000Z",
         "updatedAt": "2024-01-15T20:00:00.000Z"
       }
@@ -899,13 +902,14 @@ GET /composers?limit=50&cursor={opaque}
 
 #### 作曲家マスタ（Composer）
 
-| フィールド | 型                 | 必須 | バリデーション                    |
-| ---------- | ------------------ | ---- | --------------------------------- |
-| `name`     | string             | ✅   | 空文字・空白のみ不可、最大100文字 |
-| `era`      | PieceEra (enum)    | -    | 指定する場合は固定の選択肢から    |
-| `region`   | PieceRegion (enum) | -    | 指定する場合は固定の選択肢から    |
+| フィールド | 型                 | 必須 | バリデーション                          |
+| ---------- | ------------------ | ---- | --------------------------------------- |
+| `name`     | string             | ✅   | 空文字・空白のみ不可、最大100文字       |
+| `era`      | PieceEra (enum)    | -    | 指定する場合は固定の選択肢から          |
+| `region`   | PieceRegion (enum) | -    | 指定する場合は固定の選択肢から          |
+| `imageUrl` | string             | -    | 指定する場合は有効な URL 形式であること |
 
-> 更新時（`PUT /composers/{id}`）はすべてのフィールドが任意となる（`updateComposerSchema`）。`era` / `region` は空文字を送信するとフィールドが削除される。
+> 更新時（`PUT /composers/{id}`）はすべてのフィールドが任意となる（`updateComposerSchema`）。`era` / `region` / `imageUrl` は空文字を送信するとフィールドが削除される。
 
 #### 自動生成フィールド（入力不可）
 


### PR DESCRIPTION
## 概要

作曲家マスタに肖像画像の URL を保存・表示する機能を追加しました。Wikimedia Commons などのパブリックドメイン画像を想定しており、作曲家一覧と詳細ページで画像を表示します。

## 変更の種類

- [x] 新機能
- [x] テスト

## 変更内容

### バックエンド
- `Composer` 型に `imageUrl?: string` フィールドを追加
- `createComposerSchema` と `updateComposerSchema` に URL バリデーション（`z.url()`）を追加
- `CLEARABLE_FIELDS` に `imageUrl` を追加し、更新時に空文字で削除可能に対応
- 作成・更新時の imageUrl バリデーションテストを追加

### フロントエンド
- `Composer` 型に `imageUrl?: string` フィールドを追加
- `ComposerForm` コンポーネントに imageUrl 入力フィールドを追加
- `ComposerDetailTemplate` に画像表示機能を追加（最大 240x320px、遅延読み込み対応）
- `ComposerItem` に円形サムネイル表示機能を追加（56x56px）
- 画像表示のテストと Storybook ストーリーを追加

### ドキュメント
- `docs/SPEC.md` の Composer インターフェース定義と API レスポンス例を更新
- バリデーション仕様を記載

## テスト

- [x] ユニットテストを追加・更新した
  - バックエンド：imageUrl の追加・削除・バリデーション（3 テスト）
  - フロントエンド：画像表示・非表示の条件分岐（4 テスト）
- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] `docs/SPEC.md` を更新した

https://claude.ai/code/session_018c68EXYqmT6wNpEjrDyNSk