### PR TITLE
Consolidate paginated response types into PageResult

### DIFF
--- a/app/composables/useComposers.test.ts
+++ b/app/composables/useComposers.test.ts
@@ -1,9 +1,6 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import {
-  useComposersPaginated,
-  useComposer,
-  type PaginatedComposersResponse,
-} from "./useComposers";
+import { useComposersPaginated, useComposer } from "./useComposers";
+import type { PageResult } from "./usePaginatedList";
 import type { Composer } from "~/types";
 import { COMPOSERS_PAGE_SIZE_DEFAULT } from "~/types";
 import { ID_TOKEN_KEY } from "./useAuth";
@@ -74,7 +71,7 @@ describe("useComposersPaginated", () => {
       mockDollarFetch.mockResolvedValueOnce({
         items: [],
         nextCursor: null,
-      } satisfies PaginatedComposersResponse);
+      } satisfies PageResult<Composer>);
       const c = useComposersPaginated();
       await c.loadMore();
       expect(mockDollarFetch).toHaveBeenCalledWith("/api/composers", {

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,22 +1,17 @@
 import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "~/types";
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { usePaginatedList } from "./usePaginatedList";
-
-/**
- * GET /composers のレスポンス形式。
- */
-export type PaginatedComposersResponse = { items: Composer[]; nextCursor: string | null };
+import { usePaginatedList, type PageResult } from "./usePaginatedList";
 
 const fetchPage = async (
   apiBase: string,
   options: { limit: number; cursor?: string }
-): Promise<PaginatedComposersResponse> => {
+): Promise<PageResult<Composer>> => {
   const query: { limit: number; cursor?: string } = { limit: options.limit };
   if (options.cursor !== undefined) {
     query.cursor = options.cursor;
   }
-  return $fetch<PaginatedComposersResponse>(`${apiBase}/composers`, { query });
+  return $fetch<PageResult<Composer>>(`${apiBase}/composers`, { query });
 };
 
 /**

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -1,5 +1,6 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { usePiecesPaginated, usePiecesAll, usePiece, type PaginatedResponse } from "./usePieces";
+import { usePiecesPaginated, usePiecesAll, usePiece } from "./usePieces";
+import type { PageResult } from "./usePaginatedList";
 import type { Piece } from "~/types";
 import { ID_TOKEN_KEY } from "./useAuth";
 import {
@@ -87,7 +88,7 @@ describe("usePiecesPaginated", () => {
       mockDollarFetch.mockResolvedValueOnce({
         items: [],
         nextCursor: null,
-      } satisfies PaginatedResponse<Piece>);
+      } satisfies PageResult<Piece>);
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(mockDollarFetch).toHaveBeenCalledWith("/api/pieces", {
@@ -129,9 +130,9 @@ describe("usePiecesPaginated", () => {
     });
 
     it("pending 中に loadMore を呼んでも二重発行しない", async () => {
-      let resolvePage: ((value: PaginatedResponse<Piece>) => void) | undefined;
+      let resolvePage: ((value: PageResult<Piece>) => void) | undefined;
       mockDollarFetch.mockReturnValueOnce(
-        new Promise<PaginatedResponse<Piece>>((resolve) => {
+        new Promise<PageResult<Piece>>((resolve) => {
           resolvePage = resolve;
         })
       );

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -5,22 +5,17 @@ import {
 } from "~/types";
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { usePaginatedList } from "./usePaginatedList";
-
-/**
- * GET /pieces のレスポンス形式。
- */
-export type PaginatedResponse<T> = { items: T[]; nextCursor: string | null };
+import { usePaginatedList, type PageResult } from "./usePaginatedList";
 
 const fetchPage = async (
   apiBase: string,
   options: { limit: number; cursor?: string }
-): Promise<PaginatedResponse<Piece>> => {
+): Promise<PageResult<Piece>> => {
   const query: { limit: number; cursor?: string } = { limit: options.limit };
   if (options.cursor !== undefined) {
     query.cursor = options.cursor;
   }
-  return $fetch<PaginatedResponse<Piece>>(`${apiBase}/pieces`, { query });
+  return $fetch<PageResult<Piece>>(`${apiBase}/pieces`, { query });
 };
 
 const usePieceMutations = () => {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { PaginatedResponse } from "~/composables/usePieces";
+import type { PageResult } from "~/composables/usePaginatedList";
 import type { Piece } from "~/types";
 
 const apiBase = useApiBase();
-const { data, pending } = useFetch<PaginatedResponse<Piece>>(`${apiBase}/pieces`);
+const { data, pending } = useFetch<PageResult<Piece>>(`${apiBase}/pieces`);
 const { data: composers, refresh: refreshComposers } = useComposersAll();
 void refreshComposers();
 


### PR DESCRIPTION
## 概要

ページネーション対応のレスポンス型を統一し、重複する型定義を削除しました。`usePaginatedList` で定義された `PageResult<T>` 型を共通の型として使用するようにリファクタリングしました。

## 変更の種類

- [x] リファクタリング

## 変更内容

- `useComposers.ts` の `PaginatedComposersResponse` 型を削除し、`usePaginatedList` から `PageResult<Composer>` を使用するように変更
- `usePieces.ts` の `PaginatedResponse<T>` 型を削除し、`usePaginatedList` から `PageResult<T>` を使用するように変更
- `useComposers.test.ts` と `usePieces.test.ts` のテストファイルで、削除された型の代わりに `PageResult` をインポートして使用するように更新
- `pages/index.vue` で `PaginatedResponse` の代わりに `PageResult` をインポートして使用するように更新

## テスト

- [x] 既存テストがすべて通ることを確認した（型の変更のみで実装ロジックは変わらず）

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] 実装を含まない変更のため、`docs/SPEC.md` の更新は不要

https://claude.ai/code/session_017YoPinDHDxnXBAdiFVU5YM