### PR TITLE
Extract list query parsing logic into reusable utility

### DIFF
--- a/backend/src/handlers/composers/list.ts
+++ b/backend/src/handlers/composers/list.ts
@@ -1,7 +1,5 @@
-import createError from "http-errors";
-
-import { decodeCursor, InvalidCursorError } from "../../utils/cursor";
 import { createHandler } from "../../utils/middleware";
+import { parseListQuery } from "../../utils/parsing";
 import { ok } from "../../utils/response";
 import { listComposersQuerySchema } from "../../utils/schemas";
 import { createComposerUsecase } from "../../usecases/composer-usecase";
@@ -9,24 +7,10 @@ import { createComposerUsecase } from "../../usecases/composer-usecase";
 const usecase = createComposerUsecase();
 
 export const handler = createHandler(async (event) => {
-  const parsed = listComposersQuerySchema.safeParse(event.queryStringParameters ?? {});
-  if (!parsed.success) {
-    throw new createError.BadRequest(parsed.error.issues[0]?.message ?? "Invalid query parameter");
-  }
-  const { limit, cursor } = parsed.data;
-
-  let exclusiveStartKey: Record<string, unknown> | undefined;
-  if (cursor !== undefined) {
-    try {
-      exclusiveStartKey = decodeCursor(cursor);
-    } catch (err) {
-      if (err instanceof InvalidCursorError) {
-        throw new createError.BadRequest(err.message);
-      }
-      throw err;
-    }
-  }
-
+  const { limit, exclusiveStartKey } = parseListQuery(
+    event.queryStringParameters,
+    listComposersQuerySchema
+  );
   const page = await usecase.list({ limit, exclusiveStartKey });
   return ok(page);
 });

--- a/backend/src/handlers/pieces/list.ts
+++ b/backend/src/handlers/pieces/list.ts
@@ -1,7 +1,5 @@
-import createError from "http-errors";
-
-import { decodeCursor, InvalidCursorError } from "../../utils/cursor";
 import { createHandler } from "../../utils/middleware";
+import { parseListQuery } from "../../utils/parsing";
 import { ok } from "../../utils/response";
 import { listPiecesQuerySchema } from "../../utils/schemas";
 import { createPieceUsecase } from "../../usecases/piece-usecase";
@@ -9,24 +7,10 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 const usecase = createPieceUsecase();
 
 export const handler = createHandler(async (event) => {
-  const parsed = listPiecesQuerySchema.safeParse(event.queryStringParameters ?? {});
-  if (!parsed.success) {
-    throw new createError.BadRequest(parsed.error.issues[0]?.message ?? "Invalid query parameter");
-  }
-  const { limit, cursor } = parsed.data;
-
-  let exclusiveStartKey: Record<string, unknown> | undefined;
-  if (cursor !== undefined) {
-    try {
-      exclusiveStartKey = decodeCursor(cursor);
-    } catch (err) {
-      if (err instanceof InvalidCursorError) {
-        throw new createError.BadRequest(err.message);
-      }
-      throw err;
-    }
-  }
-
+  const { limit, exclusiveStartKey } = parseListQuery(
+    event.queryStringParameters,
+    listPiecesQuerySchema
+  );
   const page = await usecase.list({ limit, exclusiveStartKey });
   return ok(page);
 });

--- a/backend/src/utils/parsing.test.ts
+++ b/backend/src/utils/parsing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { parseRequestBody } from "./parsing";
+import { encodeCursor } from "./cursor";
+import { parseListQuery, parseRequestBody } from "./parsing";
 
 type TestInput = { name: string; value?: number };
 
@@ -57,5 +58,59 @@ describe("parseRequestBody", () => {
       const result = parseRequestBody({ name: "test", extra: "ignored" }, schema);
       expect(result).toEqual({ name: "test" });
     });
+  });
+});
+
+describe("parseListQuery", () => {
+  const schema = z.object({
+    limit: z.coerce
+      .number({ error: () => "limit must be a number" })
+      .int({ message: "limit must be an integer" })
+      .min(1, { message: "limit must be at least 1" })
+      .max(100, { message: "limit must be at most 100" })
+      .default(50),
+    cursor: z.base64url({ message: "cursor must be a base64url string" }).min(1).optional(),
+  });
+
+  it("クエリ未指定の場合は既定 limit と undefined の exclusiveStartKey を返す", () => {
+    expect(parseListQuery(null, schema)).toEqual({ limit: 50, exclusiveStartKey: undefined });
+    expect(parseListQuery(undefined, schema)).toEqual({ limit: 50, exclusiveStartKey: undefined });
+    expect(parseListQuery({}, schema)).toEqual({ limit: 50, exclusiveStartKey: undefined });
+  });
+
+  it("limit を数値に変換して返す", () => {
+    expect(parseListQuery({ limit: "20" }, schema)).toEqual({
+      limit: 20,
+      exclusiveStartKey: undefined,
+    });
+  });
+
+  it("cursor を decodeCursor でデコードして返す", () => {
+    const cursor = encodeCursor({ id: "prev-id" });
+    expect(parseListQuery({ cursor }, schema)).toEqual({
+      limit: 50,
+      exclusiveStartKey: { id: "prev-id" },
+    });
+  });
+
+  it("スキーマ違反（範囲外 limit）の場合は 400 を投げる", () => {
+    expect(() => parseListQuery({ limit: "0" }, schema)).toThrow("limit must be at least 1");
+  });
+
+  it("スキーマ違反（非数値 limit）の場合は 400 を投げる", () => {
+    expect(() => parseListQuery({ limit: "abc" }, schema)).toThrow();
+  });
+
+  it("base64url として不正な cursor は 400 を投げる", () => {
+    expect(() => parseListQuery({ cursor: "!!!invalid!!!" }, schema)).toThrow(
+      "cursor must be a base64url string"
+    );
+  });
+
+  it("バージョン不一致の cursor は 400 を投げる", () => {
+    const cursor = Buffer.from(JSON.stringify({ v: 999, k: { id: "1" } }), "utf8").toString(
+      "base64url"
+    );
+    expect(() => parseListQuery({ cursor }, schema)).toThrow(/Unsupported cursor version/);
   });
 });

--- a/backend/src/utils/parsing.ts
+++ b/backend/src/utils/parsing.ts
@@ -1,6 +1,8 @@
 import createError from "http-errors";
 import type { ZodType } from "zod";
 
+import { decodeCursor, InvalidCursorError } from "./cursor";
+
 export function parseRequestBody<T>(body: unknown, schema?: ZodType<T>): T {
   if (body === null || body === undefined) {
     throw new createError.BadRequest("Request body is required");
@@ -17,4 +19,41 @@ export function parseRequestBody<T>(body: unknown, schema?: ZodType<T>): T {
     return result.data;
   }
   return body as T;
+}
+
+type ListQueryInput = { limit: number; cursor?: string };
+
+export interface ListQueryOutput {
+  limit: number;
+  exclusiveStartKey?: Record<string, unknown>;
+}
+
+/**
+ * カーソル型ページング API（`GET /pieces`・`GET /composers` など）のクエリパラメータを検証し、
+ * `limit` とデコード済み `exclusiveStartKey` を返す。
+ *
+ * スキーマ検証失敗・不正カーソルはいずれも `400 Bad Request` として投げる。
+ */
+export function parseListQuery(
+  queryParams: Record<string, string | undefined> | null | undefined,
+  schema: ZodType<ListQueryInput>
+): ListQueryOutput {
+  const parsed = schema.safeParse(queryParams ?? {});
+  if (!parsed.success) {
+    throw new createError.BadRequest(parsed.error.issues[0]?.message ?? "Invalid query parameter");
+  }
+  const { limit, cursor } = parsed.data;
+
+  if (cursor === undefined) {
+    return { limit, exclusiveStartKey: undefined };
+  }
+
+  try {
+    return { limit, exclusiveStartKey: decodeCursor(cursor) };
+  } catch (err) {
+    if (err instanceof InvalidCursorError) {
+      throw new createError.BadRequest(err.message);
+    }
+    throw err;
+  }
 }


### PR DESCRIPTION
## 概要

カーソル型ページング API のクエリパラメータ検証ロジックを共通化し、重複コードを削減しました。`parseListQuery` 関数を新たに作成し、複数のハンドラーで使用されていた検証・デコード処理を統一しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [x] テスト
- [ ] その他（　　）

## 変更内容

- `parseListQuery` 関数を `backend/src/utils/parsing.ts` に追加
  - クエリパラメータのスキーマ検証
  - `cursor` パラメータのデコード処理
  - エラーハンドリング（スキーマ違反・不正カーソル）を統一
  
- `backend/src/handlers/pieces/list.ts` と `backend/src/handlers/composers/list.ts` をリファクタリング
  - 重複していた検証・デコード処理を削除
  - `parseListQuery` を使用するように統一
  - 各ハンドラーのコード行数を約50%削減

- `backend/src/utils/parsing.test.ts` に包括的なテストを追加
  - デフォルト値の検証
  - `limit` の型変換
  - `cursor` のデコード処理
  - スキーマ違反時のエラーハンドリング
  - 不正カーソル・バージョン不一致時のエラーハンドリング

## テスト

- [x] ユニットテストを追加・更新した（`parseListQuery` の 5 つのテストケースを追加）
- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] 実装を含む変更の場合、`docs/SPEC.md` を更新した（該当なし）

https://claude.ai/code/session_01Fgg23juAJ92EoHHkwtvz5k