### PR TITLE
refactor(backend): usecase の所有者検証と admin ハンドラ認可を共通化

### DIFF
--- a/backend/src/handlers/composers/create.ts
+++ b/backend/src/handlers/composers/create.ts
@@ -1,5 +1,4 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { createComposerSchema } from "../../utils/schemas";
 import { created } from "../../utils/response";
@@ -7,8 +6,7 @@ import { createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, createComposerSchema);
   const composer = await usecase.create(input);
   return created(composer);

--- a/backend/src/handlers/composers/delete.ts
+++ b/backend/src/handlers/composers/delete.ts
@@ -1,13 +1,11 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler } from "../../utils/middleware";
+import { createAdminHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { noContent } from "../../utils/response";
 import { createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const id = getIdParam(event);
   await usecase.delete(id);
   return noContent();

--- a/backend/src/handlers/composers/update.ts
+++ b/backend/src/handlers/composers/update.ts
@@ -1,5 +1,4 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { updateComposerSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
@@ -8,8 +7,7 @@ import { createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const id = getIdParam(event);
   const input = parseRequestBody(event.body as unknown, updateComposerSchema);
   const composer = await usecase.update(id, input);

--- a/backend/src/handlers/pieces/create.ts
+++ b/backend/src/handlers/pieces/create.ts
@@ -1,5 +1,4 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { createPieceSchema } from "../../utils/schemas";
 import { created } from "../../utils/response";
@@ -7,8 +6,7 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, createPieceSchema);
   const piece = await usecase.create(input);
   return created(piece);

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,13 +1,11 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler } from "../../utils/middleware";
+import { createAdminHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { noContent } from "../../utils/response";
 import { createPieceUsecase } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const id = getIdParam(event);
   await usecase.delete(id);
   return noContent();

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -1,5 +1,4 @@
-import { requireAdmin } from "../../utils/auth";
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
+import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { updatePieceSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
@@ -8,8 +7,7 @@ import { createPieceUsecase } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createHandler(async (event) => {
-  requireAdmin(event);
+export const handler = createAdminHandler(async (event) => {
   const id = getIdParam(event);
   const input = parseRequestBody(event.body as unknown, updatePieceSchema);
   const piece = await usecase.update(id, input);

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -1,10 +1,11 @@
-import createError from "http-errors";
-
 import { ComposerEntity } from "../domain/composer";
 import type { ComposerRepository } from "../domain/composer";
 import { DynamoDBComposerRepository } from "../repositories/composer-repository";
 import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "../types";
 import { encodeCursor } from "../utils/cursor";
+import { findByIdOrNotFound } from "./helpers";
+
+const ENTITY_NAME = "Composer";
 
 export class ComposerUsecase {
   constructor(private readonly repo: ComposerRepository) {}
@@ -28,18 +29,11 @@ export class ComposerUsecase {
   }
 
   async get(id: string): Promise<Composer> {
-    const item = await this.repo.findById(id);
-    if (item === undefined) {
-      throw new createError.NotFound("Composer not found");
-    }
-    return item;
+    return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
   }
 
   async update(id: string, input: UpdateComposerInput): Promise<Composer> {
-    const current = await this.repo.findById(id);
-    if (current === undefined) {
-      throw new createError.NotFound("Composer not found");
-    }
+    const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
     const entity = ComposerEntity.reconstruct(current);
     const updated = entity.mergeUpdate(input);
     const plain = updated.toPlain();

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -1,23 +1,22 @@
-import createError from "http-errors";
-
 import { ConcertLogEntity } from "../domain/concert-log";
 import type { ConcertLogRepository } from "../domain/concert-log";
 import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
 import type { ConcertLog, CreateConcertLogInput } from "../types";
+import { loadOwnedEntityOrNotFound } from "./helpers";
+
+const ENTITY_NAME = "Concert log";
 
 export class ConcertLogUsecase {
   constructor(private readonly repo: ConcertLogRepository) {}
 
-  private async loadOwnedEntity(id: string, userId: string): Promise<ConcertLogEntity> {
-    const item = await this.repo.findById(id);
-    if (item === undefined) {
-      throw new createError.NotFound("Concert log not found");
-    }
-    const entity = ConcertLogEntity.reconstruct(item);
-    if (!entity.isOwnedBy(userId)) {
-      throw new createError.NotFound("Concert log not found");
-    }
-    return entity;
+  private loadOwnedEntity(id: string, userId: string): Promise<ConcertLogEntity> {
+    return loadOwnedEntityOrNotFound({
+      findById: (id) => this.repo.findById(id),
+      reconstruct: ConcertLogEntity.reconstruct,
+      id,
+      userId,
+      entityName: ENTITY_NAME,
+    });
   }
 
   async create(input: CreateConcertLogInput, userId: string): Promise<ConcertLog> {

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -1,0 +1,30 @@
+import createError from "http-errors";
+
+type Owned = { isOwnedBy(userId: string): boolean };
+
+export async function findByIdOrNotFound<T>(
+  findById: (id: string) => Promise<T | undefined>,
+  id: string,
+  entityName: string
+): Promise<T> {
+  const item = await findById(id);
+  if (item === undefined) {
+    throw new createError.NotFound(`${entityName} not found`);
+  }
+  return item;
+}
+
+export async function loadOwnedEntityOrNotFound<TItem, TEntity extends Owned>(options: {
+  findById: (id: string) => Promise<TItem | undefined>;
+  reconstruct: (item: TItem) => TEntity;
+  id: string;
+  userId: string;
+  entityName: string;
+}): Promise<TEntity> {
+  const item = await findByIdOrNotFound(options.findById, options.id, options.entityName);
+  const entity = options.reconstruct(item);
+  if (!entity.isOwnedBy(options.userId)) {
+    throw new createError.NotFound(`${options.entityName} not found`);
+  }
+  return entity;
+}

--- a/backend/src/usecases/listening-log-usecase.ts
+++ b/backend/src/usecases/listening-log-usecase.ts
@@ -1,23 +1,22 @@
-import createError from "http-errors";
-
 import { ListeningLogEntity } from "../domain/listening-log";
 import type { ListeningLogRepository } from "../domain/listening-log";
 import { DynamoDBListeningLogRepository } from "../repositories/listening-log-repository";
 import type { CreateListeningLogInput, ListeningLog } from "../types";
+import { loadOwnedEntityOrNotFound } from "./helpers";
+
+const ENTITY_NAME = "Listening log";
 
 export class ListeningLogUsecase {
   constructor(private readonly repo: ListeningLogRepository) {}
 
-  private async loadOwnedEntity(id: string, userId: string): Promise<ListeningLogEntity> {
-    const item = await this.repo.findById(id);
-    if (item === undefined) {
-      throw new createError.NotFound("Listening log not found");
-    }
-    const entity = ListeningLogEntity.reconstruct(item);
-    if (!entity.isOwnedBy(userId)) {
-      throw new createError.NotFound("Listening log not found");
-    }
-    return entity;
+  private loadOwnedEntity(id: string, userId: string): Promise<ListeningLogEntity> {
+    return loadOwnedEntityOrNotFound({
+      findById: (id) => this.repo.findById(id),
+      reconstruct: ListeningLogEntity.reconstruct,
+      id,
+      userId,
+      entityName: ENTITY_NAME,
+    });
   }
 
   async create(input: CreateListeningLogInput): Promise<ListeningLog> {

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -1,10 +1,11 @@
-import createError from "http-errors";
-
 import { PieceEntity } from "../domain/piece";
 import type { PieceRepository } from "../domain/piece";
 import { DynamoDBPieceRepository } from "../repositories/piece-repository";
 import type { CreatePieceInput, Paginated, Piece, UpdatePieceInput } from "../types";
 import { encodeCursor } from "../utils/cursor";
+import { findByIdOrNotFound } from "./helpers";
+
+const ENTITY_NAME = "Piece";
 
 export class PieceUsecase {
   constructor(private readonly repo: PieceRepository) {}
@@ -28,18 +29,11 @@ export class PieceUsecase {
   }
 
   async get(id: string): Promise<Piece> {
-    const item = await this.repo.findById(id);
-    if (item === undefined) {
-      throw new createError.NotFound("Piece not found");
-    }
-    return item;
+    return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
   }
 
   async update(id: string, input: UpdatePieceInput): Promise<Piece> {
-    const current = await this.repo.findById(id);
-    if (current === undefined) {
-      throw new createError.NotFound("Piece not found");
-    }
+    const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
     const entity = PieceEntity.reconstruct(current);
     const updated = entity.mergeUpdate(input);
     const plain = updated.toPlain();

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -5,6 +5,7 @@ import httpResponseSerializer from "@middy/http-response-serializer";
 import type { HttpError } from "http-errors";
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 
+import { requireAdmin } from "./auth";
 import { getEnv } from "./env";
 
 export type LambdaHandler = (
@@ -80,3 +81,13 @@ export const createHandler = (handler: LambdaHandler) =>
         defaultContentType: "application/json",
       })
     );
+
+/**
+ * createHandler に admin グループ必須の認可チェックを加えたラッパー。
+ * `cognito:groups` に `admin` が無い場合は 403 Forbidden を返す。
+ */
+export const createAdminHandler = (handler: LambdaHandler) =>
+  createHandler(async (event, context) => {
+    requireAdmin(event);
+    return handler(event, context);
+  });


### PR DESCRIPTION
- usecases/helpers.ts を追加し findByIdOrNotFound / loadOwnedEntityOrNotFound を集約
- listening-log / concert-log usecase の loadOwnedEntity を共通ヘルパーで置き換え
- piece / composer usecase の get / update の findById + NotFound 判定もヘルパーに委譲
- createAdminHandler を middleware に追加し pieces / composers の各書き込みハンドラから requireAdmin 呼び出しを除去

https://claude.ai/code/session_01AdxDXJJGbSeumGtbhgMrLo