### PR TITLE
Refactor: Extract common entity and pagination helpers

### DIFF
--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from "node:crypto";
-
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "../types";
+import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
 
 const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
 
@@ -19,8 +18,7 @@ export class ComposerEntity {
   private constructor(private readonly props: Composer) {}
 
   static create(input: CreateComposerInput): ComposerEntity {
-    const now = new Date().toISOString();
-    return new ComposerEntity({ ...input, id: randomUUID(), createdAt: now, updatedAt: now });
+    return new ComposerEntity(buildCreateProps<CreateComposerInput, Composer>(input));
   }
 
   static reconstruct(data: Composer): ComposerEntity {
@@ -32,19 +30,7 @@ export class ComposerEntity {
   }
 
   mergeUpdate(input: UpdateComposerInput): ComposerEntity {
-    const merged: Composer = {
-      ...this.props,
-      ...input,
-      id: this.props.id,
-      createdAt: this.props.createdAt,
-      updatedAt: new Date().toISOString(),
-    };
-    const cleared = Object.fromEntries(
-      Object.entries(merged).filter(
-        ([key, value]) => !(CLEARABLE_FIELDS as readonly string[]).includes(key) || value !== ""
-      )
-    ) as Composer;
-    return new ComposerEntity(cleared);
+    return new ComposerEntity(buildUpdateProps(this.props, input, CLEARABLE_FIELDS));
   }
 
   toPlain(): Composer {

--- a/backend/src/domain/entity-helpers.ts
+++ b/backend/src/domain/entity-helpers.ts
@@ -1,0 +1,35 @@
+import { randomUUID } from "node:crypto";
+
+type BaseEntityFields = { id: string; createdAt: string; updatedAt: string };
+
+/**
+ * 新規エンティティ用のメタデータ（id / createdAt / updatedAt）を付与した props を生成する。
+ * Composer / Piece のような admin 管理エンティティで共通利用する。
+ */
+export function buildCreateProps<TInput extends object, TProps extends TInput & BaseEntityFields>(
+  input: TInput
+): TProps {
+  const now = new Date().toISOString();
+  return { ...input, id: randomUUID(), createdAt: now, updatedAt: now } as TProps;
+}
+
+/**
+ * 既存エンティティ props に更新入力をマージし、クリア可能フィールドに空文字が渡された場合は
+ * そのキーを削除（= DynamoDB の属性削除）する。id / createdAt は不変、updatedAt は常に現在時刻に更新。
+ */
+export function buildUpdateProps<TProps extends BaseEntityFields>(
+  current: TProps,
+  input: Partial<TProps>,
+  clearableFields: readonly string[]
+): TProps {
+  const merged: TProps = {
+    ...current,
+    ...input,
+    id: current.id,
+    createdAt: current.createdAt,
+    updatedAt: new Date().toISOString(),
+  };
+  return Object.fromEntries(
+    Object.entries(merged).filter(([key, value]) => !clearableFields.includes(key) || value !== "")
+  ) as TProps;
+}

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -1,6 +1,5 @@
-import { randomUUID } from "node:crypto";
-
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "../types";
+import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
 
 const CLEARABLE_FIELDS = ["videoUrl", "genre", "era", "formation", "region"] as const;
 
@@ -24,8 +23,7 @@ export class PieceEntity {
   private constructor(private readonly props: Piece) {}
 
   static create(input: CreatePieceInput): PieceEntity {
-    const now = new Date().toISOString();
-    return new PieceEntity({ ...input, id: randomUUID(), createdAt: now, updatedAt: now });
+    return new PieceEntity(buildCreateProps<CreatePieceInput, Piece>(input));
   }
 
   static reconstruct(data: Piece): PieceEntity {
@@ -37,19 +35,7 @@ export class PieceEntity {
   }
 
   mergeUpdate(input: UpdatePieceInput): PieceEntity {
-    const merged: Piece = {
-      ...this.props,
-      ...input,
-      id: this.props.id,
-      createdAt: this.props.createdAt,
-      updatedAt: new Date().toISOString(),
-    };
-    const cleared = Object.fromEntries(
-      Object.entries(merged).filter(
-        ([key, value]) => !(CLEARABLE_FIELDS as readonly string[]).includes(key) || value !== ""
-      )
-    ) as Piece;
-    return new PieceEntity(cleared);
+    return new PieceEntity(buildUpdateProps(this.props, input, CLEARABLE_FIELDS));
   }
 
   toPlain(): Piece {

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -2,8 +2,7 @@ import { ComposerEntity } from "../domain/composer";
 import type { ComposerRepository } from "../domain/composer";
 import { DynamoDBComposerRepository } from "../repositories/composer-repository";
 import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "../types";
-import { encodeCursor } from "../utils/cursor";
-import { findByIdOrNotFound } from "./helpers";
+import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
 
 const ENTITY_NAME = "Composer";
 
@@ -21,11 +20,7 @@ export class ComposerUsecase {
     limit: number;
     exclusiveStartKey?: Record<string, unknown>;
   }): Promise<Paginated<Composer>> {
-    const { items, lastEvaluatedKey } = await this.repo.findPage(options);
-    return {
-      items,
-      nextCursor: lastEvaluatedKey === undefined ? null : encodeCursor(lastEvaluatedKey),
-    };
+    return toPaginatedResult(await this.repo.findPage(options));
   }
 
   async get(id: string): Promise<Composer> {

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -1,6 +1,23 @@
 import createError from "http-errors";
 
+import type { Paginated } from "../types";
+import { encodeCursor } from "../utils/cursor";
+
 type Owned = { isOwnedBy(userId: string): boolean };
+
+/**
+ * Repository の findPage 戻り値（items + lastEvaluatedKey）を
+ * API レスポンス形式 Paginated<T> に変換する。
+ */
+export function toPaginatedResult<T>(page: {
+  items: T[];
+  lastEvaluatedKey?: Record<string, unknown>;
+}): Paginated<T> {
+  return {
+    items: page.items,
+    nextCursor: page.lastEvaluatedKey === undefined ? null : encodeCursor(page.lastEvaluatedKey),
+  };
+}
 
 export async function findByIdOrNotFound<T>(
   findById: (id: string) => Promise<T | undefined>,

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -2,8 +2,7 @@ import { PieceEntity } from "../domain/piece";
 import type { PieceRepository } from "../domain/piece";
 import { DynamoDBPieceRepository } from "../repositories/piece-repository";
 import type { CreatePieceInput, Paginated, Piece, UpdatePieceInput } from "../types";
-import { encodeCursor } from "../utils/cursor";
-import { findByIdOrNotFound } from "./helpers";
+import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
 
 const ENTITY_NAME = "Piece";
 
@@ -21,11 +20,7 @@ export class PieceUsecase {
     limit: number;
     exclusiveStartKey?: Record<string, unknown>;
   }): Promise<Paginated<Piece>> {
-    const { items, lastEvaluatedKey } = await this.repo.findPage(options);
-    return {
-      items,
-      nextCursor: lastEvaluatedKey === undefined ? null : encodeCursor(lastEvaluatedKey),
-    };
+    return toPaginatedResult(await this.repo.findPage(options));
   }
 
   async get(id: string): Promise<Piece> {


### PR DESCRIPTION
## 概要

エンティティの作成・更新処理とページネーション結果の変換処理を共通ヘルパー関数に抽出し、コードの重複を削減しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- **新規ファイル: `backend/src/domain/entity-helpers.ts`**
  - `buildCreateProps()`: エンティティ作成時のメタデータ（id, createdAt, updatedAt）付与処理を共通化
  - `buildUpdateProps()`: エンティティ更新時のマージ・クリア可能フィールド削除処理を共通化

- **`backend/src/usecases/helpers.ts`**
  - `toPaginatedResult()`: Repository の findPage 戻り値を API レスポンス形式に変換する共通関数を追加

- **`backend/src/domain/composer.ts`**
  - `ComposerEntity.create()` と `mergeUpdate()` を新しいヘルパー関数を使用するように簡潔化

- **`backend/src/domain/piece.ts`**
  - `PieceEntity.create()` と `mergeUpdate()` を新しいヘルパー関数を使用するように簡潔化

- **`backend/src/usecases/composer-usecase.ts` と `piece-usecase.ts`**
  - `listPage()` メソッドで `toPaginatedResult()` を使用し、ページネーション変換ロジックを統一

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [ ] 実装を含む変更の場合、`docs/SPEC.md` を更新した（リファクタリングのため不要）

https://claude.ai/code/session_01HJnnShBZLeFetJs2gK8VXM