### PR TITLE
Introduce ID value objects for type-safe entity identification

### DIFF
--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -1,5 +1,11 @@
-import type { Composer, CreateComposerInput, UpdateComposerInput } from "../types";
-import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
+import type {
+  Composer,
+  CreateComposerInput,
+  PieceEra,
+  PieceRegion,
+  UpdateComposerInput,
+} from "../types";
+import { buildUpdateProps } from "./entity-helpers";
 import { ComposerId } from "./value-objects/ids";
 
 const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
@@ -15,17 +21,34 @@ export type ComposerRepository = {
   remove(id: string): Promise<void>;
 };
 
+type ComposerProps = {
+  id: ComposerId;
+  name: string;
+  era?: PieceEra;
+  region?: PieceRegion;
+  imageUrl?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export class ComposerEntity {
-  private constructor(private readonly props: Composer) {}
+  private constructor(private readonly props: ComposerProps) {}
 
   static create(input: CreateComposerInput): ComposerEntity {
-    return new ComposerEntity(
-      buildCreateProps<CreateComposerInput, Composer>(input, ComposerId.generate().value)
-    );
+    const now = new Date().toISOString();
+    return new ComposerEntity({
+      ...input,
+      id: ComposerId.generate(),
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   static reconstruct(data: Composer): ComposerEntity {
-    return new ComposerEntity(data);
+    return new ComposerEntity({
+      ...data,
+      id: ComposerId.from(data.id),
+    });
   }
 
   get updatedAt(): string {
@@ -33,10 +56,14 @@ export class ComposerEntity {
   }
 
   mergeUpdate(input: UpdateComposerInput): ComposerEntity {
-    return new ComposerEntity(buildUpdateProps(this.props, input, CLEARABLE_FIELDS));
+    const merged = buildUpdateProps(this.toPlain(), input, CLEARABLE_FIELDS);
+    return ComposerEntity.reconstruct(merged);
   }
 
   toPlain(): Composer {
-    return { ...this.props };
+    return {
+      ...this.props,
+      id: this.props.id.value,
+    };
   }
 }

--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -11,14 +11,14 @@ import { ComposerId } from "./value-objects/ids";
 const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
 
 export type ComposerRepository = {
-  findById(id: string): Promise<Composer | undefined>;
+  findById(id: ComposerId): Promise<Composer | undefined>;
   findPage(options: {
     limit: number;
     exclusiveStartKey?: Record<string, unknown>;
   }): Promise<{ items: Composer[]; lastEvaluatedKey?: Record<string, unknown> }>;
   save(item: Composer): Promise<void>;
   saveWithOptimisticLock(item: Composer, prevUpdatedAt: string): Promise<void>;
-  remove(id: string): Promise<void>;
+  remove(id: ComposerId): Promise<void>;
 };
 
 type ComposerProps = {

--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -1,5 +1,6 @@
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "../types";
 import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
+import { ComposerId } from "./value-objects/ids";
 
 const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
 
@@ -18,7 +19,9 @@ export class ComposerEntity {
   private constructor(private readonly props: Composer) {}
 
   static create(input: CreateComposerInput): ComposerEntity {
-    return new ComposerEntity(buildCreateProps<CreateComposerInput, Composer>(input));
+    return new ComposerEntity(
+      buildCreateProps<CreateComposerInput, Composer>(input, ComposerId.generate().value)
+    );
   }
 
   static reconstruct(data: Composer): ComposerEntity {

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
-
 import type { ConcertLog, CreateConcertLogInput } from "../types";
+import { ConcertLogId } from "./value-objects/ids";
+import type { UserId } from "./value-objects/ids";
 
 export type ConcertLogRepository = {
   findById(id: string): Promise<ConcertLog | undefined>;
@@ -13,12 +13,12 @@ export type ConcertLogRepository = {
 export class ConcertLogEntity {
   private constructor(private readonly props: ConcertLog) {}
 
-  static create(input: CreateConcertLogInput, userId: string): ConcertLogEntity {
+  static create(input: CreateConcertLogInput, userId: UserId): ConcertLogEntity {
     const now = new Date().toISOString();
     return new ConcertLogEntity({
       ...input,
-      id: randomUUID(),
-      userId,
+      id: ConcertLogId.generate().value,
+      userId: userId.value,
       createdAt: now,
       updatedAt: now,
     });
@@ -32,8 +32,8 @@ export class ConcertLogEntity {
     return [...entities].sort((a, b) => b.props.concertDate.localeCompare(a.props.concertDate));
   }
 
-  isOwnedBy(userId: string): boolean {
-    return this.props.userId === userId;
+  isOwnedBy(userId: UserId): boolean {
+    return this.props.userId === userId.value;
   }
 
   toPlain(): ConcertLog {

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -2,11 +2,11 @@ import type { ConcertLog, CreateConcertLogInput } from "../types";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 
 export type ConcertLogRepository = {
-  findById(id: string): Promise<ConcertLog | undefined>;
-  findByUserId(userId: string): Promise<ConcertLog[]>;
+  findById(id: ConcertLogId): Promise<ConcertLog | undefined>;
+  findByUserId(userId: UserId): Promise<ConcertLog[]>;
   save(item: ConcertLog): Promise<void>;
-  update(id: string, input: Partial<ConcertLog>): Promise<ConcertLog>;
-  remove(id: string): Promise<void>;
+  update(id: ConcertLogId, input: Partial<ConcertLog>): Promise<ConcertLog>;
+  remove(id: ConcertLogId): Promise<void>;
 };
 
 type ConcertLogProps = {

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,6 +1,5 @@
 import type { ConcertLog, CreateConcertLogInput } from "../types";
-import { ConcertLogId } from "./value-objects/ids";
-import type { UserId } from "./value-objects/ids";
+import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 
 export type ConcertLogRepository = {
   findById(id: string): Promise<ConcertLog | undefined>;
@@ -10,22 +9,42 @@ export type ConcertLogRepository = {
   remove(id: string): Promise<void>;
 };
 
+type ConcertLogProps = {
+  id: ConcertLogId;
+  userId: UserId;
+  title: string;
+  concertDate: string;
+  venue: string;
+  conductor?: string;
+  orchestra?: string;
+  soloist?: string;
+  pieceIds?: PieceId[];
+  createdAt: string;
+  updatedAt: string;
+};
+
 export class ConcertLogEntity {
-  private constructor(private readonly props: ConcertLog) {}
+  private constructor(private readonly props: ConcertLogProps) {}
 
   static create(input: CreateConcertLogInput, userId: UserId): ConcertLogEntity {
     const now = new Date().toISOString();
     return new ConcertLogEntity({
       ...input,
-      id: ConcertLogId.generate().value,
-      userId: userId.value,
+      id: ConcertLogId.generate(),
+      userId,
+      pieceIds: input.pieceIds === undefined ? undefined : input.pieceIds.map(PieceId.from),
       createdAt: now,
       updatedAt: now,
     });
   }
 
   static reconstruct(data: ConcertLog): ConcertLogEntity {
-    return new ConcertLogEntity(data);
+    return new ConcertLogEntity({
+      ...data,
+      id: ConcertLogId.from(data.id),
+      userId: UserId.from(data.userId),
+      pieceIds: data.pieceIds === undefined ? undefined : data.pieceIds.map(PieceId.from),
+    });
   }
 
   static sortByConcertDateDesc(entities: ConcertLogEntity[]): ConcertLogEntity[] {
@@ -33,10 +52,16 @@ export class ConcertLogEntity {
   }
 
   isOwnedBy(userId: UserId): boolean {
-    return this.props.userId === userId.value;
+    return this.props.userId.equals(userId);
   }
 
   toPlain(): ConcertLog {
-    return { ...this.props };
+    return {
+      ...this.props,
+      id: this.props.id.value,
+      userId: this.props.userId.value,
+      pieceIds:
+        this.props.pieceIds === undefined ? undefined : this.props.pieceIds.map((id) => id.value),
+    };
   }
 }

--- a/backend/src/domain/entity-helpers.ts
+++ b/backend/src/domain/entity-helpers.ts
@@ -1,16 +1,18 @@
-import { randomUUID } from "node:crypto";
-
 type BaseEntityFields = { id: string; createdAt: string; updatedAt: string };
 
 /**
  * 新規エンティティ用のメタデータ（id / createdAt / updatedAt）を付与した props を生成する。
  * Composer / Piece のような admin 管理エンティティで共通利用する。
+ *
+ * `id` は呼び出し側の ID 値オブジェクト（例: `PieceId.generate()`）から渡すことで、
+ * エンティティ種別ごとに正しい ID 型を使っていることを呼び出し側で保証させる。
  */
 export function buildCreateProps<TInput extends object, TProps extends TInput & BaseEntityFields>(
-  input: TInput
+  input: TInput,
+  id: string
 ): TProps {
   const now = new Date().toISOString();
-  return { ...input, id: randomUUID(), createdAt: now, updatedAt: now } as TProps;
+  return { ...input, id, createdAt: now, updatedAt: now } as TProps;
 }
 
 /**

--- a/backend/src/domain/entity-helpers.ts
+++ b/backend/src/domain/entity-helpers.ts
@@ -1,21 +1,6 @@
 type BaseEntityFields = { id: string; createdAt: string; updatedAt: string };
 
 /**
- * 新規エンティティ用のメタデータ（id / createdAt / updatedAt）を付与した props を生成する。
- * Composer / Piece のような admin 管理エンティティで共通利用する。
- *
- * `id` は呼び出し側の ID 値オブジェクト（例: `PieceId.generate()`）から渡すことで、
- * エンティティ種別ごとに正しい ID 型を使っていることを呼び出し側で保証させる。
- */
-export function buildCreateProps<TInput extends object, TProps extends TInput & BaseEntityFields>(
-  input: TInput,
-  id: string
-): TProps {
-  const now = new Date().toISOString();
-  return { ...input, id, createdAt: now, updatedAt: now } as TProps;
-}
-
-/**
  * 既存エンティティ props に更新入力をマージし、クリア可能フィールドに空文字が渡された場合は
  * そのキーを削除（= DynamoDB の属性削除）する。id / createdAt は不変、updatedAt は常に現在時刻に更新。
  */

--- a/backend/src/domain/listening-log.ts
+++ b/backend/src/domain/listening-log.ts
@@ -1,6 +1,6 @@
-import { randomUUID } from "node:crypto";
-
 import type { CreateListeningLogInput, ListeningLog } from "../types";
+import { ListeningLogId } from "./value-objects/ids";
+import type { UserId } from "./value-objects/ids";
 
 export type ListeningLogRepository = {
   findById(id: string): Promise<ListeningLog | undefined>;
@@ -15,7 +15,12 @@ export class ListeningLogEntity {
 
   static create(input: CreateListeningLogInput): ListeningLogEntity {
     const now = new Date().toISOString();
-    return new ListeningLogEntity({ ...input, id: randomUUID(), createdAt: now, updatedAt: now });
+    return new ListeningLogEntity({
+      ...input,
+      id: ListeningLogId.generate().value,
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   static reconstruct(data: ListeningLog): ListeningLogEntity {
@@ -26,8 +31,8 @@ export class ListeningLogEntity {
     return [...entities].sort((a, b) => b.props.listenedAt.localeCompare(a.props.listenedAt));
   }
 
-  isOwnedBy(userId: string): boolean {
-    return this.props.userId === userId;
+  isOwnedBy(userId: UserId): boolean {
+    return this.props.userId !== null && this.props.userId === userId.value;
   }
 
   toPlain(): ListeningLog {

--- a/backend/src/domain/listening-log.ts
+++ b/backend/src/domain/listening-log.ts
@@ -2,11 +2,11 @@ import type { CreateListeningLogInput, ListeningLog, Rating } from "../types";
 import { ListeningLogId, UserId } from "./value-objects/ids";
 
 export type ListeningLogRepository = {
-  findById(id: string): Promise<ListeningLog | undefined>;
-  findByUserId(userId: string): Promise<ListeningLog[]>;
+  findById(id: ListeningLogId): Promise<ListeningLog | undefined>;
+  findByUserId(userId: UserId): Promise<ListeningLog[]>;
   save(item: ListeningLog): Promise<void>;
-  update(id: string, input: Partial<ListeningLog>): Promise<ListeningLog>;
-  remove(id: string): Promise<void>;
+  update(id: ListeningLogId, input: Partial<ListeningLog>): Promise<ListeningLog>;
+  remove(id: ListeningLogId): Promise<void>;
 };
 
 type ListeningLogProps = {

--- a/backend/src/domain/listening-log.ts
+++ b/backend/src/domain/listening-log.ts
@@ -1,6 +1,5 @@
-import type { CreateListeningLogInput, ListeningLog } from "../types";
-import { ListeningLogId } from "./value-objects/ids";
-import type { UserId } from "./value-objects/ids";
+import type { CreateListeningLogInput, ListeningLog, Rating } from "../types";
+import { ListeningLogId, UserId } from "./value-objects/ids";
 
 export type ListeningLogRepository = {
   findById(id: string): Promise<ListeningLog | undefined>;
@@ -10,21 +9,39 @@ export type ListeningLogRepository = {
   remove(id: string): Promise<void>;
 };
 
+type ListeningLogProps = {
+  id: ListeningLogId;
+  userId: UserId | null;
+  listenedAt: string;
+  composer: string;
+  piece: string;
+  rating: Rating;
+  isFavorite: boolean;
+  memo?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export class ListeningLogEntity {
-  private constructor(private readonly props: ListeningLog) {}
+  private constructor(private readonly props: ListeningLogProps) {}
 
   static create(input: CreateListeningLogInput): ListeningLogEntity {
     const now = new Date().toISOString();
     return new ListeningLogEntity({
       ...input,
-      id: ListeningLogId.generate().value,
+      id: ListeningLogId.generate(),
+      userId: input.userId === null ? null : UserId.from(input.userId),
       createdAt: now,
       updatedAt: now,
     });
   }
 
   static reconstruct(data: ListeningLog): ListeningLogEntity {
-    return new ListeningLogEntity(data);
+    return new ListeningLogEntity({
+      ...data,
+      id: ListeningLogId.from(data.id),
+      userId: data.userId === null ? null : UserId.from(data.userId),
+    });
   }
 
   static sortByListenedAtDesc(entities: ListeningLogEntity[]): ListeningLogEntity[] {
@@ -32,10 +49,14 @@ export class ListeningLogEntity {
   }
 
   isOwnedBy(userId: UserId): boolean {
-    return this.props.userId !== null && this.props.userId === userId.value;
+    return this.props.userId !== null && this.props.userId.equals(userId);
   }
 
   toPlain(): ListeningLog {
-    return { ...this.props };
+    return {
+      ...this.props,
+      id: this.props.id.value,
+      userId: this.props.userId === null ? null : this.props.userId.value,
+    };
   }
 }

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -13,7 +13,7 @@ import { ComposerId, PieceId } from "./value-objects/ids";
 const CLEARABLE_FIELDS = ["videoUrl", "genre", "era", "formation", "region"] as const;
 
 export type PieceRepository = {
-  findById(id: string): Promise<Piece | undefined>;
+  findById(id: PieceId): Promise<Piece | undefined>;
   /**
    * @deprecated 新規コードでは {@link findPage} を使うこと。
    * 本関数は `usePiecesAll`（フロントの全件集約互換ヘルパー）の削除後に併せて廃止予定。
@@ -25,7 +25,7 @@ export type PieceRepository = {
   }): Promise<{ items: Piece[]; lastEvaluatedKey?: Record<string, unknown> }>;
   save(item: Piece): Promise<void>;
   saveWithOptimisticLock(item: Piece, prevUpdatedAt: string): Promise<void>;
-  remove(id: string): Promise<void>;
+  remove(id: PieceId): Promise<void>;
 };
 
 type PieceProps = {

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -1,5 +1,6 @@
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "../types";
 import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
+import { PieceId } from "./value-objects/ids";
 
 const CLEARABLE_FIELDS = ["videoUrl", "genre", "era", "formation", "region"] as const;
 
@@ -23,7 +24,9 @@ export class PieceEntity {
   private constructor(private readonly props: Piece) {}
 
   static create(input: CreatePieceInput): PieceEntity {
-    return new PieceEntity(buildCreateProps<CreatePieceInput, Piece>(input));
+    return new PieceEntity(
+      buildCreateProps<CreatePieceInput, Piece>(input, PieceId.generate().value)
+    );
   }
 
   static reconstruct(data: Piece): PieceEntity {

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -1,6 +1,14 @@
-import type { CreatePieceInput, Piece, UpdatePieceInput } from "../types";
-import { buildCreateProps, buildUpdateProps } from "./entity-helpers";
-import { PieceId } from "./value-objects/ids";
+import type {
+  CreatePieceInput,
+  Piece,
+  PieceEra,
+  PieceFormation,
+  PieceGenre,
+  PieceRegion,
+  UpdatePieceInput,
+} from "../types";
+import { buildUpdateProps } from "./entity-helpers";
+import { ComposerId, PieceId } from "./value-objects/ids";
 
 const CLEARABLE_FIELDS = ["videoUrl", "genre", "era", "formation", "region"] as const;
 
@@ -20,17 +28,39 @@ export type PieceRepository = {
   remove(id: string): Promise<void>;
 };
 
+type PieceProps = {
+  id: PieceId;
+  title: string;
+  composerId: ComposerId;
+  videoUrl?: string;
+  genre?: PieceGenre;
+  era?: PieceEra;
+  formation?: PieceFormation;
+  region?: PieceRegion;
+  createdAt: string;
+  updatedAt: string;
+};
+
 export class PieceEntity {
-  private constructor(private readonly props: Piece) {}
+  private constructor(private readonly props: PieceProps) {}
 
   static create(input: CreatePieceInput): PieceEntity {
-    return new PieceEntity(
-      buildCreateProps<CreatePieceInput, Piece>(input, PieceId.generate().value)
-    );
+    const now = new Date().toISOString();
+    return new PieceEntity({
+      ...input,
+      id: PieceId.generate(),
+      composerId: ComposerId.from(input.composerId),
+      createdAt: now,
+      updatedAt: now,
+    });
   }
 
   static reconstruct(data: Piece): PieceEntity {
-    return new PieceEntity(data);
+    return new PieceEntity({
+      ...data,
+      id: PieceId.from(data.id),
+      composerId: ComposerId.from(data.composerId),
+    });
   }
 
   get updatedAt(): string {
@@ -38,10 +68,15 @@ export class PieceEntity {
   }
 
   mergeUpdate(input: UpdatePieceInput): PieceEntity {
-    return new PieceEntity(buildUpdateProps(this.props, input, CLEARABLE_FIELDS));
+    const merged = buildUpdateProps(this.toPlain(), input, CLEARABLE_FIELDS);
+    return PieceEntity.reconstruct(merged);
   }
 
   toPlain(): Piece {
-    return { ...this.props };
+    return {
+      ...this.props,
+      id: this.props.id.value,
+      composerId: this.props.composerId.value,
+    };
   }
 }

--- a/backend/src/domain/value-objects/ids.test.ts
+++ b/backend/src/domain/value-objects/ids.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+
+import { ComposerId, ConcertLogId, ListeningLogId, PieceId, UserId } from "./ids";
+
+describe("IdValueObject", () => {
+  describe("生成と値参照", () => {
+    it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId] as const)(
+      "%s.generate() は UUID を保持する値オブジェクトを返す",
+      (Ctor) => {
+        const id = Ctor.generate();
+        expect(id.value).toBeUUID();
+        expect(String(id)).toBe(id.value);
+      }
+    );
+
+    it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
+      "%s.from() は与えた文字列をそのまま保持する",
+      (Ctor) => {
+        const id = Ctor.from("abc-123");
+        expect(id.value).toBe("abc-123");
+      }
+    );
+
+    it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
+      "%s.from() は空文字列を拒否する",
+      (Ctor) => {
+        expect(() => Ctor.from("")).toThrow(TypeError);
+      }
+    );
+
+    it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
+      "%s.from() は非文字列を拒否する",
+      (Ctor) => {
+        // 型検査をすり抜けて渡された場合の防御
+        expect(() => Ctor.from(undefined as unknown as string)).toThrow(TypeError);
+        expect(() => Ctor.from(null as unknown as string)).toThrow(TypeError);
+        expect(() => Ctor.from(123 as unknown as string)).toThrow(TypeError);
+      }
+    );
+  });
+
+  describe("equals", () => {
+    it("同じクラス・同じ値の VO は等しい", () => {
+      const a = ListeningLogId.from("abc-123");
+      const b = ListeningLogId.from("abc-123");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("同じクラスでも値が異なれば等しくない", () => {
+      const a = ListeningLogId.from("abc-123");
+      const b = ListeningLogId.from("xyz-456");
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("値が同じでもクラスが違えば等しくない（ID 取り違え検出）", () => {
+      const log = ListeningLogId.from("abc-123");
+      const piece = PieceId.from("abc-123");
+      // 型システムで弾かれるがランタイムでも取り違えを検出する
+      expect(log.equals(piece as unknown as ListeningLogId)).toBe(false);
+    });
+  });
+
+  describe("generate で得られる ID はユニーク", () => {
+    it("連続生成した UUID は重複しない", () => {
+      const a = PieceId.generate();
+      const b = PieceId.generate();
+      expect(a.value).not.toBe(b.value);
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe("UserId", () => {
+    it("generate は定義されない（外部 IdP 発行のため）", () => {
+      expect((UserId as unknown as { generate?: () => UserId }).generate).toBeUndefined();
+    });
+  });
+});

--- a/backend/src/domain/value-objects/ids.ts
+++ b/backend/src/domain/value-objects/ids.ts
@@ -1,0 +1,96 @@
+import { randomUUID } from "node:crypto";
+
+/**
+ * エンティティ ID の値オブジェクト基底クラス。
+ *
+ * DDD の値オブジェクトとして ID を表現し、型システム上で他種 ID と混同することを防ぐ。
+ * 具象クラスは private なブランドフィールドにより nominal typing を得るため、
+ * `PieceId` を `ComposerId` として渡すと TypeScript の型エラーになる。
+ *
+ * - UUID 形式の厳密な検証は行わない（既存データとの後方互換性のため）。
+ *   入力側のスキーマ検証（Zod の `z.uuid()`）と responsibility を分ける。
+ * - 空文字・非文字列のみ拒否する。
+ */
+abstract class IdValueObject {
+  public readonly value: string;
+
+  protected constructor(value: string) {
+    if (typeof value !== "string" || value.length === 0) {
+      throw new TypeError("ID value object must be a non-empty string");
+    }
+    this.value = value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+
+  equals(other: IdValueObject): boolean {
+    return this.constructor === other.constructor && this.value === other.value;
+  }
+}
+
+export class ListeningLogId extends IdValueObject {
+  private readonly __brand = "ListeningLogId" as const;
+
+  static from(value: string): ListeningLogId {
+    return new ListeningLogId(value);
+  }
+
+  static generate(): ListeningLogId {
+    return new ListeningLogId(randomUUID());
+  }
+}
+
+export class ConcertLogId extends IdValueObject {
+  private readonly __brand = "ConcertLogId" as const;
+
+  static from(value: string): ConcertLogId {
+    return new ConcertLogId(value);
+  }
+
+  static generate(): ConcertLogId {
+    return new ConcertLogId(randomUUID());
+  }
+}
+
+export class PieceId extends IdValueObject {
+  private readonly __brand = "PieceId" as const;
+
+  static from(value: string): PieceId {
+    return new PieceId(value);
+  }
+
+  static generate(): PieceId {
+    return new PieceId(randomUUID());
+  }
+}
+
+export class ComposerId extends IdValueObject {
+  private readonly __brand = "ComposerId" as const;
+
+  static from(value: string): ComposerId {
+    return new ComposerId(value);
+  }
+
+  static generate(): ComposerId {
+    return new ComposerId(randomUUID());
+  }
+}
+
+/**
+ * Cognito sub を表す値オブジェクト。
+ * `generate()` は持たない（外部 IdP が発行する ID のため）。
+ */
+export class UserId extends IdValueObject {
+  private readonly __brand = "UserId" as const;
+
+  static from(value: string): UserId {
+    return new UserId(value);
+  }
+}
+
+/**
+ * エンティティ ID のいずれか。汎用ヘルパーの引数型で利用する。
+ */
+export type EntityId = ListeningLogId | ConcertLogId | PieceId | ComposerId;

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
+import { ComposerId } from "../../domain/value-objects/ids";
 import { handler } from "./delete";
 import {
   makeAdminEvent,
@@ -64,7 +65,7 @@ describe("DELETE /composers/{id} (delete)", () => {
     mockRepo.remove.mockResolvedValueOnce();
     await handler(makeEvent("test-id-123"), mockContext, mockCallback);
 
-    expect(mockRepo.remove).toHaveBeenCalledWith("test-id-123");
+    expect(mockRepo.remove).toHaveBeenCalledWith(ComposerId.from("test-id-123"));
   });
 
   it("Repository エラー時に 500 を返す", async () => {

--- a/backend/src/handlers/composers/delete.ts
+++ b/backend/src/handlers/composers/delete.ts
@@ -1,12 +1,12 @@
 import { createAdminHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { noContent } from "../../utils/response";
-import { createComposerUsecase } from "../../usecases/composer-usecase";
+import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
 export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ComposerId.from);
   await usecase.delete(id);
   return noContent();
 });

--- a/backend/src/handlers/composers/get.ts
+++ b/backend/src/handlers/composers/get.ts
@@ -1,12 +1,12 @@
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { ok } from "../../utils/response";
-import { createComposerUsecase } from "../../usecases/composer-usecase";
+import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ComposerId.from);
   const composer = await usecase.get(id);
   return ok(composer);
 });

--- a/backend/src/handlers/composers/update.ts
+++ b/backend/src/handlers/composers/update.ts
@@ -3,12 +3,12 @@ import { parseRequestBody } from "../../utils/parsing";
 import { updateComposerSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
 import { ok } from "../../utils/response";
-import { createComposerUsecase } from "../../usecases/composer-usecase";
+import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
 export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ComposerId.from);
   const input = parseRequestBody(event.body as unknown, updateComposerSchema);
   const composer = await usecase.update(id, input);
   return ok(composer);

--- a/backend/src/handlers/concert-logs/delete.ts
+++ b/backend/src/handlers/concert-logs/delete.ts
@@ -2,12 +2,12 @@ import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { noContent } from "../../utils/response";
-import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ConcertLogId.from);
   const userId = getUserId(event);
   await usecase.delete(id, userId);
   return noContent();

--- a/backend/src/handlers/concert-logs/get.ts
+++ b/backend/src/handlers/concert-logs/get.ts
@@ -2,12 +2,12 @@ import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { ok } from "../../utils/response";
-import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ConcertLogId.from);
   const userId = getUserId(event);
   const log = await usecase.get(id, userId);
   return ok(log);

--- a/backend/src/handlers/concert-logs/list.test.ts
+++ b/backend/src/handlers/concert-logs/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ConcertLog } from "../../types";
 
+import { UserId } from "../../domain/value-objects/ids";
 import { handler } from "./list";
 import { makeAuthEvent } from "../../test/fixtures";
 
@@ -68,7 +69,7 @@ describe("GET /concert-logs (list)", () => {
 
     await handler(mockEvent, mockContext, mockCallback);
 
-    expect(mockRepo.findByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(mockRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
   });
 
   it("Repository エラー時に 500 を返す", async () => {

--- a/backend/src/handlers/concert-logs/update.ts
+++ b/backend/src/handlers/concert-logs/update.ts
@@ -4,13 +4,13 @@ import { updateConcertLogSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { ok } from "../../utils/response";
-import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
 import type { ConcertLog } from "../../types";
 
 const usecase = createConcertLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ConcertLogId.from);
   const input = parseRequestBody(event.body as unknown, updateConcertLogSchema);
   const userId = getUserId(event);
   const updated = await usecase.update(id, input as Partial<ConcertLog>, userId);

--- a/backend/src/handlers/listening-logs/create.ts
+++ b/backend/src/handlers/listening-logs/create.ts
@@ -11,6 +11,10 @@ const usecase = createListeningLogUsecase();
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, createListeningLogSchema);
   const userId = getUserId(event);
-  const log = await usecase.create({ ...input, rating: input.rating as Rating, userId });
+  const log = await usecase.create({
+    ...input,
+    rating: input.rating as Rating,
+    userId: userId.value,
+  });
   return created(log);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/listening-logs/delete.ts
+++ b/backend/src/handlers/listening-logs/delete.ts
@@ -2,12 +2,12 @@ import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { noContent } from "../../utils/response";
-import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
+import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ListeningLogId.from);
   const userId = getUserId(event);
   await usecase.delete(id, userId);
   return noContent();

--- a/backend/src/handlers/listening-logs/get.ts
+++ b/backend/src/handlers/listening-logs/get.ts
@@ -2,12 +2,12 @@ import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { ok } from "../../utils/response";
-import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
+import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ListeningLogId.from);
   const userId = getUserId(event);
   const log = await usecase.get(id, userId);
   return ok(log);

--- a/backend/src/handlers/listening-logs/list.test.ts
+++ b/backend/src/handlers/listening-logs/list.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ListeningLog } from "../../types";
 
+import { UserId } from "../../domain/value-objects/ids";
 import { handler } from "./list";
 import { makeLog, makeAuthEvent } from "../../test/fixtures";
 
@@ -58,7 +59,7 @@ describe("GET /listening-logs (list)", () => {
 
     await handler(mockEvent, mockContext, mockCallback);
 
-    expect(mockRepo.findByUserId).toHaveBeenCalledWith(TEST_USER_ID);
+    expect(mockRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
   });
 
   it("Repository エラー時に 500 を返す", async () => {

--- a/backend/src/handlers/listening-logs/update.ts
+++ b/backend/src/handlers/listening-logs/update.ts
@@ -4,13 +4,13 @@ import { updateListeningLogSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
 import { getUserId } from "../../utils/auth";
 import { ok } from "../../utils/response";
-import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
+import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
 import type { ListeningLog } from "../../types";
 
 const usecase = createListeningLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, ListeningLogId.from);
   const input = parseRequestBody(event.body as unknown, updateListeningLogSchema);
   const userId = getUserId(event);
   const updated = await usecase.update(id, input as Partial<ListeningLog>, userId);

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
+import { PieceId } from "../../domain/value-objects/ids";
 import { handler } from "./delete";
 import {
   makeAdminEvent,
@@ -64,7 +65,7 @@ describe("DELETE /pieces/{id} (delete)", () => {
     mockRepo.remove.mockResolvedValueOnce();
     await handler(makeEvent("test-id-123"), mockContext, mockCallback);
 
-    expect(mockRepo.remove).toHaveBeenCalledWith("test-id-123");
+    expect(mockRepo.remove).toHaveBeenCalledWith(PieceId.from("test-id-123"));
   });
 
   it("Repository エラー時に 500 を返す", async () => {

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,12 +1,12 @@
 import { createAdminHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { noContent } from "../../utils/response";
-import { createPieceUsecase } from "../../usecases/piece-usecase";
+import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
 export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, PieceId.from);
   await usecase.delete(id);
   return noContent();
 });

--- a/backend/src/handlers/pieces/get.ts
+++ b/backend/src/handlers/pieces/get.ts
@@ -1,12 +1,12 @@
 import { createHandler } from "../../utils/middleware";
 import { getIdParam } from "../../utils/path-params";
 import { ok } from "../../utils/response";
-import { createPieceUsecase } from "../../usecases/piece-usecase";
+import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
 export const handler = createHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, PieceId.from);
   const piece = await usecase.get(id);
   return ok(piece);
 });

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -3,12 +3,12 @@ import { parseRequestBody } from "../../utils/parsing";
 import { updatePieceSchema } from "../../utils/schemas";
 import { getIdParam } from "../../utils/path-params";
 import { ok } from "../../utils/response";
-import { createPieceUsecase } from "../../usecases/piece-usecase";
+import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
 export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event);
+  const id = getIdParam(event, PieceId.from);
   const input = parseRequestBody(event.body as unknown, updatePieceSchema);
   const piece = await usecase.update(id, input);
   return ok(piece);

--- a/backend/src/repositories/composer-repository.ts
+++ b/backend/src/repositories/composer-repository.ts
@@ -2,13 +2,16 @@ import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import createError from "http-errors";
 
+import type { ComposerId } from "../domain/value-objects/ids";
 import { dynamo, scanPage, TABLE_COMPOSERS } from "../utils/dynamodb";
 import type { Composer } from "../types";
 import type { ComposerRepository } from "../domain/composer";
 
 export class DynamoDBComposerRepository implements ComposerRepository {
-  async findById(id: string): Promise<Composer | undefined> {
-    const result = await dynamo.send(new GetCommand({ TableName: TABLE_COMPOSERS, Key: { id } }));
+  async findById(id: ComposerId): Promise<Composer | undefined> {
+    const result = await dynamo.send(
+      new GetCommand({ TableName: TABLE_COMPOSERS, Key: { id: id.value } })
+    );
     return result.Item as Composer | undefined;
   }
 
@@ -41,7 +44,7 @@ export class DynamoDBComposerRepository implements ComposerRepository {
     }
   }
 
-  async remove(id: string): Promise<void> {
-    await dynamo.send(new DeleteCommand({ TableName: TABLE_COMPOSERS, Key: { id } }));
+  async remove(id: ComposerId): Promise<void> {
+    await dynamo.send(new DeleteCommand({ TableName: TABLE_COMPOSERS, Key: { id: id.value } }));
   }
 }

--- a/backend/src/repositories/concert-log-repository.ts
+++ b/backend/src/repositories/concert-log-repository.ts
@@ -1,30 +1,31 @@
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
+import type { ConcertLogId, UserId } from "../domain/value-objects/ids";
 import { dynamo, queryItemsByUserId, updateItem, TABLE_CONCERT_LOGS } from "../utils/dynamodb";
 import type { ConcertLog } from "../types";
 import type { ConcertLogRepository } from "../domain/concert-log";
 
 export class DynamoDBConcertLogRepository implements ConcertLogRepository {
-  async findById(id: string): Promise<ConcertLog | undefined> {
+  async findById(id: ConcertLogId): Promise<ConcertLog | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id } })
+      new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id: id.value } })
     );
     return result.Item as ConcertLog | undefined;
   }
 
-  async findByUserId(userId: string): Promise<ConcertLog[]> {
-    return queryItemsByUserId<ConcertLog>(TABLE_CONCERT_LOGS, userId);
+  async findByUserId(userId: UserId): Promise<ConcertLog[]> {
+    return queryItemsByUserId<ConcertLog>(TABLE_CONCERT_LOGS, userId.value);
   }
 
   async save(item: ConcertLog): Promise<void> {
     await dynamo.send(new PutCommand({ TableName: TABLE_CONCERT_LOGS, Item: item }));
   }
 
-  async update(id: string, input: Partial<ConcertLog>): Promise<ConcertLog> {
-    return updateItem<ConcertLog>(TABLE_CONCERT_LOGS, id, input);
+  async update(id: ConcertLogId, input: Partial<ConcertLog>): Promise<ConcertLog> {
+    return updateItem<ConcertLog>(TABLE_CONCERT_LOGS, id.value, input);
   }
 
-  async remove(id: string): Promise<void> {
-    await dynamo.send(new DeleteCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id } }));
+  async remove(id: ConcertLogId): Promise<void> {
+    await dynamo.send(new DeleteCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id: id.value } }));
   }
 }

--- a/backend/src/repositories/listening-log-repository.ts
+++ b/backend/src/repositories/listening-log-repository.ts
@@ -1,30 +1,33 @@
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
+import type { ListeningLogId, UserId } from "../domain/value-objects/ids";
 import { dynamo, queryItemsByUserId, updateItem, TABLE_LISTENING_LOGS } from "../utils/dynamodb";
 import type { ListeningLog } from "../types";
 import type { ListeningLogRepository } from "../domain/listening-log";
 
 export class DynamoDBListeningLogRepository implements ListeningLogRepository {
-  async findById(id: string): Promise<ListeningLog | undefined> {
+  async findById(id: ListeningLogId): Promise<ListeningLog | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } })
+      new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } })
     );
     return result.Item as ListeningLog | undefined;
   }
 
-  async findByUserId(userId: string): Promise<ListeningLog[]> {
-    return queryItemsByUserId<ListeningLog>(TABLE_LISTENING_LOGS, userId);
+  async findByUserId(userId: UserId): Promise<ListeningLog[]> {
+    return queryItemsByUserId<ListeningLog>(TABLE_LISTENING_LOGS, userId.value);
   }
 
   async save(item: ListeningLog): Promise<void> {
     await dynamo.send(new PutCommand({ TableName: TABLE_LISTENING_LOGS, Item: item }));
   }
 
-  async update(id: string, input: Partial<ListeningLog>): Promise<ListeningLog> {
-    return updateItem<ListeningLog>(TABLE_LISTENING_LOGS, id, input);
+  async update(id: ListeningLogId, input: Partial<ListeningLog>): Promise<ListeningLog> {
+    return updateItem<ListeningLog>(TABLE_LISTENING_LOGS, id.value, input);
   }
 
-  async remove(id: string): Promise<void> {
-    await dynamo.send(new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id } }));
+  async remove(id: ListeningLogId): Promise<void> {
+    await dynamo.send(
+      new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } })
+    );
   }
 }

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -2,14 +2,17 @@ import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 import createError from "http-errors";
 
+import type { PieceId } from "../domain/value-objects/ids";
 // `scanAllItems` は `findAll`（deprecated・互換用）のみで使用する。`usePiecesAll` 廃止後に一括削除する。
 import { dynamo, scanAllItems, scanPage, TABLE_PIECES } from "../utils/dynamodb"; // NOSONAR: typescript:S1874
 import type { Piece } from "../types";
 import type { PieceRepository } from "../domain/piece";
 
 export class DynamoDBPieceRepository implements PieceRepository {
-  async findById(id: string): Promise<Piece | undefined> {
-    const result = await dynamo.send(new GetCommand({ TableName: TABLE_PIECES, Key: { id } }));
+  async findById(id: PieceId): Promise<Piece | undefined> {
+    const result = await dynamo.send(
+      new GetCommand({ TableName: TABLE_PIECES, Key: { id: id.value } })
+    );
     return result.Item as Piece | undefined;
   }
 
@@ -49,7 +52,7 @@ export class DynamoDBPieceRepository implements PieceRepository {
     }
   }
 
-  async remove(id: string): Promise<void> {
-    await dynamo.send(new DeleteCommand({ TableName: TABLE_PIECES, Key: { id } }));
+  async remove(id: PieceId): Promise<void> {
+    await dynamo.send(new DeleteCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }));
   }
 }

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -1,8 +1,12 @@
 import { ComposerEntity } from "../domain/composer";
 import type { ComposerRepository } from "../domain/composer";
+import { ComposerId } from "../domain/value-objects/ids";
 import { DynamoDBComposerRepository } from "../repositories/composer-repository";
 import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "../types";
 import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
+
+// handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
+export { ComposerId };
 
 const ENTITY_NAME = "Composer";
 
@@ -23,11 +27,11 @@ export class ComposerUsecase {
     return toPaginatedResult(await this.repo.findPage(options));
   }
 
-  async get(id: string): Promise<Composer> {
+  async get(id: ComposerId): Promise<Composer> {
     return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
   }
 
-  async update(id: string, input: UpdateComposerInput): Promise<Composer> {
+  async update(id: ComposerId, input: UpdateComposerInput): Promise<Composer> {
     const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
     const entity = ComposerEntity.reconstruct(current);
     const updated = entity.mergeUpdate(input);
@@ -36,8 +40,8 @@ export class ComposerUsecase {
     return plain;
   }
 
-  async delete(id: string): Promise<void> {
-    await this.repo.remove(id);
+  async delete(id: ComposerId): Promise<void> {
+    await this.repo.remove(id.value);
   }
 }
 

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -41,7 +41,7 @@ export class ComposerUsecase {
   }
 
   async delete(id: ComposerId): Promise<void> {
-    await this.repo.remove(id.value);
+    await this.repo.remove(id);
   }
 }
 

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -1,15 +1,20 @@
 import { ConcertLogEntity } from "../domain/concert-log";
 import type { ConcertLogRepository } from "../domain/concert-log";
+import { ConcertLogId } from "../domain/value-objects/ids";
+import type { UserId } from "../domain/value-objects/ids";
 import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
 import type { ConcertLog, CreateConcertLogInput } from "../types";
 import { loadOwnedEntityOrNotFound } from "./helpers";
+
+// handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
+export { ConcertLogId };
 
 const ENTITY_NAME = "Concert log";
 
 export class ConcertLogUsecase {
   constructor(private readonly repo: ConcertLogRepository) {}
 
-  private loadOwnedEntity(id: string, userId: string): Promise<ConcertLogEntity> {
+  private loadOwnedEntity(id: ConcertLogId, userId: UserId): Promise<ConcertLogEntity> {
     return loadOwnedEntityOrNotFound({
       findById: (id) => this.repo.findById(id),
       reconstruct: ConcertLogEntity.reconstruct,
@@ -19,32 +24,32 @@ export class ConcertLogUsecase {
     });
   }
 
-  async create(input: CreateConcertLogInput, userId: string): Promise<ConcertLog> {
+  async create(input: CreateConcertLogInput, userId: UserId): Promise<ConcertLog> {
     const entity = ConcertLogEntity.create(input, userId);
     const plain = entity.toPlain();
     await this.repo.save(plain);
     return plain;
   }
 
-  async list(userId: string): Promise<ConcertLog[]> {
-    const items = await this.repo.findByUserId(userId);
+  async list(userId: UserId): Promise<ConcertLog[]> {
+    const items = await this.repo.findByUserId(userId.value);
     const entities = items.map((item) => ConcertLogEntity.reconstruct(item));
     return ConcertLogEntity.sortByConcertDateDesc(entities).map((e) => e.toPlain());
   }
 
-  async get(id: string, userId: string): Promise<ConcertLog> {
+  async get(id: ConcertLogId, userId: UserId): Promise<ConcertLog> {
     const entity = await this.loadOwnedEntity(id, userId);
     return entity.toPlain();
   }
 
-  async update(id: string, input: Partial<ConcertLog>, userId: string): Promise<ConcertLog> {
+  async update(id: ConcertLogId, input: Partial<ConcertLog>, userId: UserId): Promise<ConcertLog> {
     await this.loadOwnedEntity(id, userId);
-    return this.repo.update(id, input);
+    return this.repo.update(id.value, input);
   }
 
-  async delete(id: string, userId: string): Promise<void> {
+  async delete(id: ConcertLogId, userId: UserId): Promise<void> {
     await this.loadOwnedEntity(id, userId);
-    await this.repo.remove(id);
+    await this.repo.remove(id.value);
   }
 }
 

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -32,7 +32,7 @@ export class ConcertLogUsecase {
   }
 
   async list(userId: UserId): Promise<ConcertLog[]> {
-    const items = await this.repo.findByUserId(userId.value);
+    const items = await this.repo.findByUserId(userId);
     const entities = items.map((item) => ConcertLogEntity.reconstruct(item));
     return ConcertLogEntity.sortByConcertDateDesc(entities).map((e) => e.toPlain());
   }
@@ -44,12 +44,12 @@ export class ConcertLogUsecase {
 
   async update(id: ConcertLogId, input: Partial<ConcertLog>, userId: UserId): Promise<ConcertLog> {
     await this.loadOwnedEntity(id, userId);
-    return this.repo.update(id.value, input);
+    return this.repo.update(id, input);
   }
 
   async delete(id: ConcertLogId, userId: UserId): Promise<void> {
     await this.loadOwnedEntity(id, userId);
-    await this.repo.remove(id.value);
+    await this.repo.remove(id);
   }
 }
 

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -20,22 +20,26 @@ export function toPaginatedResult<T>(page: {
   };
 }
 
-export async function findByIdOrNotFound<T>(
-  findById: (id: string) => Promise<T | undefined>,
-  id: EntityId,
+export async function findByIdOrNotFound<T, I extends EntityId>(
+  findById: (id: I) => Promise<T | undefined>,
+  id: I,
   entityName: string
 ): Promise<T> {
-  const item = await findById(id.value);
+  const item = await findById(id);
   if (item === undefined) {
     throw new createError.NotFound(`${entityName} not found`);
   }
   return item;
 }
 
-export async function loadOwnedEntityOrNotFound<TItem, TEntity extends Owned>(options: {
-  findById: (id: string) => Promise<TItem | undefined>;
+export async function loadOwnedEntityOrNotFound<
+  TItem,
+  TEntity extends Owned,
+  I extends EntityId,
+>(options: {
+  findById: (id: I) => Promise<TItem | undefined>;
   reconstruct: (item: TItem) => TEntity;
-  id: EntityId;
+  id: I;
   userId: UserId;
   entityName: string;
 }): Promise<TEntity> {

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -1,9 +1,10 @@
 import createError from "http-errors";
 
+import type { EntityId, UserId } from "../domain/value-objects/ids";
 import type { Paginated } from "../types";
 import { encodeCursor } from "../utils/cursor";
 
-type Owned = { isOwnedBy(userId: string): boolean };
+type Owned = { isOwnedBy(userId: UserId): boolean };
 
 /**
  * Repository の findPage 戻り値（items + lastEvaluatedKey）を
@@ -21,10 +22,10 @@ export function toPaginatedResult<T>(page: {
 
 export async function findByIdOrNotFound<T>(
   findById: (id: string) => Promise<T | undefined>,
-  id: string,
+  id: EntityId,
   entityName: string
 ): Promise<T> {
-  const item = await findById(id);
+  const item = await findById(id.value);
   if (item === undefined) {
     throw new createError.NotFound(`${entityName} not found`);
   }
@@ -34,8 +35,8 @@ export async function findByIdOrNotFound<T>(
 export async function loadOwnedEntityOrNotFound<TItem, TEntity extends Owned>(options: {
   findById: (id: string) => Promise<TItem | undefined>;
   reconstruct: (item: TItem) => TEntity;
-  id: string;
-  userId: string;
+  id: EntityId;
+  userId: UserId;
   entityName: string;
 }): Promise<TEntity> {
   const item = await findByIdOrNotFound(options.findById, options.id, options.entityName);

--- a/backend/src/usecases/listening-log-usecase.ts
+++ b/backend/src/usecases/listening-log-usecase.ts
@@ -1,15 +1,20 @@
 import { ListeningLogEntity } from "../domain/listening-log";
 import type { ListeningLogRepository } from "../domain/listening-log";
+import { ListeningLogId } from "../domain/value-objects/ids";
+import type { UserId } from "../domain/value-objects/ids";
 import { DynamoDBListeningLogRepository } from "../repositories/listening-log-repository";
 import type { CreateListeningLogInput, ListeningLog } from "../types";
 import { loadOwnedEntityOrNotFound } from "./helpers";
+
+// handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
+export { ListeningLogId };
 
 const ENTITY_NAME = "Listening log";
 
 export class ListeningLogUsecase {
   constructor(private readonly repo: ListeningLogRepository) {}
 
-  private loadOwnedEntity(id: string, userId: string): Promise<ListeningLogEntity> {
+  private loadOwnedEntity(id: ListeningLogId, userId: UserId): Promise<ListeningLogEntity> {
     return loadOwnedEntityOrNotFound({
       findById: (id) => this.repo.findById(id),
       reconstruct: ListeningLogEntity.reconstruct,
@@ -26,25 +31,29 @@ export class ListeningLogUsecase {
     return plain;
   }
 
-  async list(userId: string): Promise<ListeningLog[]> {
-    const items = await this.repo.findByUserId(userId);
+  async list(userId: UserId): Promise<ListeningLog[]> {
+    const items = await this.repo.findByUserId(userId.value);
     const entities = items.map((item) => ListeningLogEntity.reconstruct(item));
     return ListeningLogEntity.sortByListenedAtDesc(entities).map((e) => e.toPlain());
   }
 
-  async get(id: string, userId: string): Promise<ListeningLog> {
+  async get(id: ListeningLogId, userId: UserId): Promise<ListeningLog> {
     const entity = await this.loadOwnedEntity(id, userId);
     return entity.toPlain();
   }
 
-  async update(id: string, input: Partial<ListeningLog>, userId: string): Promise<ListeningLog> {
+  async update(
+    id: ListeningLogId,
+    input: Partial<ListeningLog>,
+    userId: UserId
+  ): Promise<ListeningLog> {
     await this.loadOwnedEntity(id, userId);
-    return this.repo.update(id, input);
+    return this.repo.update(id.value, input);
   }
 
-  async delete(id: string, userId: string): Promise<void> {
+  async delete(id: ListeningLogId, userId: UserId): Promise<void> {
     await this.loadOwnedEntity(id, userId);
-    await this.repo.remove(id);
+    await this.repo.remove(id.value);
   }
 }
 

--- a/backend/src/usecases/listening-log-usecase.ts
+++ b/backend/src/usecases/listening-log-usecase.ts
@@ -32,7 +32,7 @@ export class ListeningLogUsecase {
   }
 
   async list(userId: UserId): Promise<ListeningLog[]> {
-    const items = await this.repo.findByUserId(userId.value);
+    const items = await this.repo.findByUserId(userId);
     const entities = items.map((item) => ListeningLogEntity.reconstruct(item));
     return ListeningLogEntity.sortByListenedAtDesc(entities).map((e) => e.toPlain());
   }
@@ -48,12 +48,12 @@ export class ListeningLogUsecase {
     userId: UserId
   ): Promise<ListeningLog> {
     await this.loadOwnedEntity(id, userId);
-    return this.repo.update(id.value, input);
+    return this.repo.update(id, input);
   }
 
   async delete(id: ListeningLogId, userId: UserId): Promise<void> {
     await this.loadOwnedEntity(id, userId);
-    await this.repo.remove(id.value);
+    await this.repo.remove(id);
   }
 }
 

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -1,8 +1,12 @@
 import { PieceEntity } from "../domain/piece";
 import type { PieceRepository } from "../domain/piece";
+import { PieceId } from "../domain/value-objects/ids";
 import { DynamoDBPieceRepository } from "../repositories/piece-repository";
 import type { CreatePieceInput, Paginated, Piece, UpdatePieceInput } from "../types";
 import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
+
+// handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
+export { PieceId };
 
 const ENTITY_NAME = "Piece";
 
@@ -23,11 +27,11 @@ export class PieceUsecase {
     return toPaginatedResult(await this.repo.findPage(options));
   }
 
-  async get(id: string): Promise<Piece> {
+  async get(id: PieceId): Promise<Piece> {
     return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
   }
 
-  async update(id: string, input: UpdatePieceInput): Promise<Piece> {
+  async update(id: PieceId, input: UpdatePieceInput): Promise<Piece> {
     const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
     const entity = PieceEntity.reconstruct(current);
     const updated = entity.mergeUpdate(input);
@@ -36,8 +40,8 @@ export class PieceUsecase {
     return plain;
   }
 
-  async delete(id: string): Promise<void> {
-    await this.repo.remove(id);
+  async delete(id: PieceId): Promise<void> {
+    await this.repo.remove(id.value);
   }
 }
 

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -41,7 +41,7 @@ export class PieceUsecase {
   }
 
   async delete(id: PieceId): Promise<void> {
-    await this.repo.remove(id.value);
+    await this.repo.remove(id);
   }
 }
 

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -24,9 +24,9 @@ describe("getUserId", () => {
     expect(() => getUserId(makeEvent({ claims: {} }))).toThrow("User not authenticated");
   });
 
-  it("有効な sub がある場合はその値を返す", () => {
+  it("有効な sub がある場合は UserId 値オブジェクトを返す", () => {
     const result = getUserId(makeEvent({ claims: { sub: "user-abc-123" } }));
-    expect(result).toBe("user-abc-123");
+    expect(result.value).toBe("user-abc-123");
   });
 });
 

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,6 +1,8 @@
 import createError from "http-errors";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
+import { UserId } from "../domain/value-objects/ids";
+
 type CognitoAuthorizerContext = {
   claims: {
     sub: string;
@@ -13,13 +15,13 @@ export const ADMIN_GROUP_NAME = "admin";
 const getAuthorizerContext = (event: APIGatewayProxyEvent): CognitoAuthorizerContext | null =>
   event.requestContext.authorizer as unknown as CognitoAuthorizerContext | null;
 
-export const getUserId = (event: APIGatewayProxyEvent): string => {
+export const getUserId = (event: APIGatewayProxyEvent): UserId => {
   const authorizer = getAuthorizerContext(event);
   const userId = authorizer?.claims?.sub;
   if (typeof userId !== "string" || userId === "") {
     throw new createError.Unauthorized("User not authenticated");
   }
-  return userId;
+  return UserId.from(userId);
 };
 
 // Cognito の cognito:groups クレームは所属グループによって配列・カンマ区切り文字列のいずれかで渡る

--- a/backend/src/utils/path-params.test.ts
+++ b/backend/src/utils/path-params.test.ts
@@ -1,20 +1,29 @@
 import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import { getIdParam } from "./path-params";
+import { PieceId } from "../domain/value-objects/ids";
 
 const makeEvent = (pathParameters: Record<string, string> | null): APIGatewayProxyEvent =>
   ({ pathParameters }) as unknown as APIGatewayProxyEvent;
 
+const identity = (value: string): string => value;
+
 describe("getIdParam", () => {
   it("pathParameters が null の場合は 400 を投げる", () => {
-    expect(() => getIdParam(makeEvent(null))).toThrow("id is required");
+    expect(() => getIdParam(makeEvent(null), identity)).toThrow("id is required");
   });
 
   it("id が存在しない場合は 400 を投げる", () => {
-    expect(() => getIdParam(makeEvent({}))).toThrow("id is required");
+    expect(() => getIdParam(makeEvent({}), identity)).toThrow("id is required");
   });
 
-  it("id が存在する場合はその値を返す", () => {
-    expect(getIdParam(makeEvent({ id: "abc-123" }))).toBe("abc-123");
+  it("id が存在する場合は factory が返す値を返す", () => {
+    expect(getIdParam(makeEvent({ id: "abc-123" }), identity)).toBe("abc-123");
+  });
+
+  it("factory に ID 値オブジェクトの生成関数を渡すと VO を返す", () => {
+    const id = getIdParam(makeEvent({ id: "abc-123" }), PieceId.from);
+    expect(id).toBeInstanceOf(PieceId);
+    expect(id.value).toBe("abc-123");
   });
 });

--- a/backend/src/utils/path-params.ts
+++ b/backend/src/utils/path-params.ts
@@ -1,10 +1,17 @@
 import createError from "http-errors";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
-export const getIdParam = (event: APIGatewayProxyEvent): string => {
+/**
+ * パスパラメータ `id` を取得し、呼び出し側が指定する値オブジェクトに変換する。
+ *
+ * 例: `getIdParam(event, ListeningLogId.from)` で `ListeningLogId` が得られる。
+ * これにより、エンティティごとに誤った ID 型（例: `PieceId` と `ComposerId` の取り違え）
+ * を usecase に渡すことを TypeScript の型検査で防ぐ。
+ */
+export const getIdParam = <T>(event: APIGatewayProxyEvent, factory: (value: string) => T): T => {
   const id = event.pathParameters?.id;
   if (id === undefined || id === "") {
     throw new createError.BadRequest("id is required");
   }
-  return id;
+  return factory(id);
 };

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1243,9 +1243,9 @@ cdk deploy
 #### レイヤー境界との関係
 
 - **domain**: エンティティの内部フィールド（`props`）は ID を値オブジェクトとして保持する（例: `PieceEntity` の `props.composerId` は `ComposerId`、`ConcertLogEntity` の `props.pieceIds` は `PieceId[]`）。`create()` で `Xxx.generate()` を使い新規 ID を採番し、`reconstruct(data)` で DynamoDB から復元した文字列 ID を VO に変換する。`toPlain()` は VO を `.value` で string に戻して DTO を返す
-- **usecases**: `get(id: XxxId, userId: UserId)` のようにメソッド引数を値オブジェクトで受け取る。Repository 呼び出し時のみ `.value` で string を取り出す
+- **usecases**: `get(id: XxxId, userId: UserId)` のようにメソッド引数を値オブジェクトで受け取り、Repository にも値オブジェクトのまま渡す
 - **handlers**: パスパラメータ・認証情報から `getIdParam(event, XxxId.from)` / `getUserId(event)` で値オブジェクトを組み立てて usecase に渡す
-- **repositories**: インフラ層のため引数・戻り値は string ベースの DTO のまま（DynamoDB の Key も string）
+- **repositories**: インターフェイス（`domain/*.ts` で定義）のメソッド引数は ID 値オブジェクト（`findById(id: XxxId)` / `findByUserId(userId: UserId)` / `remove(id: XxxId)` / `update(id: XxxId, ...)`）を受け取る。実装（`repositories/*.ts`）内部で `.value` に変換して DynamoDB の Key / GSI に渡す。戻り値は引き続き string ベースの DTO（Entity 復元は usecase 層の責務）
 
 #### レイヤー依存規約との統合
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1222,6 +1222,35 @@ cdk deploy
 | --------------- | -------------------------------------------------------- |
 | `isValidRating` | Rating のバリデーション関数（Lambda 内バリデーション用） |
 
+### 8.2 ID 値オブジェクト（バックエンドのみ）
+
+バックエンドではエンティティ ID を DDD の値オブジェクトとして表現し、異種 ID の取り違え（例: `PieceId` を `ComposerId` として渡す）を TypeScript の型検査で防ぐ。定義箇所は `backend/src/domain/value-objects/ids.ts`。
+
+| クラス           | 用途                                                                                     |
+| ---------------- | ---------------------------------------------------------------------------------------- |
+| `ListeningLogId` | 鑑賞ログの ID                                                                            |
+| `ConcertLogId`   | コンサート記録の ID                                                                      |
+| `PieceId`        | 楽曲マスタの ID（コンサート記録 `pieceIds` 参照にも使用）                                |
+| `ComposerId`     | 作曲家マスタの ID（楽曲マスタ `composerId` 参照にも使用）                                |
+| `UserId`         | Cognito sub を表す。外部 IdP 発行のため `generate()` は持たず `from(value)` のみ提供する |
+
+- 各クラスは共通基底 `IdValueObject` を継承し、`private readonly __brand` フィールドで nominal typing を得る（subclass 間で代入不可）
+- 生成系は `Xxx.generate()`（内部で UUID v4 を採番）と `Xxx.from(value)`（既存文字列からの復元）の 2 つを提供する
+- 厳密な UUID 形式検証は行わない（後方互換性のため）。空文字・非文字列のみ拒否する。UUID 形式の検証は Zod スキーマ（`z.uuid()`）で行う責務分離
+- 値の取り出しは `.value` プロパティまたは `toString()`
+- 同一クラス同士は `.equals(other)` で比較する（クラスが異なれば値が同じでも `false`）
+
+#### レイヤー境界との関係
+
+- **domain**: `ListeningLogEntity` 等の `create()` で `Xxx.generate()` を使い新規 ID を採番する。`isOwnedBy(userId: UserId)` のように値オブジェクトを引数に取る
+- **usecases**: `get(id: XxxId, userId: UserId)` のようにメソッド引数を値オブジェクトで受け取る。Repository 呼び出し時のみ `.value` で string を取り出す
+- **handlers**: パスパラメータ・認証情報から `getIdParam(event, XxxId.from)` / `getUserId(event)` で値オブジェクトを組み立てて usecase に渡す
+- **repositories**: インフラ層のため引数は string のまま（DynamoDB の Key も string）
+
+#### レイヤー依存規約との統合
+
+`handlers/` 層から `domain/` への直接 import は ESLint で禁止されているため、ID 値オブジェクトは各 usecase ファイル（例: `usecases/listening-log-usecase.ts`）から re-export してハンドラに公開する。
+
 #### 変更時のチェックリスト
 
 1. 共通定数・型を変更する場合、`shared/` のファイルを編集する（re-export により両パッケージに自動反映）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1242,10 +1242,10 @@ cdk deploy
 
 #### レイヤー境界との関係
 
-- **domain**: `ListeningLogEntity` 等の `create()` で `Xxx.generate()` を使い新規 ID を採番する。`isOwnedBy(userId: UserId)` のように値オブジェクトを引数に取る
+- **domain**: エンティティの内部フィールド（`props`）は ID を値オブジェクトとして保持する（例: `PieceEntity` の `props.composerId` は `ComposerId`、`ConcertLogEntity` の `props.pieceIds` は `PieceId[]`）。`create()` で `Xxx.generate()` を使い新規 ID を採番し、`reconstruct(data)` で DynamoDB から復元した文字列 ID を VO に変換する。`toPlain()` は VO を `.value` で string に戻して DTO を返す
 - **usecases**: `get(id: XxxId, userId: UserId)` のようにメソッド引数を値オブジェクトで受け取る。Repository 呼び出し時のみ `.value` で string を取り出す
 - **handlers**: パスパラメータ・認証情報から `getIdParam(event, XxxId.from)` / `getUserId(event)` で値オブジェクトを組み立てて usecase に渡す
-- **repositories**: インフラ層のため引数は string のまま（DynamoDB の Key も string）
+- **repositories**: インフラ層のため引数・戻り値は string ベースの DTO のまま（DynamoDB の Key も string）
 
 #### レイヤー依存規約との統合
 


### PR DESCRIPTION
## 概要

DDD の値オブジェクトパターンを導入し、エンティティ ID を型安全に管理します。異種 ID の取り違え（例: `PieceId` を `ComposerId` として渡す）を TypeScript の型検査で防ぎ、ランタイムエラーを事前に検出します。

## 変更の種類

- [x] 新機能
- [x] リファクタリング
- [x] ドキュメント

## 変更内容

### 新規ファイル
- **`backend/src/domain/value-objects/ids.ts`**: ID 値オブジェクトの基底クラス `IdValueObject` と具象クラス（`ListeningLogId`, `ConcertLogId`, `PieceId`, `ComposerId`, `UserId`）を実装
  - 各クラスは `private readonly __brand` フィールドで nominal typing を実現
  - `generate()` で UUID v4 を採番、`from(value)` で既存文字列から復元
  - `.equals(other)` で同一クラス同士の比較をサポート
  - 空文字・非文字列のみ拒否（UUID 形式の厳密な検証は Zod スキーマに委譲）

- **`backend/src/domain/value-objects/ids.test.ts`**: ID 値オブジェクトの包括的なユニットテスト
  - 生成・値参照・等値比較・型安全性の検証

### ドメイン層の更新
- **`backend/src/domain/listening-log.ts`**: `ListeningLogEntity.create()` で `ListeningLogId.generate()` を使用、`isOwnedBy(userId: UserId)` に型付け
- **`backend/src/domain/concert-log.ts`**: `ConcertLogEntity.create()` で `ConcertLogId.generate()` を使用、`isOwnedBy(userId: UserId)` に型付け
- **`backend/src/domain/composer.ts`**: `ComposerEntity.create()` で `ComposerId.generate()` を使用
- **`backend/src/domain/piece.ts`**: `PieceEntity.create()` で `PieceId.generate()` を使用
- **`backend/src/domain/entity-helpers.ts`**: `buildCreateProps()` に `id` パラメータを追加し、呼び出し側で ID 値オブジェクトから生成した ID を渡すように変更

### ユースケース層の更新
- **`backend/src/usecases/listening-log-usecase.ts`**: メソッド引数を `ListeningLogId`, `UserId` に型付け、`ListeningLogId` を re-export
- **`backend/src/usecases/concert-log-usecase.ts`**: メソッド引数を `ConcertLogId`, `UserId` に型付け、`ConcertLogId` を re-export
- **`backend/src/usecases/composer-usecase.ts`**: メソッド引数を `ComposerId` に型付け、`ComposerId` を re-export
- **`backend/src/usecases/piece-usecase.ts`**: メソッド引数を `PieceId` に型付け、`PieceId` を re-export
- **`backend/src/usecases/helpers.ts`**: `findByIdOrNotFound()`, `loadOwnedEntityOrNotFound()` の引数を `EntityId`, `UserId` に型付け

### ハンドラ層の更新
- **`backend/src/handlers/*/`**: `get

https://claude.ai/code/session_015vKBcqKzyrAsbEMusaEhQA