### PR TITLE
ci(release): release-please-action を v5.0.0 に更新して ID 値オブジェクトのリリースをトリガー

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
+      - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## 概要

Release Please Action が動作しない 2 つの根本原因を修正する。

## 背景と問題

release-please の実行ログで確認された問題：

1. **`Merge pull request #XXX` が毎回 unparseable になる**
   → マージコミット方式を使っていたため。`Merge pull request #XXX` は CC 非準拠のため release-please が常にスキップ

2. **PR #538 のコミットメッセージが CC 形式でない**
   → スカッシュマージ時の PR タイトル `Introduce ID value objects...` が CC 形式でなく `No user facing commits found - skipping` になっていた

3. **Node.js 20 の非推奨警告**
   → `googleapis/release-please-action` v4 が Node.js 20 で動作。2026年6月から強制的に Node.js 24 になる

## 変更内容

### リポジトリ設定（GitHub API で適用済み）
- マージコミット・リベースマージを無効化し、**スカッシュマージのみ**に統一
- スカッシュマージのコミットメッセージ = **PR タイトル**（`squash_merge_commit_title: PR_TITLE`）

### ワークフロー変更
- `.github/workflows/release.yml`: `release-please-action@5c625bfb` (v4) → `@45996ed1` (v5.0.0, Node.js 24 対応)
- `.github/workflows/pr-title-lint.yml`: 追加。PR タイトルを `amannn/action-semantic-pull-request` v6.1.1 で CC 形式検証

### 空コミット
- `feat(backend): エンティティ ID の型安全な識別のため ID 値オブジェクトを導入`
  → PR #538 がリリース漏れになっていたため、次のリリース PR をトリガーするための空コミット

## Test plan

- [ ] PR マージ後に release-please が v2.4.0 の release PR を自動生成することを確認
- [ ] 以降の PR で CC 非準拠タイトルをつけると pr-title-lint が失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)