### PR TITLE
Extract form submission logic into useSubmitHandler composable

### DIFF
--- a/app/components/templates/ComposerEditTemplate.stories.ts
+++ b/app/components/templates/ComposerEditTemplate.stories.ts
@@ -20,13 +20,13 @@ const sample: Composer = {
 };
 
 export const Default: Story = {
-  args: { composer: sample, fetchError: null, errorMessage: "" },
+  args: { composer: sample, fetchError: null, error: null },
 };
 
 export const WithError: Story = {
-  args: { composer: sample, fetchError: null, errorMessage: "更新に失敗しました" },
+  args: { composer: sample, fetchError: null, error: "更新に失敗しました" },
 };
 
 export const FetchError: Story = {
-  args: { composer: null, fetchError: new Error("fail"), errorMessage: "" },
+  args: { composer: null, fetchError: new Error("fail"), error: null },
 };

--- a/app/components/templates/ComposerEditTemplate.test.ts
+++ b/app/components/templates/ComposerEditTemplate.test.ts
@@ -13,29 +13,29 @@ const sample: Composer = {
 describe("ComposerEditTemplate", () => {
   it("タイトルが表示される", async () => {
     const wrapper = await mountSuspended(ComposerEditTemplate, {
-      props: { composer: sample, fetchError: null, errorMessage: "" },
+      props: { composer: sample, fetchError: null, error: null },
     });
     expect(wrapper.text()).toContain("作曲家を編集");
   });
 
   it("fetchError が渡されるとエラーが表示されフォームが表示されない", async () => {
     const wrapper = await mountSuspended(ComposerEditTemplate, {
-      props: { composer: null, fetchError: new Error("fail"), errorMessage: "" },
+      props: { composer: null, fetchError: new Error("fail"), error: null },
     });
     expect(wrapper.text()).toContain("作曲家の取得に失敗しました");
     expect(wrapper.find("form.composer-form").exists()).toBe(false);
   });
 
-  it("errorMessage があるとフォーム上部にエラーメッセージが表示される", async () => {
+  it("error があるとフォーム上部にエラーメッセージが表示される", async () => {
     const wrapper = await mountSuspended(ComposerEditTemplate, {
-      props: { composer: sample, fetchError: null, errorMessage: "更新に失敗" },
+      props: { composer: sample, fetchError: null, error: "更新に失敗" },
     });
     expect(wrapper.text()).toContain("更新に失敗");
   });
 
   it("composer の値が初期値としてフォームに入る", async () => {
     const wrapper = await mountSuspended(ComposerEditTemplate, {
-      props: { composer: sample, fetchError: null, errorMessage: "" },
+      props: { composer: sample, fetchError: null, error: null },
     });
     const nameInput = wrapper.find("#name");
     expect((nameInput.element as HTMLInputElement).value).toBe("ベートーヴェン");

--- a/app/components/templates/ComposerEditTemplate.vue
+++ b/app/components/templates/ComposerEditTemplate.vue
@@ -4,7 +4,7 @@ import type { Composer, UpdateComposerInput } from "~/types";
 defineProps<{
   composer: Composer | null;
   fetchError: Error | null;
-  errorMessage: string;
+  error: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -19,7 +19,7 @@ const emit = defineEmits<{
     <ErrorMessage v-if="fetchError" message="作曲家の取得に失敗しました。" variant="block" />
 
     <template v-else>
-      <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+      <ErrorMessage v-if="error" :message="error" variant="block" />
       <ComposerForm
         :initial-values="{
           name: composer?.name,

--- a/app/components/templates/ComposerNewTemplate.stories.ts
+++ b/app/components/templates/ComposerNewTemplate.stories.ts
@@ -10,9 +10,9 @@ export default meta;
 type Story = StoryObj<typeof ComposerNewTemplate>;
 
 export const Default: Story = {
-  args: { errorMessage: "" },
+  args: { error: null },
 };
 
 export const WithError: Story = {
-  args: { errorMessage: "登録に失敗しました。入力内容を確認してください。" },
+  args: { error: "登録に失敗しました。入力内容を確認してください。" },
 };

--- a/app/components/templates/ComposerNewTemplate.test.ts
+++ b/app/components/templates/ComposerNewTemplate.test.ts
@@ -4,21 +4,21 @@ import ComposerNewTemplate from "./ComposerNewTemplate.vue";
 describe("ComposerNewTemplate", () => {
   it("タイトルが表示される", async () => {
     const wrapper = await mountSuspended(ComposerNewTemplate, {
-      props: { errorMessage: "" },
+      props: { error: null },
     });
     expect(wrapper.text()).toContain("作曲家を追加");
   });
 
-  it("errorMessage が渡されるとエラーメッセージが表示される", async () => {
+  it("error が渡されるとエラーメッセージが表示される", async () => {
     const wrapper = await mountSuspended(ComposerNewTemplate, {
-      props: { errorMessage: "登録に失敗しました" },
+      props: { error: "登録に失敗しました" },
     });
     expect(wrapper.text()).toContain("登録に失敗しました");
   });
 
-  it("errorMessage が空文字列のときはエラーメッセージを表示しない", async () => {
+  it("error が null のときはエラーメッセージを表示しない", async () => {
     const wrapper = await mountSuspended(ComposerNewTemplate, {
-      props: { errorMessage: "" },
+      props: { error: null },
     });
     expect(wrapper.find(".error-message").exists()).toBe(false);
   });

--- a/app/components/templates/ComposerNewTemplate.vue
+++ b/app/components/templates/ComposerNewTemplate.vue
@@ -2,7 +2,7 @@
 import type { CreateComposerInput } from "~/types";
 
 defineProps<{
-  errorMessage: string;
+  error: string | null;
 }>();
 
 const emit = defineEmits<{
@@ -14,7 +14,7 @@ const emit = defineEmits<{
   <div>
     <h1 class="page-title">作曲家を追加</h1>
 
-    <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+    <ErrorMessage v-if="error" :message="error" variant="block" />
 
     <ComposerForm submit-label="登録する" @submit="emit('submit', $event)" />
   </div>

--- a/app/components/templates/PieceEditTemplate.stories.ts
+++ b/app/components/templates/PieceEditTemplate.stories.ts
@@ -30,18 +30,18 @@ const samplePiece: Piece = {
 };
 
 export const Default: Story = {
-  args: { piece: samplePiece, fetchError: null, errorMessage: "", composers },
+  args: { piece: samplePiece, fetchError: null, error: null, composers },
 };
 
 export const WithFetchError: Story = {
-  args: { piece: null, fetchError: new Error("取得失敗"), errorMessage: "", composers },
+  args: { piece: null, fetchError: new Error("取得失敗"), error: null, composers },
 };
 
 export const WithSubmitError: Story = {
   args: {
     piece: samplePiece,
     fetchError: null,
-    errorMessage: "更新に失敗しました。時間をおいて再度お試しください。",
+    error: "更新に失敗しました。時間をおいて再度お試しください。",
     composers,
   },
 };

--- a/app/components/templates/PieceEditTemplate.test.ts
+++ b/app/components/templates/PieceEditTemplate.test.ts
@@ -24,7 +24,7 @@ const composers: Composer[] = [
 describe("PieceEditTemplate", () => {
   it("ページタイトルが表示される", async () => {
     const wrapper = await mountSuspended(PieceEditTemplate, {
-      props: { piece: samplePiece, fetchError: null, errorMessage: "", composers },
+      props: { piece: samplePiece, fetchError: null, error: null, composers },
     });
     expect(wrapper.text()).toContain("楽曲を編集");
   });
@@ -34,7 +34,7 @@ describe("PieceEditTemplate", () => {
       props: {
         piece: null,
         fetchError: new Error("fetch error"),
-        errorMessage: "",
+        error: null,
         composers,
       },
     });
@@ -46,7 +46,7 @@ describe("PieceEditTemplate", () => {
       props: {
         piece: null,
         fetchError: new Error("fetch error"),
-        errorMessage: "",
+        error: null,
         composers,
       },
     });
@@ -55,14 +55,14 @@ describe("PieceEditTemplate", () => {
 
   it("fetchError がない場合は PieceForm が表示される", async () => {
     const wrapper = await mountSuspended(PieceEditTemplate, {
-      props: { piece: samplePiece, fetchError: null, errorMessage: "", composers },
+      props: { piece: samplePiece, fetchError: null, error: null, composers },
     });
     expect(wrapper.find("form.piece-form").exists()).toBe(true);
   });
 
   it("初期値が PieceForm に反映される", async () => {
     const wrapper = await mountSuspended(PieceEditTemplate, {
-      props: { piece: samplePiece, fetchError: null, errorMessage: "", composers },
+      props: { piece: samplePiece, fetchError: null, error: null, composers },
     });
     const titleInput = wrapper.find('input[placeholder="例：交響曲第9番"]');
     expect((titleInput.element as HTMLInputElement).value).toBe("交響曲第9番");
@@ -72,7 +72,7 @@ describe("PieceEditTemplate", () => {
 
   it("フォーム送信時に submit イベントが emit される", async () => {
     const wrapper = await mountSuspended(PieceEditTemplate, {
-      props: { piece: samplePiece, fetchError: null, errorMessage: "", composers },
+      props: { piece: samplePiece, fetchError: null, error: null, composers },
     });
     await wrapper.find("form").trigger("submit.prevent");
     expect(wrapper.emitted("submit")).toBeDefined();

--- a/app/components/templates/PieceEditTemplate.vue
+++ b/app/components/templates/PieceEditTemplate.vue
@@ -4,7 +4,7 @@ import type { Composer, Piece, UpdatePieceInput } from "~/types";
 defineProps<{
   piece: Piece | null;
   fetchError: Error | null;
-  errorMessage: string;
+  error: string | null;
   composers: Composer[];
   composersPending?: boolean;
 }>();
@@ -21,7 +21,7 @@ const emit = defineEmits<{
     <ErrorMessage v-if="fetchError" message="楽曲の取得に失敗しました。" variant="block" />
 
     <template v-else>
-      <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+      <ErrorMessage v-if="error" :message="error" variant="block" />
       <PieceForm
         :initial-values="{
           title: piece?.title,

--- a/app/components/templates/PieceNewTemplate.stories.ts
+++ b/app/components/templates/PieceNewTemplate.stories.ts
@@ -11,12 +11,12 @@ type Story = StoryObj<typeof PieceNewTemplate>;
 
 export const Default: Story = {
   args: {
-    errorMessage: "",
+    error: null,
   },
 };
 
 export const WithError: Story = {
   args: {
-    errorMessage: "楽曲の登録に失敗しました。時間をおいて再度お試しください。",
+    error: "楽曲の登録に失敗しました。時間をおいて再度お試しください。",
   },
 };

--- a/app/components/templates/PieceNewTemplate.test.ts
+++ b/app/components/templates/PieceNewTemplate.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceNewTemplate from "./PieceNewTemplate.vue";
 
-const commonProps = { errorMessage: "", composers: [] } as const;
+const commonProps = { error: null, composers: [] } as const;
 
 describe("PieceNewTemplate", () => {
   it("ページタイトルが表示される", async () => {
@@ -16,7 +16,7 @@ describe("PieceNewTemplate", () => {
 
   it("エラーがあるとき ErrorMessage が表示される", async () => {
     const wrapper = await mountSuspended(PieceNewTemplate, {
-      props: { ...commonProps, errorMessage: "登録に失敗しました" },
+      props: { ...commonProps, error: "登録に失敗しました" },
     });
     expect(wrapper.findComponent({ name: "ErrorMessage" }).exists()).toBe(true);
   });

--- a/app/components/templates/PieceNewTemplate.vue
+++ b/app/components/templates/PieceNewTemplate.vue
@@ -2,7 +2,7 @@
 import type { Composer, CreatePieceInput } from "~/types";
 
 defineProps<{
-  errorMessage: string;
+  error: string | null;
   composers: Composer[];
   composersPending?: boolean;
 }>();
@@ -16,7 +16,7 @@ const emit = defineEmits<{
   <div>
     <h1 class="page-title">楽曲を追加</h1>
 
-    <ErrorMessage v-if="errorMessage" :message="errorMessage" variant="block" />
+    <ErrorMessage v-if="error" :message="error" variant="block" />
 
     <PieceForm
       :composers="composers"

--- a/app/pages/composers/[id]/edit.test.ts
+++ b/app/pages/composers/[id]/edit.test.ts
@@ -55,10 +55,10 @@ describe("ComposerEditPage", () => {
     const wrapper = await mountSuspended(ComposerEditPage);
     const vm = wrapper.vm as {
       handleSubmit: (values: UpdateComposerInput) => Promise<void>;
-      errorMessage: string;
+      error: string | null;
     };
     await vm.handleSubmit({ name: "モーツァルト" });
     await flushPromises();
-    expect(vm.errorMessage).toContain("失敗");
+    expect(vm.error).toContain("失敗");
   });
 });

--- a/app/pages/composers/[id]/edit.vue
+++ b/app/pages/composers/[id]/edit.vue
@@ -6,26 +6,20 @@ definePageMeta({ middleware: ["admin"] });
 const route = useRoute();
 const id = computed(() => route.params.id as string);
 
-const { data: composer, error } = await useComposer(() => id.value);
+const { data: composer, error: fetchError } = await useComposer(() => id.value);
 const { updateComposer } = useComposersPaginated();
-const errorMessage = ref("");
-
-async function handleSubmit(values: UpdateComposerInput) {
-  errorMessage.value = "";
-  try {
-    await updateComposer(id.value, values);
-    await navigateTo("/composers");
-  } catch {
-    errorMessage.value = "更新に失敗しました。入力内容を確認してください。";
-  }
-}
+const { error, handleSubmit } = useSubmitHandler<UpdateComposerInput>({
+  submit: (values) => updateComposer(id.value, values),
+  redirectTo: "/composers",
+  errorMessage: "更新に失敗しました。入力内容を確認してください。",
+});
 </script>
 
 <template>
   <ComposerEditTemplate
     :composer="composer ?? null"
-    :fetch-error="error"
-    :error-message="errorMessage"
+    :fetch-error="fetchError"
+    :error="error"
     @submit="handleSubmit"
   />
 </template>

--- a/app/pages/composers/new.test.ts
+++ b/app/pages/composers/new.test.ts
@@ -48,10 +48,10 @@ describe("ComposerNewPage", () => {
     const wrapper = await mountSuspended(ComposerNewPage);
     const vm = wrapper.vm as {
       handleSubmit: (values: CreateComposerInput) => Promise<void>;
-      errorMessage: string;
+      error: string | null;
     };
     await vm.handleSubmit({ name: "ベートーヴェン" });
     await flushPromises();
-    expect(vm.errorMessage).toContain("失敗");
+    expect(vm.error).toContain("失敗");
   });
 });

--- a/app/pages/composers/new.vue
+++ b/app/pages/composers/new.vue
@@ -4,19 +4,13 @@ import type { CreateComposerInput } from "~/types";
 definePageMeta({ middleware: ["admin"] });
 
 const { createComposer } = useComposersPaginated();
-const errorMessage = ref("");
-
-async function handleSubmit(values: CreateComposerInput) {
-  errorMessage.value = "";
-  try {
-    await createComposer(values);
-    await navigateTo("/composers");
-  } catch {
-    errorMessage.value = "登録に失敗しました。入力内容を確認してください。";
-  }
-}
+const { error, handleSubmit } = useSubmitHandler<CreateComposerInput>({
+  submit: (values) => createComposer(values),
+  redirectTo: "/composers",
+  errorMessage: "登録に失敗しました。入力内容を確認してください。",
+});
 </script>
 
 <template>
-  <ComposerNewTemplate :error-message="errorMessage" @submit="handleSubmit" />
+  <ComposerNewTemplate :error="error" @submit="handleSubmit" />
 </template>

--- a/app/pages/pieces/[id]/edit.test.ts
+++ b/app/pages/pieces/[id]/edit.test.ts
@@ -63,10 +63,10 @@ describe("PieceEditPage", () => {
     const wrapper = await mountSuspended(PieceEditPage);
     const vm = wrapper.vm as {
       handleSubmit: (values: UpdatePieceInput) => Promise<void>;
-      errorMessage: string;
+      error: string | null;
     };
     await vm.handleSubmit({ title: "更新後" });
     await flushPromises();
-    expect(vm.errorMessage).toContain("失敗");
+    expect(vm.error).toContain("失敗");
   });
 });

--- a/app/pages/pieces/[id]/edit.vue
+++ b/app/pages/pieces/[id]/edit.vue
@@ -6,28 +6,23 @@ definePageMeta({ middleware: ["admin"] });
 const route = useRoute();
 const id = computed(() => route.params.id as string);
 
-const { data: piece, error } = await usePiece(() => id.value);
+const { data: piece, error: fetchError } = await usePiece(() => id.value);
 const { updatePiece } = usePiecesPaginated();
 const { data: composers, pending: composersPending, refresh: refreshComposers } = useComposersAll();
 await refreshComposers();
-const errorMessage = ref("");
 
-async function handleSubmit(values: UpdatePieceInput) {
-  errorMessage.value = "";
-  try {
-    await updatePiece(id.value, values);
-    await navigateTo("/pieces");
-  } catch {
-    errorMessage.value = "更新に失敗しました。入力内容を確認してください。";
-  }
-}
+const { error, handleSubmit } = useSubmitHandler<UpdatePieceInput>({
+  submit: (values) => updatePiece(id.value, values),
+  redirectTo: "/pieces",
+  errorMessage: "更新に失敗しました。入力内容を確認してください。",
+});
 </script>
 
 <template>
   <PieceEditTemplate
     :piece="piece ?? null"
-    :fetch-error="error"
-    :error-message="errorMessage"
+    :fetch-error="fetchError"
+    :error="error"
     :composers="composers ?? []"
     :composers-pending="composersPending"
     @submit="handleSubmit"

--- a/app/pages/pieces/new.test.ts
+++ b/app/pages/pieces/new.test.ts
@@ -58,10 +58,10 @@ describe("PieceNewPage", () => {
     const wrapper = await mountSuspended(PieceNewPage);
     const vm = wrapper.vm as {
       handleSubmit: (values: CreatePieceInput) => Promise<void>;
-      errorMessage: string;
+      error: string | null;
     };
     await vm.handleSubmit({ title: "交響曲第9番", composer: "ベートーヴェン" });
     await flushPromises();
-    expect(vm.errorMessage).toContain("失敗");
+    expect(vm.error).toContain("失敗");
   });
 });

--- a/app/pages/pieces/new.vue
+++ b/app/pages/pieces/new.vue
@@ -7,22 +7,16 @@ const { createPiece } = usePiecesPaginated();
 const { data: composers, pending: composersPending, refresh: refreshComposers } = useComposersAll();
 await refreshComposers();
 
-const errorMessage = ref("");
-
-async function handleSubmit(values: CreatePieceInput) {
-  errorMessage.value = "";
-  try {
-    await createPiece(values);
-    await navigateTo("/pieces");
-  } catch {
-    errorMessage.value = "登録に失敗しました。入力内容を確認してください。";
-  }
-}
+const { error, handleSubmit } = useSubmitHandler<CreatePieceInput>({
+  submit: (values) => createPiece(values),
+  redirectTo: "/pieces",
+  errorMessage: "登録に失敗しました。入力内容を確認してください。",
+});
 </script>
 
 <template>
   <PieceNewTemplate
-    :error-message="errorMessage"
+    :error="error"
     :composers="composers ?? []"
     :composers-pending="composersPending"
     @submit="handleSubmit"


### PR DESCRIPTION
## 概要

フォーム送信時のエラーハンドリングロジックを共通の `useSubmitHandler` コンポーザブルに抽出し、複数のページで重複していたコードを削減しました。

## 変更の種類

- [x] リファクタリング

## 変更内容

- **新規コンポーザブル**: `useSubmitHandler` を作成し、フォーム送信、エラーハンドリング、リダイレクト処理を統一
- **ページコンポーネント**: 以下のページで重複していた `handleSubmit` 関数と `errorMessage` ref を削除
  - `pages/composers/[id]/edit.vue`
  - `pages/composers/new.vue`
  - `pages/pieces/[id]/edit.vue`
  - `pages/pieces/new.vue`
- **Props 名の統一**: テンプレートコンポーネントの `errorMessage` prop を `error` に統一し、型を `string | null` に変更
  - `ComposerEditTemplate.vue`
  - `ComposerNewTemplate.vue`
  - `PieceEditTemplate.vue`
  - `PieceNewTemplate.vue`
- **Fetch エラーの明確化**: `useComposer` / `usePiece` から取得したエラーを `fetchError` に明示的にリネーム
- **テスト・ストーリーの更新**: 上記の変更に対応するテストとStorybook ストーリーを更新

## テスト

- [x] ユニットテストを追加・更新した
- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] リファクタリングのため `docs/SPEC.md` の更新は不要

https://claude.ai/code/session_01B9zGibfPSeoTCJ9WwfJoQw