### PR TITLE
Extract fetchCursorPage helper to reduce duplication

### DIFF
--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,18 +1,10 @@
 import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "~/types";
 import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { usePaginatedList, type PageResult } from "./usePaginatedList";
+import { fetchCursorPage, usePaginatedList } from "./usePaginatedList";
 
-const fetchPage = async (
-  apiBase: string,
-  options: { limit: number; cursor?: string }
-): Promise<PageResult<Composer>> => {
-  const query: { limit: number; cursor?: string } = { limit: options.limit };
-  if (options.cursor !== undefined) {
-    query.cursor = options.cursor;
-  }
-  return $fetch<PageResult<Composer>>(`${apiBase}/composers`, { query });
-};
+const fetchComposersPage = (apiBase: string, options: { limit: number; cursor?: string }) =>
+  fetchCursorPage<Composer>(`${apiBase}/composers`, options);
 
 /**
  * 作曲家マスタ一覧の無限スクロール / カーソル型ページング用 composable。
@@ -28,7 +20,7 @@ export const useComposersPaginated = () => {
     putJson<Composer>(`${apiBase}/composers/${id}`, input);
 
   const pagination = usePaginatedList<Composer>((cursor) =>
-    fetchPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_DEFAULT, cursor })
+    fetchComposersPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_DEFAULT, cursor })
   );
 
   const createComposer = async (input: CreateComposerInput) => {
@@ -72,7 +64,7 @@ export const useComposersAll = () => {
     pending.value = true;
     error.value = null;
     try {
-      const res = await fetchPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_MAX });
+      const res = await fetchComposersPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_MAX });
       if (res.nextCursor !== null) {
         throw new Error(
           `useComposersAll: composers exceed single-scan limit (${COMPOSERS_PAGE_SIZE_MAX}). Switch to paginated/search UI.`

--- a/app/composables/usePaginatedList.ts
+++ b/app/composables/usePaginatedList.ts
@@ -5,6 +5,21 @@
  */
 export type PageResult<T> = { items: T[]; nextCursor: string | null };
 
+/**
+ * カーソル型ページング API（`{ items, nextCursor }` 形式）を呼び出す共通ヘルパー。
+ * `cursor` が `undefined` のときはクエリに含めない（初回リクエスト用）。
+ */
+export const fetchCursorPage = <T>(
+  url: string,
+  options: { limit: number; cursor?: string }
+): Promise<PageResult<T>> => {
+  const query: { limit: number; cursor?: string } = { limit: options.limit };
+  if (options.cursor !== undefined) {
+    query.cursor = options.cursor;
+  }
+  return $fetch<PageResult<T>>(url, { query });
+};
+
 export const usePaginatedList = <T>(fetchPage: (cursor?: string) => Promise<PageResult<T>>) => {
   const items = ref<T[]>([]);
   const nextCursor = ref<string | null>(null);

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -5,18 +5,10 @@ import {
 } from "~/types";
 import type { CreatePieceInput, Piece, UpdatePieceInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { usePaginatedList, type PageResult } from "./usePaginatedList";
+import { fetchCursorPage, usePaginatedList } from "./usePaginatedList";
 
-const fetchPage = async (
-  apiBase: string,
-  options: { limit: number; cursor?: string }
-): Promise<PageResult<Piece>> => {
-  const query: { limit: number; cursor?: string } = { limit: options.limit };
-  if (options.cursor !== undefined) {
-    query.cursor = options.cursor;
-  }
-  return $fetch<PageResult<Piece>>(`${apiBase}/pieces`, { query });
-};
+const fetchPiecesPage = (apiBase: string, options: { limit: number; cursor?: string }) =>
+  fetchCursorPage<Piece>(`${apiBase}/pieces`, options);
 
 const usePieceMutations = () => {
   const apiBase = useApiBase();
@@ -42,7 +34,7 @@ export const usePiecesPaginated = () => {
   const apiBase = useApiBase();
   const { postPiece, putPiece } = usePieceMutations();
   const pagination = usePaginatedList<Piece>((cursor) =>
-    fetchPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor })
+    fetchPiecesPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor })
   );
 
   const createPiece = async (input: CreatePieceInput) => {
@@ -86,7 +78,7 @@ export const usePiecesAll = () => {
     let consecutiveEmpty = 0;
     try {
       while (true) {
-        const res = await fetchPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor });
+        const res = await fetchPiecesPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor });
         acc.push(...res.items);
         if (acc.length > PIECES_ALL_MAX_TOTAL) {
           throw new Error(`usePiecesAll: exceeded maximum total items (${PIECES_ALL_MAX_TOTAL})`);


### PR DESCRIPTION
## 概要

カーソル型ページング API を呼び出す共通ロジックを `usePaginatedList.ts` に `fetchCursorPage` ヘルパー関数として抽出し、`useComposers.ts` と `usePieces.ts` での重複を排除しました。

## 変更の種類

- [x] リファクタリング

## 変更内容

- `usePaginatedList.ts` に `fetchCursorPage` ヘルパー関数を追加
  - カーソル型ページング API（`{ items, nextCursor }` 形式）を呼び出す共通ロジック
  - `cursor` が `undefined` のときはクエリに含めない（初回リクエスト用）
- `useComposers.ts` の `fetchPage` 関数を `fetchCursorPage` を使用した `fetchComposersPage` に置き換え
- `usePieces.ts` の `fetchPage` 関数を `fetchCursorPage` を使用した `fetchPiecesPage` に置き換え
- 両ファイルの呼び出し箇所を新しい関数名に更新

## テスト

- [x] 既存テストがすべて通ることを確認した（CI）
- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている

https://claude.ai/code/session_01CLn6JLtW15gNyPtwuu5fwk