### PR TITLE
Add text-based value objects for domain entities

### DIFF
--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -6,6 +6,7 @@ import type {
   UpdateComposerInput,
 } from "../types";
 import { buildUpdateProps } from "./entity-helpers";
+import { ComposerName } from "./value-objects/composer-name";
 import { ComposerId } from "./value-objects/ids";
 
 const CLEARABLE_FIELDS = ["era", "region", "imageUrl"] as const;
@@ -23,7 +24,7 @@ export type ComposerRepository = {
 
 type ComposerProps = {
   id: ComposerId;
-  name: string;
+  name: ComposerName;
   era?: PieceEra;
   region?: PieceRegion;
   imageUrl?: string;
@@ -39,6 +40,7 @@ export class ComposerEntity {
     return new ComposerEntity({
       ...input,
       id: ComposerId.generate(),
+      name: ComposerName.of(input.name),
       createdAt: now,
       updatedAt: now,
     });
@@ -48,6 +50,7 @@ export class ComposerEntity {
     return new ComposerEntity({
       ...data,
       id: ComposerId.from(data.id),
+      name: ComposerName.of(data.name),
     });
   }
 
@@ -64,6 +67,7 @@ export class ComposerEntity {
     return {
       ...this.props,
       id: this.props.id.value,
+      name: this.props.name.value,
     };
   }
 }

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,5 +1,6 @@
 import type { ConcertLog, CreateConcertLogInput } from "../types";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
+import { Venue } from "./value-objects/venue";
 
 export type ConcertLogRepository = {
   findById(id: ConcertLogId): Promise<ConcertLog | undefined>;
@@ -14,7 +15,7 @@ type ConcertLogProps = {
   userId: UserId;
   title: string;
   concertDate: string;
-  venue: string;
+  venue: Venue;
   conductor?: string;
   orchestra?: string;
   soloist?: string;
@@ -32,6 +33,7 @@ export class ConcertLogEntity {
       ...input,
       id: ConcertLogId.generate(),
       userId,
+      venue: Venue.of(input.venue),
       pieceIds: input.pieceIds === undefined ? undefined : input.pieceIds.map(PieceId.from),
       createdAt: now,
       updatedAt: now,
@@ -43,6 +45,7 @@ export class ConcertLogEntity {
       ...data,
       id: ConcertLogId.from(data.id),
       userId: UserId.from(data.userId),
+      venue: Venue.of(data.venue),
       pieceIds: data.pieceIds === undefined ? undefined : data.pieceIds.map(PieceId.from),
     });
   }
@@ -60,6 +63,7 @@ export class ConcertLogEntity {
       ...this.props,
       id: this.props.id.value,
       userId: this.props.userId.value,
+      venue: this.props.venue.value,
       pieceIds:
         this.props.pieceIds === undefined ? undefined : this.props.pieceIds.map((id) => id.value),
     };

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -9,6 +9,7 @@ import type {
 } from "../types";
 import { buildUpdateProps } from "./entity-helpers";
 import { ComposerId, PieceId } from "./value-objects/ids";
+import { PieceTitle } from "./value-objects/piece-title";
 
 const CLEARABLE_FIELDS = ["videoUrl", "genre", "era", "formation", "region"] as const;
 
@@ -30,7 +31,7 @@ export type PieceRepository = {
 
 type PieceProps = {
   id: PieceId;
-  title: string;
+  title: PieceTitle;
   composerId: ComposerId;
   videoUrl?: string;
   genre?: PieceGenre;
@@ -49,6 +50,7 @@ export class PieceEntity {
     return new PieceEntity({
       ...input,
       id: PieceId.generate(),
+      title: PieceTitle.of(input.title),
       composerId: ComposerId.from(input.composerId),
       createdAt: now,
       updatedAt: now,
@@ -59,6 +61,7 @@ export class PieceEntity {
     return new PieceEntity({
       ...data,
       id: PieceId.from(data.id),
+      title: PieceTitle.of(data.title),
       composerId: ComposerId.from(data.composerId),
     });
   }
@@ -76,6 +79,7 @@ export class PieceEntity {
     return {
       ...this.props,
       id: this.props.id.value,
+      title: this.props.title.value,
       composerId: this.props.composerId.value,
     };
   }

--- a/backend/src/domain/value-objects/composer-name.test.ts
+++ b/backend/src/domain/value-objects/composer-name.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { ComposerName } from "./composer-name";
+
+describe("ComposerName", () => {
+  describe("of", () => {
+    it("非空文字列を受理して値を保持する", () => {
+      const name = ComposerName.of("ベートーヴェン");
+      expect(name.value).toBe("ベートーヴェン");
+      expect(String(name)).toBe("ベートーヴェン");
+    });
+
+    it("前後の空白をトリムする", () => {
+      const name = ComposerName.of("  モーツァルト  ");
+      expect(name.value).toBe("モーツァルト");
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => ComposerName.of("")).toThrow(RangeError);
+    });
+
+    it("空白のみの文字列を拒否する", () => {
+      expect(() => ComposerName.of("   ")).toThrow(RangeError);
+    });
+
+    it("100 文字ちょうどは受理する", () => {
+      const value = "a".repeat(100);
+      expect(ComposerName.of(value).value).toBe(value);
+    });
+
+    it("101 文字以上を拒否する", () => {
+      expect(() => ComposerName.of("a".repeat(101))).toThrow(RangeError);
+    });
+
+    it("文字列以外を拒否する", () => {
+      expect(() => ComposerName.of(null as unknown as string)).toThrow(TypeError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の ComposerName は等しい", () => {
+      expect(ComposerName.of("バッハ").equals(ComposerName.of("バッハ"))).toBe(true);
+    });
+
+    it("異なる値の ComposerName は等しくない", () => {
+      expect(ComposerName.of("ショパン").equals(ComposerName.of("リスト"))).toBe(false);
+    });
+
+    it("ComposerName 以外のオブジェクトとは等しくない", () => {
+      const name = ComposerName.of("ブラームス");
+      expect(name.equals({ value: "ブラームス" } as unknown as ComposerName)).toBe(false);
+    });
+  });
+});

--- a/backend/src/domain/value-objects/composer-name.ts
+++ b/backend/src/domain/value-objects/composer-name.ts
@@ -1,0 +1,38 @@
+/**
+ * 作曲家の名前を表す値オブジェクト。
+ *
+ * - 前後の空白を除去して保持する。
+ * - 空文字（空白のみを含む）を拒否する。
+ * - 最大 100 文字。
+ */
+const MAX_LENGTH = 100;
+
+export class ComposerName {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  static of(value: string): ComposerName {
+    if (typeof value !== "string") {
+      throw new TypeError("ComposerName must be a string");
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new RangeError("ComposerName must be a non-empty string");
+    }
+    if (trimmed.length > MAX_LENGTH) {
+      throw new RangeError(`ComposerName must be ${MAX_LENGTH} characters or less`);
+    }
+    return new ComposerName(trimmed);
+  }
+
+  equals(other: ComposerName): boolean {
+    return other instanceof ComposerName && this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/backend/src/domain/value-objects/piece-title.test.ts
+++ b/backend/src/domain/value-objects/piece-title.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { PieceTitle } from "./piece-title";
+
+describe("PieceTitle", () => {
+  describe("of", () => {
+    it("非空文字列を受理して値を保持する", () => {
+      const title = PieceTitle.of("交響曲第9番");
+      expect(title.value).toBe("交響曲第9番");
+      expect(String(title)).toBe("交響曲第9番");
+    });
+
+    it("前後の空白をトリムする", () => {
+      const title = PieceTitle.of("  月光ソナタ  ");
+      expect(title.value).toBe("月光ソナタ");
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => PieceTitle.of("")).toThrow(RangeError);
+    });
+
+    it("空白のみの文字列を拒否する", () => {
+      expect(() => PieceTitle.of("   ")).toThrow(RangeError);
+    });
+
+    it("200 文字ちょうどは受理する", () => {
+      const value = "a".repeat(200);
+      expect(PieceTitle.of(value).value).toBe(value);
+    });
+
+    it("201 文字以上を拒否する", () => {
+      expect(() => PieceTitle.of("a".repeat(201))).toThrow(RangeError);
+    });
+
+    it("文字列以外を拒否する", () => {
+      expect(() => PieceTitle.of(123 as unknown as string)).toThrow(TypeError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の PieceTitle は等しい", () => {
+      expect(PieceTitle.of("魔弾の射手").equals(PieceTitle.of("魔弾の射手"))).toBe(true);
+    });
+
+    it("異なる値の PieceTitle は等しくない", () => {
+      expect(PieceTitle.of("ボレロ").equals(PieceTitle.of("ラ・ヴァルス"))).toBe(false);
+    });
+
+    it("PieceTitle 以外のオブジェクトとは等しくない", () => {
+      const title = PieceTitle.of("運命");
+      expect(title.equals({ value: "運命" } as unknown as PieceTitle)).toBe(false);
+    });
+  });
+});

--- a/backend/src/domain/value-objects/piece-title.ts
+++ b/backend/src/domain/value-objects/piece-title.ts
@@ -1,0 +1,41 @@
+/**
+ * 楽曲のタイトルを表す値オブジェクト。
+ *
+ * - 前後の空白を除去して保持する。
+ * - 空文字（空白のみを含む）を拒否する。
+ * - 最大 200 文字。
+ *
+ * プリミティブな `string` との混同を型システムで抑止し、タイトルとしての
+ * 不変条件をドメイン層で単独に保証する。
+ */
+const MAX_LENGTH = 200;
+
+export class PieceTitle {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  static of(value: string): PieceTitle {
+    if (typeof value !== "string") {
+      throw new TypeError("PieceTitle must be a string");
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new RangeError("PieceTitle must be a non-empty string");
+    }
+    if (trimmed.length > MAX_LENGTH) {
+      throw new RangeError(`PieceTitle must be ${MAX_LENGTH} characters or less`);
+    }
+    return new PieceTitle(trimmed);
+  }
+
+  equals(other: PieceTitle): boolean {
+    return other instanceof PieceTitle && this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/backend/src/domain/value-objects/venue.test.ts
+++ b/backend/src/domain/value-objects/venue.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+
+import { Venue } from "./venue";
+
+describe("Venue", () => {
+  describe("of", () => {
+    it("非空文字列を受理して値を保持する", () => {
+      const venue = Venue.of("サントリーホール");
+      expect(venue.value).toBe("サントリーホール");
+      expect(String(venue)).toBe("サントリーホール");
+    });
+
+    it("前後の空白をトリムする", () => {
+      const venue = Venue.of("  東京文化会館  ");
+      expect(venue.value).toBe("東京文化会館");
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => Venue.of("")).toThrow(RangeError);
+    });
+
+    it("空白のみの文字列を拒否する", () => {
+      expect(() => Venue.of("   ")).toThrow(RangeError);
+    });
+
+    it("200 文字ちょうどは受理する", () => {
+      const value = "a".repeat(200);
+      expect(Venue.of(value).value).toBe(value);
+    });
+
+    it("201 文字以上を拒否する", () => {
+      expect(() => Venue.of("a".repeat(201))).toThrow(RangeError);
+    });
+
+    it("文字列以外を拒否する", () => {
+      expect(() => Venue.of(undefined as unknown as string)).toThrow(TypeError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の Venue は等しい", () => {
+      expect(Venue.of("NHKホール").equals(Venue.of("NHKホール"))).toBe(true);
+    });
+
+    it("異なる値の Venue は等しくない", () => {
+      expect(Venue.of("ミューザ川崎").equals(Venue.of("オーチャードホール"))).toBe(false);
+    });
+
+    it("Venue 以外のオブジェクトとは等しくない", () => {
+      const venue = Venue.of("フェスティバルホール");
+      expect(venue.equals({ value: "フェスティバルホール" } as unknown as Venue)).toBe(false);
+    });
+  });
+});

--- a/backend/src/domain/value-objects/venue.ts
+++ b/backend/src/domain/value-objects/venue.ts
@@ -1,0 +1,38 @@
+/**
+ * コンサートの開催会場名を表す値オブジェクト。
+ *
+ * - 前後の空白を除去して保持する。
+ * - 空文字（空白のみを含む）を拒否する。
+ * - 最大 200 文字。
+ */
+const MAX_LENGTH = 200;
+
+export class Venue {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  static of(value: string): Venue {
+    if (typeof value !== "string") {
+      throw new TypeError("Venue must be a string");
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new RangeError("Venue must be a non-empty string");
+    }
+    if (trimmed.length > MAX_LENGTH) {
+      throw new RangeError(`Venue must be ${MAX_LENGTH} characters or less`);
+    }
+    return new Venue(trimmed);
+  }
+
+  equals(other: Venue): boolean {
+    return other instanceof Venue && this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1262,15 +1262,30 @@ cdk deploy
 
 ID 以外のドメイン概念についても、不変条件を型と実装の両面で保証するために値オブジェクトを導入する。
 
-| クラス   | 定義箇所                                     | 用途                                                                          |
-| -------- | -------------------------------------------- | ----------------------------------------------------------------------------- |
-| `Rating` | `backend/src/domain/value-objects/rating.ts` | 鑑賞ログの評価値（1〜5 の整数）。`ListeningLogEntity` の内部 props で保持する |
+| クラス         | 定義箇所                                            | 用途                                                                                  |
+| -------------- | --------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| `Rating`       | `backend/src/domain/value-objects/rating.ts`        | 鑑賞ログの評価値（1〜5 の整数）。`ListeningLogEntity` の内部 props で保持する         |
+| `PieceTitle`   | `backend/src/domain/value-objects/piece-title.ts`   | 楽曲マスタのタイトル（非空・最大 200 文字）。`PieceEntity` の内部 props で保持する    |
+| `ComposerName` | `backend/src/domain/value-objects/composer-name.ts` | 作曲家マスタの名前（非空・最大 100 文字）。`ComposerEntity` の内部 props で保持する   |
+| `Venue`        | `backend/src/domain/value-objects/venue.ts`         | コンサートの会場名（非空・最大 200 文字）。`ConcertLogEntity` の内部 props で保持する |
+
+#### `Rating`
 
 - 生成は `Rating.of(value)`。整数・範囲（1〜5）を満たさない場合は `RangeError` を投げる
 - `.value` は narrow な `1 | 2 | 3 | 4 | 5` 型
 - 等価判定は `equals(other)`。インスタンスが `Rating` でない場合は `false` を返す
 - `ListeningLogEntity` は `create()` / `reconstruct()` で `Rating.of(input.rating)` により VO を組み立て、`toPlain()` で `.value` に戻して DTO を返す
 - DTO 境界（`types/index.ts` の `Rating` 型エイリアス = `1 | 2 | 3 | 4 | 5`）は従来どおり。VO と primitive を混同しないよう、エンティティ props の型と DTO の型を分けて扱う
+
+#### `PieceTitle` / `ComposerName` / `Venue`（テキスト系 VO）
+
+ドメインにおける名前・タイトル系のプリミティブな `string` を値オブジェクト化し、「非空・最大文字数」の不変条件をドメイン層で保証する。
+
+- 生成は `Xxx.of(value)`。内部で `value.trim()` を適用した上で、空文字は `RangeError`、最大長超過も `RangeError`、文字列以外は `TypeError` を投げる
+- 最大長は VO ごとに異なる（`PieceTitle`: 200、`ComposerName`: 100、`Venue`: 200）。Zod スキーマ（`utils/schemas.ts`）と数値を揃えて二重検証を行う
+- 等価判定は `equals(other)`。異なる VO クラス間は型レベルで混同できないため、実質クラス内比較となる
+- 各エンティティは `create()` / `reconstruct()` で `Xxx.of(...)` により VO を組み立て、`toPlain()` で `.value` に戻して DTO を返す
+- DTO 境界（`types/index.ts` の `Piece.title` / `Composer.name` / `ConcertLog.venue` など）は従来どおり `string`。VO はエンティティ内部の props 型としてのみ扱い、ハンドラ・ユースケース・リポジトリは引き続き string ベースの DTO を受け渡す
 
 ---
 


### PR DESCRIPTION
## 概要

ドメイン層に3つのテキスト系値オブジェクト（`PieceTitle`、`ComposerName`、`Venue`）を導入し、プリミティブな `string` 型の混同を防ぎ、「非空・最大文字数」の不変条件をドメイン層で保証します。

## 変更の種類

- [x] 新機能
- [x] リファクタリング
- [x] テスト
- [x] ドキュメント

## 変更内容

### 新規値オブジェクト
- **`PieceTitle`** (`backend/src/domain/value-objects/piece-title.ts`)
  - 楽曲のタイトルを表す値オブジェクト
  - 最大200文字、非空（空白のみは拒否）
  - `of()` ファクトリメソッドで生成、`equals()` で等価判定

- **`ComposerName`** (`backend/src/domain/value-objects/composer-name.ts`)
  - 作曲家の名前を表す値オブジェクト
  - 最大100文字、非空（空白のみは拒否）
  - `of()` ファクトリメソッドで生成、`equals()` で等価判定

- **`Venue`** (`backend/src/domain/value-objects/venue.ts`)
  - コンサートの会場名を表す値オブジェクト
  - 最大200文字、非空（空白のみは拒否）
  - `of()` ファクトリメソッドで生成、`equals()` で等価判定

### エンティティの更新
- **`PieceEntity`**: `title` プロパティを `string` から `PieceTitle` に変更、`create()`/`reconstruct()` で VO を組み立て、`toPlain()` で `.value` に戻す
- **`ComposerEntity`**: `name` プロパティを `string` から `ComposerName` に変更、同様に VO を組み立て・分解
- **`ConcertLogEntity`**: `venue` プロパティを `string` から `Venue` に変更、同様に VO を組み立て・分解

### テスト
- 各値オブジェクトに対して包括的なユニットテストを追加
  - 正常系：非空文字列の受理、前後の空白トリム、最大長ちょうどの受理
  - 異常系：空文字列、空白のみの文字列、最大長超過、文字列以外の型
  - 等価判定：同じ値の比較、異なる値の比較、異なるクラスとの比較

### ドキュメント
- `docs/SPEC.md` の「値オブジェクト」セクションを更新
  - 新規3つの VO をテーブルに追加
  - テキスト系 VO の設計方針（生成・検証・等価判定・エンティティ統合・DTO 境界）を詳述

## テスト

- [x] ユニットテストを追加・更新した
  - `composer-name.test.ts`、`piece-title.test.ts`、`venue.test.ts` を新規作成
  - 各 VO の生成・検証・等価判定をカバー
- [ ] 既存テストがすべて通ることを確認した（エンティティの VO 統合により既存テストの更新が必要

https://claude.ai/code/session_013YdYVeW3Kp477W2WRqvFvT