### PR TITLE
fix(frontend): autoplay機能を削除

### DIFF
--- a/app/components/molecules/VideoPlayer.test.ts
+++ b/app/components/molecules/VideoPlayer.test.ts
@@ -29,25 +29,11 @@ describe("VideoPlayer", () => {
       expect(wrapper.find("a.external-link").exists()).toBe(false);
     });
 
-    it("autoplay が未指定のときは embed URL に autoplay=1 が含まれない", async () => {
+    it("embed URL に autoplay パラメータが含まれない", async () => {
       const wrapper = await mountSuspended(VideoPlayer, {
         props: { videoUrl: youtubeUrl },
       });
-      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay=1");
-    });
-
-    it("autoplay が true のとき embed URL に autoplay=1 が追加される", async () => {
-      const wrapper = await mountSuspended(VideoPlayer, {
-        props: { videoUrl: youtubeUrl, autoplay: true },
-      });
-      expect(wrapper.find("iframe").attributes("src")).toContain("autoplay=1");
-    });
-
-    it("iframe に allow='autoplay' 属性が設定される", async () => {
-      const wrapper = await mountSuspended(VideoPlayer, {
-        props: { videoUrl: youtubeUrl },
-      });
-      expect(wrapper.find("iframe").attributes("allow")).toBe("autoplay");
+      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay");
     });
   });
 

--- a/app/components/molecules/VideoPlayer.test.ts
+++ b/app/components/molecules/VideoPlayer.test.ts
@@ -42,6 +42,13 @@ describe("VideoPlayer", () => {
       });
       expect(wrapper.find("iframe").attributes("src")).toContain("autoplay=1");
     });
+
+    it("iframe に allow='autoplay' 属性が設定される", async () => {
+      const wrapper = await mountSuspended(VideoPlayer, {
+        props: { videoUrl: youtubeUrl },
+      });
+      expect(wrapper.find("iframe").attributes("allow")).toBe("autoplay");
+    });
   });
 
   describe("非 YouTube URL の場合", () => {

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -1,23 +1,16 @@
 <script setup lang="ts">
 import { isYouTubeUrl, toYouTubeEmbedUrl } from "~/utils/video";
 
-const props = withDefaults(
-  defineProps<{
-    videoUrl: string;
-    autoplay?: boolean;
-  }>(),
-  { autoplay: false }
-);
+const props = defineProps<{
+  videoUrl: string;
+}>();
 
 const emit = defineEmits<{
   play: [];
 }>();
 
 const isYouTube = computed(() => isYouTubeUrl(props.videoUrl));
-const embedUrl = computed(() => {
-  const base = toYouTubeEmbedUrl(props.videoUrl);
-  return props.autoplay ? `${base}&autoplay=1` : base;
-});
+const embedUrl = computed(() => toYouTubeEmbedUrl(props.videoUrl));
 
 type YTPlayer = { destroy: () => void };
 
@@ -82,7 +75,6 @@ onUnmounted(() => {
       :src="embedUrl"
       class="youtube-iframe"
       title="YouTube 動画プレーヤー"
-      allow="autoplay"
     />
     <a
       v-else

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -82,6 +82,7 @@ onUnmounted(() => {
       :src="embedUrl"
       class="youtube-iframe"
       title="YouTube 動画プレーヤー"
+      allow="autoplay"
     />
     <a
       v-else

--- a/app/components/organisms/PieceList.test.ts
+++ b/app/components/organisms/PieceList.test.ts
@@ -108,7 +108,7 @@ describe("PieceList", () => {
       expect(emitted[0][0].id).toBe("piece-1");
     });
 
-    it("詳細ボタンクリックで autoplay なしの詳細ページへ遷移する", async () => {
+    it("詳細ボタンクリックで詳細ページへ遷移する", async () => {
       const wrapper = await mountSuspended(PieceList, {
         props: { pieces: makePieces(), error: null, composerNameById },
       });
@@ -117,13 +117,13 @@ describe("PieceList", () => {
       expect(routerPushSpy).toHaveBeenCalledWith("/pieces/piece-1");
     });
 
-    it("サムネイルクリックで autoplay=1 付きの詳細ページへ遷移する", async () => {
+    it("サムネイルクリックで詳細ページへ遷移する", async () => {
       const wrapper = await mountSuspended(PieceList, {
         props: { pieces: makePieces(), error: null, composerNameById },
       });
       const routerPushSpy = vi.spyOn(wrapper.vm.$router, "push");
       await wrapper.find(".piece-thumbnail").trigger("click");
-      expect(routerPushSpy).toHaveBeenCalledWith("/pieces/piece-1?autoplay=1");
+      expect(routerPushSpy).toHaveBeenCalledWith("/pieces/piece-1");
     });
   });
 });

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -31,7 +31,7 @@ const router = useRouter();
           :piece="piece"
           :composer-name="composerNameById[piece.composerId] ?? '(不明な作曲家)'"
           @detail="router.push(`/pieces/${piece.id}`)"
-          @play="router.push(`/pieces/${piece.id}?autoplay=1`)"
+          @play="router.push(`/pieces/${piece.id}`)"
           @edit="router.push(`/pieces/${piece.id}/edit`)"
           @delete="emit('delete', piece)"
         />

--- a/app/components/templates/PieceDetailTemplate.test.ts
+++ b/app/components/templates/PieceDetailTemplate.test.ts
@@ -81,7 +81,7 @@ describe("PieceDetailTemplate", () => {
       expect(wrapper.find(".quick-log-form").exists()).toBe(false);
     });
 
-    it("autoplay が未指定のとき iframe の src に autoplay=1 が含まれない", async () => {
+    it("iframe の src に autoplay パラメータが含まれない", async () => {
       const wrapper = await mountSuspended(PieceDetailTemplate, {
         props: {
           piece: pieceWithVideo,
@@ -90,20 +90,7 @@ describe("PieceDetailTemplate", () => {
           composerName: "ベートーヴェン",
         },
       });
-      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay=1");
-    });
-
-    it("autoplay が true のとき iframe の src に autoplay=1 が含まれる", async () => {
-      const wrapper = await mountSuspended(PieceDetailTemplate, {
-        props: {
-          piece: pieceWithVideo,
-          error: null,
-          autoplay: true,
-          isAdmin: false,
-          composerName: "ベートーヴェン",
-        },
-      });
-      expect(wrapper.find("iframe").attributes("src")).toContain("autoplay=1");
+      expect(wrapper.find("iframe").attributes("src")).not.toContain("autoplay");
     });
   });
 

--- a/app/components/templates/PieceDetailTemplate.vue
+++ b/app/components/templates/PieceDetailTemplate.vue
@@ -1,16 +1,12 @@
 <script setup lang="ts">
 import type { Piece, Rating } from "~/types";
 
-withDefaults(
-  defineProps<{
-    piece: Piece | null;
-    error: Error | null;
-    autoplay?: boolean;
-    isAdmin: boolean;
-    composerName: string;
-  }>(),
-  { autoplay: false }
-);
+defineProps<{
+  piece: Piece | null;
+  error: Error | null;
+  isAdmin: boolean;
+  composerName: string;
+}>();
 
 const emit = defineEmits<{
   save: [values: { rating: Rating; isFavorite: boolean; memo: string }];
@@ -44,11 +40,7 @@ const hasStartedPlaying = ref(false);
       </div>
 
       <template v-if="piece.videoUrl">
-        <VideoPlayer
-          :video-url="piece.videoUrl"
-          :autoplay="autoplay"
-          @play="hasStartedPlaying = true"
-        />
+        <VideoPlayer :video-url="piece.videoUrl" @play="hasStartedPlaying = true" />
 
         <QuickLogForm
           v-if="hasStartedPlaying"

--- a/app/pages/pieces/[id]/index.vue
+++ b/app/pages/pieces/[id]/index.vue
@@ -10,8 +10,6 @@ const { create } = useListeningLogs();
 const { isAdmin } = useAuth();
 const isAdminUser = isAdmin();
 
-const autoplay = computed(() => route.query.autoplay === "1");
-
 const composerName = computed(() => {
   const id = piece.value?.composerId;
   if (id === undefined) {
@@ -51,7 +49,6 @@ async function handleDelete(target: Piece) {
   <PieceDetailTemplate
     :piece="piece ?? null"
     :error="error"
-    :autoplay="autoplay"
     :is-admin="isAdminUser"
     :composer-name="composerName"
     @save="handleSave"


### PR DESCRIPTION
## Summary

autoplayはブラウザのautoplayポリシーにより機能しないため、機能自体を削除する。

- `VideoPlayer.vue` から `autoplay` prop と関連ロジック（`&autoplay=1` の付加）を削除
- `PieceDetailTemplate.vue` から `autoplay` prop を削除
- `PieceList.vue` の「動画を再生」クリック時の `?autoplay=1` クエリを削除
- `pages/pieces/[id]/index.vue` から `autoplay` computed を削除

## Test plan

- [ ] 楽曲一覧の「動画を再生」サムネイルをクリック → 詳細ページへ遷移する（クエリなし）
- [ ] 詳細ページで動画が自動再生されないことを確認（手動クリックで再生できることを確認）
- [ ] フロントエンドテスト: `pnpm run test:frontend` がすべてパス

Closes #475

🤖 Generated with [Claude Code](https://claude.com/claude-code)