### PR TITLE
refactor(backend): エンティティ基底クラスを導入して共通プロパティを集約

### DIFF
--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -5,6 +5,7 @@ import type {
   PieceRegion,
   UpdateComposerInput,
 } from "../types";
+import { Entity, type EntityProps } from "./entity";
 import { buildUpdateProps } from "./entity-helpers";
 import { ComposerName } from "./value-objects/composer-name";
 import { ComposerId } from "./value-objects/ids";
@@ -23,18 +24,17 @@ export type ComposerRepository = {
   remove(id: ComposerId): Promise<void>;
 };
 
-type ComposerProps = {
-  id: ComposerId;
+type ComposerProps = EntityProps<ComposerId> & {
   name: ComposerName;
   era?: PieceEra;
   region?: PieceRegion;
   imageUrl?: Url;
-  createdAt: string;
-  updatedAt: string;
 };
 
-export class ComposerEntity {
-  private constructor(private readonly props: ComposerProps) {}
+export class ComposerEntity extends Entity<ComposerId, ComposerProps> {
+  private constructor(props: ComposerProps) {
+    super(props);
+  }
 
   static create(input: CreateComposerInput): ComposerEntity {
     const now = new Date().toISOString();
@@ -55,10 +55,6 @@ export class ComposerEntity {
       name: ComposerName.of(data.name),
       imageUrl: data.imageUrl !== undefined ? Url.of(data.imageUrl) : undefined,
     });
-  }
-
-  get updatedAt(): string {
-    return this.props.updatedAt;
   }
 
   mergeUpdate(input: UpdateComposerInput): ComposerEntity {

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,4 +1,5 @@
 import type { ConcertLog, CreateConcertLogInput } from "../types";
+import { Entity, type EntityProps } from "./entity";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 import { Venue } from "./value-objects/venue";
 
@@ -10,8 +11,7 @@ export type ConcertLogRepository = {
   remove(id: ConcertLogId): Promise<void>;
 };
 
-type ConcertLogProps = {
-  id: ConcertLogId;
+type ConcertLogProps = EntityProps<ConcertLogId> & {
   userId: UserId;
   title: string;
   concertDate: string;
@@ -20,12 +20,12 @@ type ConcertLogProps = {
   orchestra?: string;
   soloist?: string;
   pieceIds?: PieceId[];
-  createdAt: string;
-  updatedAt: string;
 };
 
-export class ConcertLogEntity {
-  private constructor(private readonly props: ConcertLogProps) {}
+export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
+  private constructor(props: ConcertLogProps) {
+    super(props);
+  }
 
   static create(input: CreateConcertLogInput, userId: UserId): ConcertLogEntity {
     const now = new Date().toISOString();

--- a/backend/src/domain/entity.test.ts
+++ b/backend/src/domain/entity.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import { Entity, type EntityProps } from "./entity";
+import { ComposerId, PieceId } from "./value-objects/ids";
+
+type DummyPieceProps = EntityProps<PieceId> & { label: string };
+type DummyComposerProps = EntityProps<ComposerId> & { label: string };
+
+class DummyPieceEntity extends Entity<PieceId, DummyPieceProps> {
+  static of(id: PieceId, label = "x"): DummyPieceEntity {
+    return new DummyPieceEntity({
+      id,
+      label,
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+  }
+}
+
+class DummyComposerEntity extends Entity<ComposerId, DummyComposerProps> {
+  static of(id: ComposerId): DummyComposerEntity {
+    return new DummyComposerEntity({
+      id,
+      label: "y",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      updatedAt: "2026-01-02T00:00:00.000Z",
+    });
+  }
+}
+
+describe("Entity", () => {
+  describe("getter", () => {
+    it("id / createdAt / updatedAt を props から返す", () => {
+      const id = PieceId.generate();
+      const entity = DummyPieceEntity.of(id);
+      expect(entity.id).toBe(id);
+      expect(entity.createdAt).toBe("2026-01-01T00:00:00.000Z");
+      expect(entity.updatedAt).toBe("2026-01-02T00:00:00.000Z");
+    });
+  });
+
+  describe("equals", () => {
+    it("同じクラス・同じ ID なら true を返す", () => {
+      const id = PieceId.generate();
+      const a = DummyPieceEntity.of(id, "a");
+      const b = DummyPieceEntity.of(id, "b");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("同じクラスでも ID が異なれば false を返す", () => {
+      const a = DummyPieceEntity.of(PieceId.generate());
+      const b = DummyPieceEntity.of(PieceId.generate());
+      expect(a.equals(b)).toBe(false);
+    });
+
+    it("異なるクラスでは ID 値が同じでも false を返す", () => {
+      const value = "00000000-0000-0000-0000-000000000000";
+      const piece = DummyPieceEntity.of(PieceId.from(value));
+      const composer = DummyComposerEntity.of(ComposerId.from(value));
+      expect(piece.equals(composer)).toBe(false);
+    });
+
+    it("Entity でないものを渡すと false を返す", () => {
+      const entity = DummyPieceEntity.of(PieceId.generate());
+      expect(entity.equals(null)).toBe(false);
+      expect(entity.equals(undefined)).toBe(false);
+      expect(entity.equals({ id: entity.id })).toBe(false);
+    });
+  });
+});

--- a/backend/src/domain/entity.ts
+++ b/backend/src/domain/entity.ts
@@ -1,0 +1,40 @@
+import type { IdValueObject } from "./value-objects/ids";
+
+export type EntityProps<TId extends IdValueObject> = {
+  id: TId;
+  createdAt: string;
+  updatedAt: string;
+};
+
+/**
+ * DDD のエンティティ基底クラス。
+ *
+ * - `id` / `createdAt` / `updatedAt` の保持と getter を共通化する
+ * - `equals` は「同じ具象クラス かつ 同じ ID」をエンティティの等価条件として実装する
+ *   （IdValueObject.equals が constructor 比較を含むため、ここでも明示的に揃える）
+ */
+export abstract class Entity<TId extends IdValueObject, TProps extends EntityProps<TId>> {
+  protected constructor(protected readonly props: TProps) {}
+
+  get id(): TId {
+    return this.props.id;
+  }
+
+  get createdAt(): string {
+    return this.props.createdAt;
+  }
+
+  get updatedAt(): string {
+    return this.props.updatedAt;
+  }
+
+  equals(other: unknown): boolean {
+    if (!(other instanceof Entity)) {
+      return false;
+    }
+    if (this.constructor !== other.constructor) {
+      return false;
+    }
+    return this.id.equals(other.id);
+  }
+}

--- a/backend/src/domain/listening-log.ts
+++ b/backend/src/domain/listening-log.ts
@@ -1,4 +1,5 @@
 import type { CreateListeningLogInput, ListeningLog } from "../types";
+import { Entity, type EntityProps } from "./entity";
 import { Rating } from "./value-objects/rating";
 import { ListeningLogId, UserId } from "./value-objects/ids";
 
@@ -10,8 +11,7 @@ export type ListeningLogRepository = {
   remove(id: ListeningLogId): Promise<void>;
 };
 
-type ListeningLogProps = {
-  id: ListeningLogId;
+type ListeningLogProps = EntityProps<ListeningLogId> & {
   userId: UserId | null;
   listenedAt: string;
   composer: string;
@@ -19,12 +19,12 @@ type ListeningLogProps = {
   rating: Rating;
   isFavorite: boolean;
   memo?: string;
-  createdAt: string;
-  updatedAt: string;
 };
 
-export class ListeningLogEntity {
-  private constructor(private readonly props: ListeningLogProps) {}
+export class ListeningLogEntity extends Entity<ListeningLogId, ListeningLogProps> {
+  private constructor(props: ListeningLogProps) {
+    super(props);
+  }
 
   static create(input: CreateListeningLogInput): ListeningLogEntity {
     const now = new Date().toISOString();

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -7,6 +7,7 @@ import type {
   PieceRegion,
   UpdatePieceInput,
 } from "../types";
+import { Entity, type EntityProps } from "./entity";
 import { buildUpdateProps } from "./entity-helpers";
 import { ComposerId, PieceId } from "./value-objects/ids";
 import { PieceTitle } from "./value-objects/piece-title";
@@ -30,8 +31,7 @@ export type PieceRepository = {
   remove(id: PieceId): Promise<void>;
 };
 
-type PieceProps = {
-  id: PieceId;
+type PieceProps = EntityProps<PieceId> & {
   title: PieceTitle;
   composerId: ComposerId;
   videoUrl?: Url;
@@ -39,12 +39,12 @@ type PieceProps = {
   era?: PieceEra;
   formation?: PieceFormation;
   region?: PieceRegion;
-  createdAt: string;
-  updatedAt: string;
 };
 
-export class PieceEntity {
-  private constructor(private readonly props: PieceProps) {}
+export class PieceEntity extends Entity<PieceId, PieceProps> {
+  private constructor(props: PieceProps) {
+    super(props);
+  }
 
   static create(input: CreatePieceInput): PieceEntity {
     const now = new Date().toISOString();
@@ -67,10 +67,6 @@ export class PieceEntity {
       composerId: ComposerId.from(data.composerId),
       videoUrl: data.videoUrl !== undefined ? Url.of(data.videoUrl) : undefined,
     });
-  }
-
-  get updatedAt(): string {
-    return this.props.updatedAt;
   }
 
   mergeUpdate(input: UpdatePieceInput): PieceEntity {

--- a/backend/src/domain/value-objects/ids.ts
+++ b/backend/src/domain/value-objects/ids.ts
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
  *   入力側のスキーマ検証（Zod の `z.uuid()`）と responsibility を分ける。
  * - 空文字・非文字列のみ拒否する。
  */
-abstract class IdValueObject {
+export abstract class IdValueObject {
   public readonly value: string;
 
   protected constructor(value: string) {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1258,7 +1258,30 @@ cdk deploy
 3. バックエンド固有の型・関数はバックエンド側にのみ追加し、フロントエンド側には移植しない
 4. フロントエンド固有の型はフロントエンド側にのみ追加し、バックエンド側には移植しない
 
-### 8.3 その他の値オブジェクト（バックエンドのみ）
+### 8.3 エンティティ基底クラス（バックエンドのみ）
+
+DDD のエンティティが共通で持つべき性質（ID・タイムスタンプの保持、等価性）を `backend/src/domain/entity.ts` の `Entity<TId, TProps>` 抽象クラスに集約する。各エンティティ（`ListeningLogEntity` / `ConcertLogEntity` / `PieceEntity` / `ComposerEntity`）はこれを継承する。
+
+#### 提供する API
+
+- `protected readonly props: TProps`: 派生クラスが内部状態を保持する領域。`TProps` は `EntityProps<TId> = { id: TId; createdAt: string; updatedAt: string }` を拡張した型を指定する
+- `get id(): TId` / `get createdAt(): string` / `get updatedAt(): string`: タイムスタンプ・ID への共通アクセサ
+- `equals(other: unknown): boolean`: DDD の等価性。「同じ具象クラス」かつ「同じ ID」を満たすときに `true`。`Entity` でないオブジェクトや異なる派生クラス（例: `PieceEntity` vs `ComposerEntity`）を渡すと `false`
+
+#### 派生クラスの規約
+
+- `private constructor(props: XxxProps)` を定義し `super(props)` を呼ぶ
+- `static create(input)` / `static reconstruct(data)` ファクトリは従来どおり各エンティティで実装する
+- `props` には `EntityProps<XxxId>` を含めるため `id` / `createdAt` / `updatedAt` の重複定義は不要
+- `toPlain()`・`isOwnedBy()`・`mergeUpdate()` など、エンティティ固有のロジックは派生クラスで実装する（基底クラスでは抽象化しない）
+
+#### `ListeningLogEntity` / `ConcertLogEntity` / `PieceEntity` / `ComposerEntity` への影響
+
+- `get updatedAt()` を個別実装していた `PieceEntity` / `ComposerEntity` の getter は基底クラスから継承される（`saveWithOptimisticLock` の呼び出し元コードはそのまま）
+- 内部 `props` 型は `EntityProps<XxxId> & { ... }` の交差型で表現する
+- 各エンティティの公開 API（`create` / `reconstruct` / `toPlain` / `isOwnedBy` / `mergeUpdate` 等）は変更なし
+
+### 8.4 その他の値オブジェクト（バックエンドのみ）
 
 ID 以外のドメイン概念についても、不変条件を型と実装の両面で保証するために値オブジェクトを導入する。
 


### PR DESCRIPTION
DDD のエンティティが共通で持つ id / createdAt / updatedAt の保持と等価性
（同じ具象クラス + 同じ ID）を Entity<TId, TProps> 抽象クラスに集約し、
ListeningLog / ConcertLog / Piece / Composer の各エンティティが継承する
形に変更する。Piece / Composer に重複していた get updatedAt() を削除し、
SPEC.md にエンティティ基底クラスの章を追加する