### PR TITLE
Add CloudWatch alarms with SNS email notifications

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,6 +163,7 @@ jobs:
           STAGE_NAME: ${{ env.STAGE_NAME }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+          ALERT_EMAIL: ${{ secrets.ALERT_EMAIL }}
 
       # ----------------------------------------
       # CDK デプロイ後にスタック出力を取得

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -5,6 +5,9 @@ import * as lambda from "aws-cdk-lib/aws-lambda";
 import * as lambdaNodejs from "aws-cdk-lib/aws-lambda-nodejs";
 import * as logs from "aws-cdk-lib/aws-logs";
 import * as cloudwatch from "aws-cdk-lib/aws-cloudwatch";
+import * as cloudwatchActions from "aws-cdk-lib/aws-cloudwatch-actions";
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as snsSubscriptions from "aws-cdk-lib/aws-sns-subscriptions";
 import * as apigateway from "aws-cdk-lib/aws-apigateway";
 import type { IResource } from "aws-cdk-lib/aws-apigateway";
 import * as s3 from "aws-cdk-lib/aws-s3";
@@ -780,8 +783,31 @@ function handler(event) {
     });
 
     // -------------------------
-    // CloudWatch アラーム
+    // CloudWatch アラート（SNS 経由でメール通知）
+    // ALERT_EMAIL（カンマ区切り）が設定されていればメール購読を作成。
+    // 未設定でも SNS トピックは作成され、後から AWS コンソール / CLI で購読を追加できる。
     // -------------------------
+    const alertTopic = new sns.Topic(this, "AlertTopic", {
+      topicName: `classical-music-lake-${stageName}-alerts`,
+      displayName: `Classical Music Lake (${stageName}) alerts`,
+    });
+
+    const alertEmails = (process.env.ALERT_EMAIL ?? "")
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s !== "");
+    alertEmails.forEach((email) => {
+      alertTopic.addSubscription(new snsSubscriptions.EmailSubscription(email));
+    });
+
+    const alarmAction = new cloudwatchActions.SnsAction(alertTopic);
+    const createAlarm = (id: string, props: cloudwatch.AlarmProps): cloudwatch.Alarm => {
+      const alarm = new cloudwatch.Alarm(this, id, props);
+      alarm.addAlarmAction(alarmAction);
+      alarm.addOkAction(alarmAction);
+      return alarm;
+    };
+
     const allFunctions = [
       listeningLogsList,
       listeningLogsGet,
@@ -811,12 +837,12 @@ function handler(event) {
       deleteComposer,
     ];
 
-    // Lambda エラー監視：各関数ごとにアラーム作成
+    // Lambda エラー監視：各関数ごとにアラームを作成
     allFunctions.forEach((f, i) => {
-      new cloudwatch.Alarm(this, `LambdaErrorAlarm${i}`, {
-        alarmName: `classical-music-lake-${stageName}-lambda-${f.functionName}-errors`,
-        alarmDescription: `Lambda 関数 ${f.functionName} でエラーが発生しています`,
-        metric: f.metricErrors({ period: cdk.Duration.minutes(5) }),
+      createAlarm(`LambdaErrorAlarm${i}`, {
+        alarmName: `classical-music-lake-${stageName}-lambda-${f.node.id}-errors`,
+        alarmDescription: `Lambda 関数 ${f.node.id} でエラーが発生しています`,
+        metric: f.metricErrors({ period: cdk.Duration.minutes(5), statistic: "Sum" }),
         threshold: 1,
         evaluationPeriods: 1,
         comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
@@ -825,28 +851,61 @@ function handler(event) {
     });
 
     // API Gateway 5xx エラー監視
-    new cloudwatch.Alarm(this, "ApiGateway5xxAlarm", {
+    createAlarm("ApiGateway5xxAlarm", {
       alarmName: `classical-music-lake-${stageName}-api-5xx`,
       alarmDescription: "API Gateway で 5xx エラーが発生しています",
-      metric: api.metricServerError({ period: cdk.Duration.minutes(5) }),
+      metric: api.metricServerError({ period: cdk.Duration.minutes(5), statistic: "Sum" }),
       threshold: 1,
       evaluationPeriods: 1,
       comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
     });
 
-    // DynamoDB スロットリング監視
-    new cloudwatch.Alarm(this, "DynamoThrottleAlarm", {
-      alarmName: `classical-music-lake-${stageName}-dynamo-throttle`,
-      alarmDescription: "DynamoDB でスロットリングが発生しています",
-      metric: listeningLogsTable.metric("ThrottledRequests", {
-        statistic: "Sum",
-        period: cdk.Duration.minutes(5),
-      }),
-      threshold: 1,
-      evaluationPeriods: 1,
-      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+    // API Gateway レイテンシ監視（p99 が 3 秒を超えたら通知）
+    createAlarm("ApiGatewayLatencyAlarm", {
+      alarmName: `classical-music-lake-${stageName}-api-latency-p99`,
+      alarmDescription: "API Gateway のレイテンシ p99 が 3 秒を超えています",
+      metric: api.metricLatency({ period: cdk.Duration.minutes(5), statistic: "p99" }),
+      threshold: 3000,
+      evaluationPeriods: 2,
+      comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_THRESHOLD,
       treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+    });
+
+    // DynamoDB の監視（全テーブルでスロットリング・SystemErrors を監視）
+    const dynamoTables: Array<{ id: string; table: dynamodb.Table }> = [
+      { id: "ListeningLogs", table: listeningLogsTable },
+      { id: "Pieces", table: piecesTable },
+      { id: "ConcertLogs", table: concertLogsTable },
+      { id: "Composers", table: composersTable },
+    ];
+
+    dynamoTables.forEach(({ id, table }) => {
+      createAlarm(`Dynamo${id}ThrottleAlarm`, {
+        alarmName: `classical-music-lake-${stageName}-dynamo-${id}-throttle`,
+        alarmDescription: `DynamoDB ${id} テーブルでスロットリングが発生しています`,
+        metric: table.metric("ThrottledRequests", {
+          statistic: "Sum",
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
+
+      createAlarm(`Dynamo${id}SystemErrorAlarm`, {
+        alarmName: `classical-music-lake-${stageName}-dynamo-${id}-system-errors`,
+        alarmDescription: `DynamoDB ${id} テーブルで SystemErrors が発生しています`,
+        metric: table.metric("SystemErrors", {
+          statistic: "Sum",
+          period: cdk.Duration.minutes(5),
+        }),
+        threshold: 1,
+        evaluationPeriods: 1,
+        comparisonOperator: cloudwatch.ComparisonOperator.GREATER_THAN_OR_EQUAL_TO_THRESHOLD,
+        treatMissingData: cloudwatch.TreatMissingData.NOT_BREACHING,
+      });
     });
 
     // -------------------------
@@ -895,6 +954,11 @@ function handler(event) {
     new cdk.CfnOutput(this, "DistributionId", {
       value: distribution.distributionId,
       description: "CloudFront Distribution ID",
+    });
+
+    new cdk.CfnOutput(this, "AlertTopicArn", {
+      value: alertTopic.topicArn,
+      description: "CloudWatch アラート通知用 SNS トピック ARN",
     });
   }
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -94,19 +94,55 @@ Lambda 関数のログは自動的に CloudWatch Logs に収集される。
 aws logs tail /aws/lambda/ClassicalMusicLake-ListeningLogsCreate --follow
 ```
 
-### 現在の監視設定
+### CloudWatch アラート
 
-現時点では CloudWatch アラートは未設定（フェーズ2で整備予定）。
+CDK で各環境に CloudWatch アラートを定義済み（`cdk/lib/classical-music-lake-stack.ts`）。アラート発火時の通知先は SNS トピック `classical-music-lake-<stage>-alerts` 経由でメール送信される。
 
-エラーは Lambda の `console.error` 出力で CloudWatch Logs に記録される。
+| メトリクス                         | 閾値                           | 通知先             |
+| ---------------------------------- | ------------------------------ | ------------------ |
+| Lambda Errors（関数ごと）          | 1 件以上 / 5 分                | SNS Topic → メール |
+| API Gateway 5XX                    | 1 件以上 / 5 分                | SNS Topic → メール |
+| API Gateway Latency (p99)          | 3,000ms 超 / 5 分 × 2 期間連続 | SNS Topic → メール |
+| DynamoDB ThrottledRequests（各表） | 1 件以上 / 5 分                | SNS Topic → メール |
+| DynamoDB SystemErrors（各表）      | 1 件以上 / 5 分                | SNS Topic → メール |
 
-### 推奨アラート（今後設定予定）
+> 各アラームは ALARM 状態と OK 状態の両方で SNS にイベントを送信する。
 
-| メトリクス            | 閾値        | アクション |
-| --------------------- | ----------- | ---------- |
-| Lambda Errors         | 1件以上/5分 | メール通知 |
-| API Gateway 5XX       | 1件以上/5分 | メール通知 |
-| DynamoDB SystemErrors | 1件以上/5分 | メール通知 |
+#### 通知先メールアドレスの設定
+
+CDK デプロイ時に `ALERT_EMAIL` 環境変数（カンマ区切りで複数指定可）を渡すと、SNS トピックにメール購読が作成される。GitHub Actions では `ALERT_EMAIL` シークレットを参照する。
+
+```bash
+# ローカルからのデプロイ例
+ALERT_EMAIL="ops@example.com,oncall@example.com" \
+STAGE_NAME=stg \
+npx cdk deploy ClassicalMusicLakeStack-stg
+```
+
+未設定でも SNS トピック自体は作成されるため、後から AWS コンソールまたは CLI で購読を追加できる：
+
+```bash
+TOPIC_ARN=$(aws cloudformation describe-stacks \
+  --stack-name ClassicalMusicLakeStack-stg \
+  --query 'Stacks[0].Outputs[?OutputKey==`AlertTopicArn`].OutputValue' \
+  --output text)
+
+aws sns subscribe \
+  --topic-arn "$TOPIC_ARN" \
+  --protocol email \
+  --notification-endpoint ops@example.com
+```
+
+メール購読は購読確認メール内のリンクをクリックして承認するまで `PendingConfirmation` 状態となる。
+
+#### アラート停止（一時的）
+
+メンテナンス等で通知を一時停止したい場合、AWS コンソールから対象アラームのアクションを無効化するか、CLI で実施する：
+
+```bash
+aws cloudwatch disable-alarm-actions \
+  --alarm-names classical-music-lake-stg-api-5xx
+```
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1004,6 +1004,20 @@ GET /composers?limit=50&cursor={opaque}
 - **エラーハンドリング**: 404/403 → index.html（SPA対応）
 - **プロトコル**: HTTPS強制
 
+#### CloudWatch アラーム / SNS
+
+各環境のメインスタック（`ClassicalMusicLakeStack[-<stage>]`）で以下のアラームと通知用 SNS トピックを作成する。詳細手順は `docs/OPERATIONS.md` の「監視・アラート設定」を参照。
+
+- **SNS トピック**: `classical-music-lake-<stage>-alerts`（CDK 出力 `AlertTopicArn`）
+- **メール購読**: CDK デプロイ時の `ALERT_EMAIL`（カンマ区切りで複数指定可）から自動作成。未指定時はサブスクリプションなし
+- **アラーム一覧**:
+  - Lambda Errors（関数ごと、26 個）: 5 分間に 1 件以上のエラーで発火
+  - API Gateway 5XX: 5 分間に 1 件以上の 5xx で発火
+  - API Gateway Latency p99: 5 分間の p99 レイテンシが 3,000ms を超えた状態が 2 期間連続で発火
+  - DynamoDB ThrottledRequests（4 テーブル分）: 5 分間に 1 件以上のスロットリングで発火
+  - DynamoDB SystemErrors（4 テーブル分）: 5 分間に 1 件以上のシステムエラーで発火
+- **通知**: 各アラームは ALARM / OK の両状態で SNS にイベント送信する
+
 ### 5.2 環境変数
 
 #### フロントエンド
@@ -1020,9 +1034,10 @@ GET /composers?limit=50&cursor={opaque}
 
 #### CI/CD（GitHub Secrets）
 
-| シークレット名       | 用途                                          |
-| -------------------- | --------------------------------------------- |
-| `AWS_ROLE_TO_ASSUME` | GitHub OIDC で AssumeRole する IAM ロール ARN |
+| シークレット名       | 用途                                                                                          |
+| -------------------- | --------------------------------------------------------------------------------------------- |
+| `AWS_ROLE_TO_ASSUME` | GitHub OIDC で AssumeRole する IAM ロール ARN                                                 |
+| `ALERT_EMAIL`        | CloudWatch アラート通知先メールアドレス（任意、カンマ区切りで複数指定可。未設定時は購読なし） |
 
 > **シークレット管理方針**: CI/CD 認証は GitHub Actions OIDC + IAM Role Assume によるキーレス認証を採用。長期 AWS アクセスキーを使用しない。Lambda 環境変数に秘密情報は含まれない（テーブル名・CORS オリジンのみ）。将来フェーズで認証機能を追加する場合は AWS Secrets Manager の導入を検討すること。
 >


### PR DESCRIPTION
## 概要

CloudWatch アラート機能を実装し、Lambda エラー、API Gateway エラー/レイテンシ、DynamoDB スロットリング・システムエラーを監視。SNS トピック経由でメール通知を送信できるようにしました。

## 変更の種類

- [x] 新機能
- [x] ドキュメント

## 変更内容

### CDK スタック (`cdk/lib/classical-music-lake-stack.ts`)

- **SNS トピック作成**: `classical-music-lake-<stage>-alerts` トピックを作成
- **メール購読の自動化**: `ALERT_EMAIL` 環境変数（カンマ区切り）から自動的にメール購読を追加
- **アラーム作成ヘルパー関数**: `createAlarm()` を実装し、すべてのアラームに SNS アクション（ALARM/OK 両状態）を自動付与
- **監視対象の拡充**:
  - Lambda Errors（26 関数分）: 5 分間に 1 件以上
  - API Gateway 5XX: 5 分間に 1 件以上
  - **新規** API Gateway Latency p99: 3,000ms 超が 2 期間連続
  - DynamoDB ThrottledRequests（4 テーブル分）: 5 分間に 1 件以上
  - **新規** DynamoDB SystemErrors（4 テーブル分）: 5 分間に 1 件以上
- **CloudFormation 出力**: `AlertTopicArn` を追加し、後から購読を追加する際に参照可能に
- **メトリクス改善**: Lambda/API Gateway メトリクスに `statistic: "Sum"` を明示的に指定

### ドキュメント更新

- **`docs/OPERATIONS.md`**: 
  - 監視設定の詳細説明を追加
  - メール購読の設定手順（ローカル/CLI）を記載
  - アラーム一時停止の方法を記載

- **`docs/SPEC.md`**:
  - CloudWatch アラーム/SNS セクションを追加
  - 環境変数テーブルに `ALERT_EMAIL` を追加

### CI/CD (`github/workflows/deploy.yml`)

- CDK デプロイ時に `ALERT_EMAIL` シークレットを環境変数として渡すよう設定

## テスト

- [x] 既存テストがすべて通ることを確認した
- CDK 構文は TypeScript コンパイルで検証済み
- SNS トピック・アラーム作成ロジックは CDK デプロイ時に実行される

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] `docs/SPEC.md` を更新した

https://claude.ai/code/session_01F1HScf2Ah5bNwPfxqSe2Dk