### PR TITLE
refactor(backend): auth usecase/handler の重複を tryCognito ヘルパーに集約

### DIFF
--- a/backend/src/handlers/auth/login.ts
+++ b/backend/src/handlers/auth/login.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { loginSchema } from "../../utils/schemas";
@@ -9,9 +7,5 @@ const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, loginSchema);
-  const result = await usecase.login(input.email, input.password);
-  if (result.success) {
-    return { statusCode: StatusCodes.OK, body: result.body };
-  }
-  return { statusCode: result.statusCode, body: result.body };
+  return usecase.login(input.email, input.password);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/refresh.ts
+++ b/backend/src/handlers/auth/refresh.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { refreshTokenSchema } from "../../utils/schemas";
@@ -9,9 +7,5 @@ const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, refreshTokenSchema);
-  const result = await usecase.refreshToken(input.refreshToken);
-  if (result.success) {
-    return { statusCode: StatusCodes.OK, body: result.body };
-  }
-  return { statusCode: result.statusCode, body: result.body };
+  return usecase.refreshToken(input.refreshToken);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/register.ts
+++ b/backend/src/handlers/auth/register.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { registerSchema } from "../../utils/schemas";
@@ -9,9 +7,5 @@ const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, registerSchema);
-  const result = await usecase.register(input.email, input.password);
-  if (result.success) {
-    return { statusCode: StatusCodes.CREATED, body: result.body };
-  }
-  return { statusCode: result.statusCode, body: result.body };
+  return usecase.register(input.email, input.password);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/resend-verification-code.ts
+++ b/backend/src/handlers/auth/resend-verification-code.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { resendVerificationCodeSchema } from "../../utils/schemas";
@@ -9,9 +7,5 @@ const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, resendVerificationCodeSchema);
-  const result = await usecase.resendVerificationCode(input.email);
-  if (result.success) {
-    return { statusCode: StatusCodes.OK, body: result.body };
-  }
-  return { statusCode: result.statusCode, body: result.body };
+  return usecase.resendVerificationCode(input.email);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/verify-email.ts
+++ b/backend/src/handlers/auth/verify-email.ts
@@ -1,5 +1,3 @@
-import { StatusCodes } from "http-status-codes";
-
 import { createHandler, jsonBodyParser } from "../../utils/middleware";
 import { parseRequestBody } from "../../utils/parsing";
 import { verifyEmailSchema } from "../../utils/schemas";
@@ -9,9 +7,5 @@ const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
   const input = parseRequestBody(event.body as unknown, verifyEmailSchema);
-  const result = await usecase.verifyEmail(input.email, input.code);
-  if (result.success) {
-    return { statusCode: StatusCodes.OK, body: result.body };
-  }
-  return { statusCode: result.statusCode, body: result.body };
+  return usecase.verifyEmail(input.email, input.code);
 }).use(jsonBodyParser);

--- a/backend/src/usecases/auth-usecase.ts
+++ b/backend/src/usecases/auth-usecase.ts
@@ -1,4 +1,7 @@
+import { StatusCodes } from "http-status-codes";
+
 import { mapCognitoError } from "../domain/auth-error";
+import type { AuthContext } from "../domain/auth-error";
 import type { AuthRepository } from "../domain/auth";
 import { CognitoAuthRepository } from "../repositories/cognito-auth-repository";
 import type { CognitoError } from "../types";
@@ -7,88 +10,76 @@ const providerNameMap: Record<string, string> = {
   google: "Google",
 };
 
+export type AuthResponse = { statusCode: number; body: unknown };
+
+// Cognito 呼び出しのエラーをコンテキスト別にマッピングし、共通レスポンス形式に整える。
+// マッピング対象外のエラーは throw して middleware の 500 ハンドリングへ委ねる。
+const tryCognito = async <T>(
+  context: AuthContext,
+  successCode: number,
+  successBodyFactory: (result: T) => unknown,
+  fn: () => Promise<T>
+): Promise<AuthResponse> => {
+  try {
+    const result = await fn();
+    return { statusCode: successCode, body: successBodyFactory(result) };
+  } catch (error) {
+    const mapped = mapCognitoError((error as CognitoError).name, context);
+    if (mapped !== undefined) {
+      return mapped;
+    }
+    throw error;
+  }
+};
+
 export class AuthUsecase {
   constructor(private readonly repo: AuthRepository) {}
 
-  async login(email: string, password: string) {
-    try {
-      const tokens = await this.repo.initiateAuth(email, password);
-      return { success: true as const, body: tokens };
-    } catch (error) {
-      const mapped = mapCognitoError((error as CognitoError).name, "login");
-      if (mapped !== undefined) {
-        return { success: false as const, ...mapped };
-      }
-      throw error;
-    }
+  login(email: string, password: string): Promise<AuthResponse> {
+    return tryCognito(
+      "login",
+      StatusCodes.OK,
+      (tokens) => tokens,
+      () => this.repo.initiateAuth(email, password)
+    );
   }
 
-  async register(email: string, password: string) {
-    try {
-      await this.repo.signUp(email, password);
-      return {
-        success: true as const,
-        body: {
-          message: "User created successfully. Please check your email to verify your account.",
-        },
-      };
-    } catch (error) {
-      const mapped = mapCognitoError((error as CognitoError).name, "register");
-      if (mapped !== undefined) {
-        return { success: false as const, ...mapped };
-      }
-      throw error;
-    }
+  register(email: string, password: string): Promise<AuthResponse> {
+    return tryCognito(
+      "register",
+      StatusCodes.CREATED,
+      () => ({
+        message: "User created successfully. Please check your email to verify your account.",
+      }),
+      () => this.repo.signUp(email, password)
+    );
   }
 
-  async verifyEmail(email: string, code: string) {
-    try {
-      await this.repo.confirmSignUp(email, code);
-      return { success: true as const, body: { message: "Email confirmed successfully." } };
-    } catch (error) {
-      const mapped = mapCognitoError((error as CognitoError).name, "verify");
-      if (mapped !== undefined) {
-        return { success: false as const, ...mapped };
-      }
-      return {
-        success: false as const,
-        statusCode: 500,
-        body: { message: "Internal server error" },
-      };
-    }
+  verifyEmail(email: string, code: string): Promise<AuthResponse> {
+    return tryCognito(
+      "verify",
+      StatusCodes.OK,
+      () => ({ message: "Email confirmed successfully." }),
+      () => this.repo.confirmSignUp(email, code)
+    );
   }
 
-  async refreshToken(token: string) {
-    try {
-      const tokens = await this.repo.refreshToken(token);
-      return { success: true as const, body: tokens };
-    } catch (error) {
-      const mapped = mapCognitoError((error as CognitoError).name, "refresh");
-      if (mapped !== undefined) {
-        return { success: false as const, ...mapped };
-      }
-      throw error;
-    }
+  refreshToken(token: string): Promise<AuthResponse> {
+    return tryCognito(
+      "refresh",
+      StatusCodes.OK,
+      (tokens) => tokens,
+      () => this.repo.refreshToken(token)
+    );
   }
 
-  async resendVerificationCode(email: string) {
-    try {
-      await this.repo.resendConfirmationCode(email);
-      return {
-        success: true as const,
-        body: { message: "Verification code resent. Please check your email." },
-      };
-    } catch (error) {
-      const mapped = mapCognitoError((error as CognitoError).name, "resend");
-      if (mapped !== undefined) {
-        return { success: false as const, ...mapped };
-      }
-      return {
-        success: false as const,
-        statusCode: 500,
-        body: { message: "Internal server error" },
-      };
-    }
+  resendVerificationCode(email: string): Promise<AuthResponse> {
+    return tryCognito(
+      "resend",
+      StatusCodes.OK,
+      () => ({ message: "Verification code resent. Please check your email." }),
+      () => this.repo.resendConfirmationCode(email)
+    );
   }
 
   async linkExternalProvider(


### PR DESCRIPTION
5 つの auth ハンドラと auth-usecase の 5 つのメソッドで重複していた
try-catch + mapCognitoError パターンを tryCognito ヘルパーに集約し、
usecase の戻り値を { statusCode, body } 形式に統一した。
ハンドラ側は usecase の戻り値をそのまま return するだけになる。

副次的な変更として、verify-email / resend-verification-code で
マッピング外エラー時に直接 500 を返していた挙動を throw に揃えた。
レスポンスは middleware の httpErrorMiddleware が同形式で返すため
外部から見た挙動は変わらず、エラーログ出力が追加される利点がある。

https://claude.ai/code/session_01Y7sLQe44PNfqKAecxRV2Ty