### PR TITLE
feat: プレビューAWS環境をPRごとに自動構築する仕組みを追加

### DIFF
--- a/.github/workflows/preview-cleanup.yml
+++ b/.github/workflows/preview-cleanup.yml
@@ -1,0 +1,87 @@
+name: Preview Cleanup (48h idle)
+
+on:
+  schedule:
+    # 6 時間おきに実行（UTC 0:00, 6:00, 12:00, 18:00）
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      # ----------------------------------------
+      # 48 時間以上更新されていない Preview スタックを検出
+      # CFN の LastUpdatedTime（無い場合は CreationTime）を判定基準にする
+      # ----------------------------------------
+      - name: Find idle preview stacks
+        id: find
+        run: |
+          THRESHOLD=$(($(date -u +%s) - 48 * 3600))
+          aws cloudformation describe-stacks \
+            --query 'Stacks[?starts_with(StackName,`ClassicalMusicLakeStack-pr-`)].[StackName,LastUpdatedTime,CreationTime]' \
+            --output json > /tmp/stacks.json
+
+          jq -r --argjson th "$THRESHOLD" '
+            .[] | . as $s |
+            ($s[1] // $s[2]) as $time |
+            select(($time | fromdateiso8601) < $th) |
+            $s[0]
+          ' /tmp/stacks.json > /tmp/idle.txt
+
+          echo "Found idle stacks:"
+          cat /tmp/idle.txt
+          {
+            echo 'stacks<<EOF'
+            cat /tmp/idle.txt
+            echo 'EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------
+      # アイドルスタックを destroy
+      # ----------------------------------------
+      - name: Destroy idle stacks
+        if: steps.find.outputs.stacks != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          while IFS= read -r STACK; do
+            [ -z "$STACK" ] && continue
+            STAGE="${STACK#ClassicalMusicLakeStack-}"
+            PR_NUM="${STAGE#pr-}"
+            echo "Destroying $STACK (stage: $STAGE)"
+            if ! STAGE_NAME="$STAGE" npx cdk destroy "$STACK" --force --exclusively \
+              --context cognitoUserPoolId=cleanup-dummy \
+              --context cognitoClientId=cleanup-dummy; then
+              echo "::warning::Failed to destroy $STACK"
+              continue
+            fi
+            BODY=$(printf '### Preview environment auto-destroyed (48h idle)\n\nStage `%s` を 48 時間以上更新が無かったため自動で削除しました。再度プレビューが必要な場合は `preview` ラベルを外して付け直してください。' "$STAGE")
+            gh pr comment "$PR_NUM" --body "$BODY" --repo "$REPO" \
+              || echo "::warning::Failed to comment on PR $PR_NUM"
+          done < /tmp/idle.txt
+        working-directory: cdk

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -1,0 +1,185 @@
+name: Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, labeled, synchronize, reopened]
+
+# 同一 PR の連続 push は最新コミットだけデプロイする
+concurrency:
+  group: preview-deploy-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    # preview ラベルが付与されている場合のみ実行
+    # （labeled 以外のイベントでは「現在ラベルが付いている」、labeled では追加されたラベルが preview のときだけ）
+    if: |
+      contains(github.event.pull_request.labels.*.name, 'preview') &&
+      (github.event.action != 'labeled' || github.event.label.name == 'preview')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    env:
+      STAGE_NAME: pr-${{ github.event.pull_request.number }}
+      DEV_STACK_NAME: ClassicalMusicLakeStack-dev
+      STACK_NAME: ClassicalMusicLakeStack-pr-${{ github.event.pull_request.number }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate required secrets
+        env:
+          AWS_ROLE_TO_ASSUME: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+        run: |
+          if [ -z "$AWS_ROLE_TO_ASSUME" ]; then
+            echo "::error::AWS_ROLE_TO_ASSUME secret is not set"
+            exit 1
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      # ----------------------------------------
+      # dev スタックから Cognito User Pool ID / Client ID を取得
+      # Preview スタックは独自の Cognito を作らず dev のものを参照する
+      # ----------------------------------------
+      - name: Fetch dev Cognito IDs
+        id: cognito
+        run: |
+          POOL=$(aws cloudformation describe-stacks --stack-name "$DEV_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`CognitoUserPoolId`].OutputValue' \
+            --output text 2>/dev/null || true)
+          CLIENT=$(aws cloudformation describe-stacks --stack-name "$DEV_STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`CognitoClientId`].OutputValue' \
+            --output text 2>/dev/null || true)
+          if [ -z "$POOL" ] || [ "$POOL" = "None" ] || [ -z "$CLIENT" ] || [ "$CLIENT" = "None" ]; then
+            echo "::error::dev スタック (${DEV_STACK_NAME}) が稼働していないため Cognito ID が取得できませんでした。プレビュー環境のデプロイには dev スタックが必要です。"
+            exit 1
+          fi
+          echo "pool=$POOL" >> "$GITHUB_OUTPUT"
+          echo "client=$CLIENT" >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------
+      # 同時稼働中の Preview スタック数を集計
+      # ----------------------------------------
+      - name: Count active preview stacks
+        id: count
+        run: |
+          COUNT=$(aws cloudformation list-stacks \
+            --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE UPDATE_ROLLBACK_COMPLETE CREATE_IN_PROGRESS UPDATE_IN_PROGRESS \
+            --query 'StackSummaries[?starts_with(StackName,`ClassicalMusicLakeStack-pr-`)].StackName' \
+            --output text | tr '\t' '\n' | grep -v '^$' | wc -l)
+          echo "active=$COUNT" >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------
+      # CDK Deploy
+      # Preview スタックは us-east-1 を使わず ap-northeast-1 のみ
+      # 既存 deploy.yml が bootstrap を担当するため、ここでは bootstrap しない
+      # ----------------------------------------
+      - name: CDK Deploy
+        run: |
+          npx cdk deploy "$STACK_NAME" \
+            --require-approval never \
+            --hotswap-fallback \
+            --exclusively \
+            --context cognitoUserPoolId="${{ steps.cognito.outputs.pool }}" \
+            --context cognitoClientId="${{ steps.cognito.outputs.client }}"
+        working-directory: cdk
+        env:
+          STAGE_NAME: ${{ env.STAGE_NAME }}
+
+      # ----------------------------------------
+      # API URL を取得
+      # ----------------------------------------
+      - name: Get API URL
+        id: out
+        run: |
+          API_URL=$(aws cloudformation describe-stacks --stack-name "$STACK_NAME" \
+            --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' \
+            --output text 2>/dev/null || true)
+          if [ -z "$API_URL" ] || [ "$API_URL" = "None" ]; then
+            echo "::error::ApiUrl not found in stack outputs"
+            exit 1
+          fi
+          echo "api=$API_URL" >> "$GITHUB_OUTPUT"
+
+      # ----------------------------------------
+      # NOTE: 48h cleanup は CFN スタックの LastUpdatedTime を使って判定するため、
+      # ここで明示的にタグを更新する必要はない（CDK で Preview / PreviewStage タグは
+      # 既に付与されている）。
+      # ----------------------------------------
+
+      # ----------------------------------------
+      # PR にコメントを投稿
+      # ----------------------------------------
+      - name: Comment on PR
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8
+        with:
+          script: |
+            const apiUrl = '${{ steps.out.outputs.api }}';
+            const active = parseInt('${{ steps.count.outputs.active }}', 10);
+            const stage = process.env.STAGE_NAME;
+            const warning = active >= 5
+              ? `\n\n> ⚠️ 現在 ${active} 件のプレビュー環境が稼働中です。コストにご注意ください。`
+              : '';
+            const body = [
+              '### 🚀 Preview environment deployed',
+              '',
+              `- **Stage**: \`${stage}\``,
+              `- **API URL**: ${apiUrl}`,
+              '',
+              '#### ログイン手順（dev Cognito を使用）',
+              '1. [dev フロント](https://dev.nocturne-app.com) にアクセスして通常通りログイン',
+              '2. ブラウザの DevTools → Application → Local Storage で `cognito.idToken` をコピー',
+              '',
+              '#### サンプル curl',
+              '```bash',
+              `# 公開 API`,
+              `curl ${apiUrl}pieces`,
+              '',
+              `# 認証必須 API（ID Token を Authorization ヘッダーに指定）`,
+              `curl -H "Authorization: <ID_TOKEN>" ${apiUrl}listening-logs`,
+              '```',
+              '',
+              '> このプレビュー環境のデータは PR クローズ または `preview` ラベル削除で破棄されます。dev 環境のデータには影響しません。',
+              warning
+            ].join('\n');
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body
+            });
+
+      # ----------------------------------------
+      # 失敗時に PR にコメント
+      # ----------------------------------------
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### ❌ Preview deploy failed\n\nWorkflow run: ${runUrl}\n\nログを確認してください。dev スタックが稼働していない場合はプレビュー環境を作成できません。`
+            });

--- a/.github/workflows/preview-destroy.yml
+++ b/.github/workflows/preview-destroy.yml
@@ -1,0 +1,98 @@
+name: Preview Destroy
+
+on:
+  pull_request:
+    types: [unlabeled, closed]
+
+concurrency:
+  group: preview-destroy-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  destroy:
+    # preview ラベルが外された、または preview ラベル付き PR がクローズされたとき
+    if: |
+      (github.event.action == 'unlabeled' && github.event.label.name == 'preview') ||
+      (github.event.action == 'closed' && contains(github.event.pull_request.labels.*.name, 'preview'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      pull-requests: write
+    env:
+      STAGE_NAME: pr-${{ github.event.pull_request.number }}
+      STACK_NAME: ClassicalMusicLakeStack-pr-${{ github.event.pull_request.number }}
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - uses: pnpm/action-setup@903f9c1a6ebcba6cf41d87230be49611ac97822e # v6.0.3
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: ap-northeast-1
+
+      # ----------------------------------------
+      # スタックの存在確認（既に削除済みなら skip）
+      # ----------------------------------------
+      - name: Check if stack exists
+        id: check
+        run: |
+          if aws cloudformation describe-stacks --stack-name "$STACK_NAME" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Stack ${STACK_NAME} does not exist (already deleted), skipping destroy"
+          fi
+
+      # ----------------------------------------
+      # CDK Destroy
+      # context は cdk app の require チェックを通すためのダミー値
+      # （Preview スタックは既に CFN にデプロイ済みのテンプレートが使われるため値は実害なし）
+      # ----------------------------------------
+      - name: CDK Destroy
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          npx cdk destroy "$STACK_NAME" --force --exclusively \
+            --context cognitoUserPoolId=destroy-dummy \
+            --context cognitoClientId=destroy-dummy
+        working-directory: cdk
+        env:
+          STAGE_NAME: ${{ env.STAGE_NAME }}
+
+      - name: Comment on success
+        if: success() && steps.check.outputs.exists == 'true'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### 🗑️ Preview environment destroyed\n\nStage: \`${process.env.STAGE_NAME}\` のリソースを削除しました。`
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v8
+        with:
+          script: |
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `### ⚠️ Preview destroy failed\n\nStage: \`${process.env.STAGE_NAME}\` の削除に失敗しました。手動で確認してください。\n\nWorkflow run: ${runUrl}`
+            });

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -4,14 +4,17 @@ import * as cdk from "aws-cdk-lib";
 import { ClassicalMusicLakeStack, type StageName } from "../lib/classical-music-lake-stack";
 import { DnsStack } from "../lib/dns-stack";
 import { MigrationsStack } from "../lib/migrations-stack";
+import { PreviewBudgetsStack } from "../lib/preview-budgets-stack";
 
 const app = new cdk.App();
 
-const validStages: StageName[] = ["dev", "stg", "prod"];
+const fixedStages: StageName[] = ["dev", "stg", "prod"];
 const rawStageName = process.env.STAGE_NAME ?? "prod";
-if (!validStages.includes(rawStageName as StageName)) {
+const isPreviewName = /^pr-\d+$/.test(rawStageName);
+
+if (!isPreviewName && !fixedStages.includes(rawStageName as StageName)) {
   throw new Error(
-    `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${validStages.join(", ")}`
+    `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${fixedStages.join(", ")}, or pr-{number}`
   );
 }
 
@@ -21,54 +24,100 @@ const stackNameFor = (stage: StageName): string =>
 const migrationsStackNameFor = (stage: StageName): string =>
   stage === "prod" ? "MigrationsStack" : `MigrationsStack-${stage}`;
 
-// -------------------------
-// DNS スタック（us-east-1）
-// CloudFront 用の ACM 証明書は us-east-1 に作成する必要がある
-// 初回デプロイ時は手動で実行: npx cdk deploy NocturneAppDnsStack
-// ※ ACM 証明書の DNS 検証が完了するまで CloudFormation がペンディングになるため、
-//    先にこのスタックだけデプロイし、お名前.comで NS レコードを設定してから
-//    メインスタックをデプロイすること
-// -------------------------
-const dnsStack = new DnsStack(app, "NocturneAppDnsStack", {
-  env: {
-    account: process.env.CDK_DEFAULT_ACCOUNT,
-    region: "us-east-1",
-  },
-  crossRegionReferences: true,
-});
-
-// -------------------------
-// 全ステージの Consumer スタックを常に instantiate する
-// DnsStack の cross-region SSM エクスポートは Consumer スタックごとに
-// /cdk/exports/<ConsumerStackName>/... のパスで作成される。
-// STAGE_NAME で分岐して 1 ステージ分だけ synth すると、DnsStack の
-// テンプレートから他ステージ用の SSM エクスポートが消え、別ステージの
-// deploy 時に "Parameters cannot be found" で失敗する。
-// 3 環境分を常に synth し、CI/CD では `cdk deploy <stackName> --exclusively`
-// で対象のみデプロイする運用とする。
-// -------------------------
-for (const stage of validStages) {
+if (isPreviewName) {
+  // -------------------------
+  // Preview スタック（pr-{番号}）
+  // フロントエンドリソースと Cognito User Pool を持たないため
+  // DnsStack に依存せず単独で synth/deploy できる
+  // -------------------------
+  const previewStageName = rawStageName as `pr-${number}`;
+  const cognitoUserPoolId = app.node.tryGetContext("cognitoUserPoolId") as string | undefined;
+  const cognitoClientId = app.node.tryGetContext("cognitoClientId") as string | undefined;
+  if (!cognitoUserPoolId || !cognitoClientId) {
+    throw new Error(
+      "Preview stack requires --context cognitoUserPoolId=... --context cognitoClientId=..."
+    );
+  }
   const env = {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
   };
   // prettier-ignore
-  new ClassicalMusicLakeStack(app, stackNameFor(stage), { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
-    stageName: stage,
-    hostedZone: dnsStack.hostedZone,
-    certificate: dnsStack.certificate,
+  new ClassicalMusicLakeStack(app, stackNameFor(previewStageName), { // NOSONAR
+    stageName: previewStageName,
+    isPreview: true,
+    existingCognitoUserPoolId: cognitoUserPoolId,
+    existingCognitoClientId: cognitoClientId,
     env,
+    crossRegionReferences: false,
+    terminationProtection: false,
+  });
+} else {
+  // -------------------------
+  // DNS スタック（us-east-1）
+  // CloudFront 用の ACM 証明書は us-east-1 に作成する必要がある
+  // 初回デプロイ時は手動で実行: npx cdk deploy NocturneAppDnsStack
+  // ※ ACM 証明書の DNS 検証が完了するまで CloudFormation がペンディングになるため、
+  //    先にこのスタックだけデプロイし、お名前.comで NS レコードを設定してから
+  //    メインスタックをデプロイすること
+  // -------------------------
+  const dnsStack = new DnsStack(app, "NocturneAppDnsStack", {
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: "us-east-1",
+    },
     crossRegionReferences: true,
-    terminationProtection: stage === "prod",
   });
 
-  // 移行 Lambda は専用スタックに分離。本番スタックのデプロイ後に
-  // `cdk deploy MigrationsStack[-<stage>]` で個別にデプロイする運用。
-  // 移行完了後はスタックごと破棄できる。
+  // -------------------------
+  // 全ステージの Consumer スタックを常に instantiate する
+  // DnsStack の cross-region SSM エクスポートは Consumer スタックごとに
+  // /cdk/exports/<ConsumerStackName>/... のパスで作成される。
+  // STAGE_NAME で分岐して 1 ステージ分だけ synth すると、DnsStack の
+  // テンプレートから他ステージ用の SSM エクスポートが消え、別ステージの
+  // deploy 時に "Parameters cannot be found" で失敗する。
+  // 3 環境分を常に synth し、CI/CD では `cdk deploy <stackName> --exclusively`
+  // で対象のみデプロイする運用とする。
+  // -------------------------
+  for (const stage of fixedStages) {
+    const env = {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      region: process.env.CDK_DEFAULT_REGION ?? "ap-northeast-1",
+    };
+    // prettier-ignore
+    new ClassicalMusicLakeStack(app, stackNameFor(stage), { // NOSONAR: CDK はスタックのインスタンス化時に app へ自動登録されるため戻り値は不要
+      stageName: stage,
+      hostedZone: dnsStack.hostedZone,
+      certificate: dnsStack.certificate,
+      env,
+      crossRegionReferences: true,
+      terminationProtection: stage === "prod",
+    });
+
+    // 移行 Lambda は専用スタックに分離。本番スタックのデプロイ後に
+    // `cdk deploy MigrationsStack[-<stage>]` で個別にデプロイする運用。
+    // 移行完了後はスタックごと破棄できる。
+    // prettier-ignore
+    new MigrationsStack(app, migrationsStackNameFor(stage), { // NOSONAR
+      stageName: stage,
+      env,
+      terminationProtection: stage === "prod",
+    });
+  }
+
+  // -------------------------
+  // Preview Budgets スタック（PR プレビュー環境のコスト監視）
+  // 通常のデプロイサイクルとは独立して 1 回だけ手動デプロイする:
+  //   npx cdk deploy PreviewBudgetsStack
+  // -------------------------
   // prettier-ignore
-  new MigrationsStack(app, migrationsStackNameFor(stage), { // NOSONAR
-    stageName: stage,
-    env,
-    terminationProtection: stage === "prod",
+  new PreviewBudgetsStack(app, "PreviewBudgetsStack", { // NOSONAR
+    env: {
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+      // Budgets はグローバルサービスのためリージョンは us-east-1 を使う慣例
+      region: "us-east-1",
+    },
+    notifyEmail: "rt.konabe@gmail.com",
+    monthlyLimitUsd: 20,
   });
 }

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -17,23 +17,46 @@ import type * as acm from "aws-cdk-lib/aws-certificatemanager";
 import type { Construct } from "constructs";
 import * as path from "node:path";
 
-export type StageName = "dev" | "stg" | "prod";
+export type StageName = "dev" | "stg" | "prod" | `pr-${number}`;
 
 export interface ClassicalMusicLakeStackProps extends cdk.StackProps {
   stageName: StageName;
-  hostedZone: route53.IHostedZone;
-  certificate: acm.ICertificate;
+  // 通常デプロイ（dev/stg/prod）では必須、Preview デプロイ（pr-*）では未指定
+  hostedZone?: route53.IHostedZone;
+  certificate?: acm.ICertificate;
+  // Preview デプロイ用フラグ。true の場合、フロントエンド関連リソース（S3/CloudFront/
+  // Route53）と Cognito User Pool の新規作成をスキップし、dev 環境の Cognito を参照する
+  isPreview?: boolean;
+  // Preview デプロイで参照する既存 Cognito User Pool ID（dev 環境のものを想定）
+  existingCognitoUserPoolId?: string;
+  // Preview デプロイで参照する既存 Cognito User Pool Client ID
+  existingCognitoClientId?: string;
 }
 
 export class ClassicalMusicLakeStack extends cdk.Stack {
-  private readonly corsAllowOrigin: string = "";
-  private readonly corsAllowOrigins: string[] = [];
+  private corsAllowOrigin: string = "";
+  private corsAllowOrigins: string[] = [];
 
   constructor(scope: Construct, id: string, props: ClassicalMusicLakeStackProps) {
     super(scope, id, props);
 
     const { stageName, hostedZone, certificate } = props;
+    const isPreview = props.isPreview === true;
     const isProd = stageName === "prod";
+
+    // Preview スタックは Budgets フィルタ用にタグを付与
+    if (isPreview) {
+      cdk.Tags.of(this).add("Preview", "true");
+      cdk.Tags.of(this).add("PreviewStage", stageName);
+      if (!props.existingCognitoUserPoolId || !props.existingCognitoClientId) {
+        throw new Error(
+          "Preview stack requires existingCognitoUserPoolId and existingCognitoClientId"
+        );
+      }
+    } else if (!hostedZone || !certificate) {
+      throw new Error("Non-preview stack requires hostedZone and certificate");
+    }
+
     const domainName = isProd ? "nocturne-app.com" : `${stageName}.nocturne-app.com`;
 
     // -------------------------
@@ -47,8 +70,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       tableName,
       partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      // prod は RETAIN、stg/dev は DESTROY（スタック削除時にテーブルも削除）
-      removalPolicy: this.removalPolicy(isProd),
+      // prod は RETAIN、stg/dev/preview は DESTROY（スタック削除時にテーブルも削除）
+      removalPolicy: this.removalPolicy(isProd && !isPreview),
       // ポイントインタイムリカバリ（PITR）有効化（35日間のバックアップ自動保持）
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
@@ -77,7 +100,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       tableName: piecesTableName,
       partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      // 通常は RETAIN だが Preview ではスタック削除時に消す
+      removalPolicy: isPreview ? cdk.RemovalPolicy.DESTROY : cdk.RemovalPolicy.RETAIN,
     });
 
     // -------------------------
@@ -91,229 +115,256 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       tableName: composersTableName,
       partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      // 通常は RETAIN だが Preview ではスタック削除時に消す
+      removalPolicy: isPreview ? cdk.RemovalPolicy.DESTROY : cdk.RemovalPolicy.RETAIN,
     });
 
     // -------------------------
     // AWS Cognito User Pool
+    // Preview デプロイでは新規作成せず、dev 環境の User Pool を import して使う
     // -------------------------
-    const userPoolName = isProd ? "classical-music-lake" : `classical-music-lake-${stageName}`;
+    let userPool: cognito.IUserPool;
+    if (isPreview) {
+      userPool = cognito.UserPool.fromUserPoolId(
+        this,
+        "ImportedUserPool",
+        props.existingCognitoUserPoolId!
+      );
+    } else {
+      const userPoolName = isProd ? "classical-music-lake" : `classical-music-lake-${stageName}`;
 
-    const userPool = new cognito.UserPool(this, "CognitoUserPool", {
-      userPoolName,
-      removalPolicy: this.removalPolicy(isProd),
-      selfSignUpEnabled: true,
-      signInAliases: { email: true },
-      passwordPolicy: {
-        minLength: 8,
-        requireLowercase: true,
-        requireDigits: true,
-        requireSymbols: false,
-        requireUppercase: true,
-      },
-      accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
-      userVerification: {
-        emailStyle: cognito.VerificationEmailStyle.CODE,
-      },
-      standardAttributes: {
-        email: {
-          required: true,
-          mutable: true,
+      const newUserPool = new cognito.UserPool(this, "CognitoUserPool", {
+        userPoolName,
+        removalPolicy: this.removalPolicy(isProd),
+        selfSignUpEnabled: true,
+        signInAliases: { email: true },
+        passwordPolicy: {
+          minLength: 8,
+          requireLowercase: true,
+          requireDigits: true,
+          requireSymbols: false,
+          requireUppercase: true,
         },
-      },
-      signInCaseSensitive: false,
-    });
-
-    new cognito.CfnUserPoolGroup(this, "AdminGroup", {
-      userPoolId: userPool.userPoolId,
-      groupName: "admin",
-      description: "管理者グループ",
-    });
-
-    // -------------------------
-    // S3 + CloudFront (SPA ホスティング)
-    // App Client の callback URL に CloudFront ドメインが必要なため先に作成する
-    // -------------------------
-    const spaBucket = new s3.Bucket(this, "SpaBucket", {
-      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
-      enforceSSL: true,
-      // prod は RETAIN（本番アセットの誤削除防止）、stg/dev は DESTROY
-      removalPolicy: this.removalPolicy(isProd),
-      autoDeleteObjects: !isProd,
-      // prod は S3 バージョニング有効（静的ファイルのロールバック用）
-      versioned: isProd,
-    });
-
-    // セキュリティヘッダポリシー（SPA 用: X-Frame-Options: DENY）
-    const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
-      this,
-      "SecurityHeadersPolicy",
-      {
-        securityHeadersBehavior: {
-          strictTransportSecurity: {
-            accessControlMaxAge: cdk.Duration.days(365),
-            includeSubdomains: true,
-            override: true,
-          },
-          contentTypeOptions: { override: true },
-          frameOptions: {
-            frameOption: cloudfront.HeadersFrameOption.DENY,
-            override: true,
-          },
-          xssProtection: { protection: true, modeBlock: true, override: true },
-          referrerPolicy: {
-            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            override: true,
+        accountRecovery: cognito.AccountRecovery.EMAIL_ONLY,
+        userVerification: {
+          emailStyle: cognito.VerificationEmailStyle.CODE,
+        },
+        standardAttributes: {
+          email: {
+            required: true,
+            mutable: true,
           },
         },
-      }
-    );
+        signInCaseSensitive: false,
+      });
 
-    // Storybook 用セキュリティヘッダポリシー（X-Frame-Options を除外: iframe プレビューに必要）
-    const storybookHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
-      this,
-      "StorybookHeadersPolicy",
-      {
-        securityHeadersBehavior: {
-          strictTransportSecurity: {
-            accessControlMaxAge: cdk.Duration.days(365),
-            includeSubdomains: true,
-            override: true,
-          },
-          contentTypeOptions: { override: true },
-          contentSecurityPolicy: {
-            contentSecurityPolicy: "frame-ancestors 'self';",
-            override: true,
-          },
-          xssProtection: { protection: true, modeBlock: true, override: true },
-          referrerPolicy: {
-            referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
-            override: true,
-          },
-        },
-      }
-    );
+      new cognito.CfnUserPoolGroup(this, "AdminGroup", {
+        userPoolId: newUserPool.userPoolId,
+        groupName: "admin",
+        description: "管理者グループ",
+      });
 
-    const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
-      domainNames: [domainName],
-      certificate,
-      defaultBehavior: {
-        origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
-        responseHeadersPolicy: securityHeadersPolicy,
-      },
-      // index.html はキャッシュしない（SPA デプロイ後に即反映させるため）
-      additionalBehaviors: {
-        "/index.html": {
+      userPool = newUserPool;
+    }
+
+    // -------------------------
+    // フロントエンド関連リソース（S3 + CloudFront + Cognito クライアント + Hosted UI + Google IdP + Route53）
+    // Preview デプロイでは作成しない
+    // -------------------------
+    let spaBucket: s3.Bucket | undefined;
+    let distribution: cloudfront.Distribution | undefined;
+    let storybookHeadersPolicy: cloudfront.ResponseHeadersPolicy | undefined;
+    let storybookRootRewrite: cloudfront.Function | undefined;
+    let appClientId: string;
+    let cognitoDomainPrefix: string | undefined;
+
+    if (isPreview) {
+      // Preview ではフロント無し、dev User Pool の Client ID を直接使う
+      appClientId = props.existingCognitoClientId!;
+      this.corsAllowOrigin = "*";
+      this.corsAllowOrigins = ["*"];
+    } else {
+      spaBucket = new s3.Bucket(this, "SpaBucket", {
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        enforceSSL: true,
+        // prod は RETAIN（本番アセットの誤削除防止）、stg/dev は DESTROY
+        removalPolicy: this.removalPolicy(isProd),
+        autoDeleteObjects: !isProd,
+        // prod は S3 バージョニング有効（静的ファイルのロールバック用）
+        versioned: isProd,
+      });
+
+      // セキュリティヘッダポリシー（SPA 用: X-Frame-Options: DENY）
+      const securityHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+        this,
+        "SecurityHeadersPolicy",
+        {
+          securityHeadersBehavior: {
+            strictTransportSecurity: {
+              accessControlMaxAge: cdk.Duration.days(365),
+              includeSubdomains: true,
+              override: true,
+            },
+            contentTypeOptions: { override: true },
+            frameOptions: {
+              frameOption: cloudfront.HeadersFrameOption.DENY,
+              override: true,
+            },
+            xssProtection: { protection: true, modeBlock: true, override: true },
+            referrerPolicy: {
+              referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+              override: true,
+            },
+          },
+        }
+      );
+
+      // Storybook 用セキュリティヘッダポリシー（X-Frame-Options を除外: iframe プレビューに必要）
+      storybookHeadersPolicy = new cloudfront.ResponseHeadersPolicy(
+        this,
+        "StorybookHeadersPolicy",
+        {
+          securityHeadersBehavior: {
+            strictTransportSecurity: {
+              accessControlMaxAge: cdk.Duration.days(365),
+              includeSubdomains: true,
+              override: true,
+            },
+            contentTypeOptions: { override: true },
+            contentSecurityPolicy: {
+              contentSecurityPolicy: "frame-ancestors 'self';",
+              override: true,
+            },
+            xssProtection: { protection: true, modeBlock: true, override: true },
+            referrerPolicy: {
+              referrerPolicy: cloudfront.HeadersReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN,
+              override: true,
+            },
+          },
+        }
+      );
+
+      distribution = new cloudfront.Distribution(this, "SpaDistribution", {
+        domainNames: [domainName],
+        certificate: certificate!,
+        defaultBehavior: {
           origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
           responseHeadersPolicy: securityHeadersPolicy,
         },
-      },
-      defaultRootObject: "index.html",
-      errorResponses: [
-        // SPA のクライアントサイドルーティング対応
-        // ttl を 0 にして index.html の古いキャッシュが返らないようにする
-        {
-          httpStatus: 403,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.seconds(0),
+        // index.html はキャッシュしない（SPA デプロイ後に即反映させるため）
+        additionalBehaviors: {
+          "/index.html": {
+            origin: origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
+            viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+            cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+            responseHeadersPolicy: securityHeadersPolicy,
+          },
         },
-        {
-          httpStatus: 404,
-          responseHttpStatus: 200,
-          responsePagePath: "/index.html",
-          ttl: cdk.Duration.seconds(0),
-        },
-      ],
-    });
-
-    // カスタムドメインを CORS オリジンとして Lambda 環境変数に設定
-    // 移行期間中は CloudFront デフォルトドメインも許可（DNS 切り替え完了後に削除可能）
-    this.corsAllowOrigin = `https://${domainName}`;
-    const cloudFrontOrigin = `https://${distribution.distributionDomainName}`;
-    // dev 環境のみローカル開発用に localhost を許可（NOTE: 3000だとなぜか起動できない）
-    this.corsAllowOrigins =
-      stageName === "dev"
-        ? [this.corsAllowOrigin, cloudFrontOrigin, "http://localhost:3010"]
-        : [this.corsAllowOrigin, cloudFrontOrigin];
-
-    // -------------------------
-    // Google Identity Provider
-    // GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET 環境変数が設定されている場合のみ作成
-    // -------------------------
-    const googleClientId = process.env.GOOGLE_CLIENT_ID ?? "";
-    const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET ?? "";
-    const hasGoogleCredentials = googleClientId !== "" && googleClientSecret !== "";
-
-    let googleIdP: cognito.UserPoolIdentityProviderGoogle | undefined;
-    if (hasGoogleCredentials) {
-      googleIdP = new cognito.UserPoolIdentityProviderGoogle(this, "GoogleProvider", {
-        userPool,
-        clientId: googleClientId,
-        clientSecretValue: cdk.SecretValue.unsafePlainText(googleClientSecret),
-        scopes: ["email", "profile", "openid"],
-        attributeMapping: {
-          email: cognito.ProviderAttribute.GOOGLE_EMAIL,
-          givenName: cognito.ProviderAttribute.GOOGLE_GIVEN_NAME,
-          familyName: cognito.ProviderAttribute.GOOGLE_FAMILY_NAME,
-        },
+        defaultRootObject: "index.html",
+        errorResponses: [
+          // SPA のクライアントサイドルーティング対応
+          // ttl を 0 にして index.html の古いキャッシュが返らないようにする
+          {
+            httpStatus: 403,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+            ttl: cdk.Duration.seconds(0),
+          },
+          {
+            httpStatus: 404,
+            responseHttpStatus: 200,
+            responsePagePath: "/index.html",
+            ttl: cdk.Duration.seconds(0),
+          },
+        ],
       });
-    }
 
-    // App Client: フロントエンド用
-    // 移行期間中は CloudFront デフォルトドメインも callback URL に含める
-    const callbackUrls = [
-      `https://${domainName}/auth/callback`,
-      `https://${distribution.distributionDomainName}/auth/callback`,
-    ];
-    const logoutUrls = [
-      `https://${domainName}/auth/login`,
-      `https://${distribution.distributionDomainName}/auth/login`,
-    ];
-    if (stageName === "dev") {
-      callbackUrls.push("http://localhost:3010/auth/callback");
-      logoutUrls.push("http://localhost:3010/auth/login");
-    }
+      // カスタムドメインを CORS オリジンとして Lambda 環境変数に設定
+      // 移行期間中は CloudFront デフォルトドメインも許可（DNS 切り替え完了後に削除可能）
+      this.corsAllowOrigin = `https://${domainName}`;
+      const cloudFrontOrigin = `https://${distribution.distributionDomainName}`;
+      // dev 環境のみローカル開発用に localhost を許可（NOTE: 3000だとなぜか起動できない）
+      this.corsAllowOrigins =
+        stageName === "dev"
+          ? [this.corsAllowOrigin, cloudFrontOrigin, "http://localhost:3010"]
+          : [this.corsAllowOrigin, cloudFrontOrigin];
 
-    const appClient = userPool.addClient("FrontendClient", {
-      authFlows: {
-        userPassword: true,
-        custom: true,
-      },
-      supportedIdentityProviders: [
-        cognito.UserPoolClientIdentityProvider.COGNITO,
-        ...(hasGoogleCredentials ? [cognito.UserPoolClientIdentityProvider.GOOGLE] : []),
-      ],
-      oAuth: {
-        flows: {
-          authorizationCodeGrant: true,
+      // -------------------------
+      // Google Identity Provider
+      // GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET 環境変数が設定されている場合のみ作成
+      // -------------------------
+      const googleClientId = process.env.GOOGLE_CLIENT_ID ?? "";
+      const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET ?? "";
+      const hasGoogleCredentials = googleClientId !== "" && googleClientSecret !== "";
+
+      let googleIdP: cognito.UserPoolIdentityProviderGoogle | undefined;
+      if (hasGoogleCredentials) {
+        googleIdP = new cognito.UserPoolIdentityProviderGoogle(this, "GoogleProvider", {
+          userPool,
+          clientId: googleClientId,
+          clientSecretValue: cdk.SecretValue.unsafePlainText(googleClientSecret),
+          scopes: ["email", "profile", "openid"],
+          attributeMapping: {
+            email: cognito.ProviderAttribute.GOOGLE_EMAIL,
+            givenName: cognito.ProviderAttribute.GOOGLE_GIVEN_NAME,
+            familyName: cognito.ProviderAttribute.GOOGLE_FAMILY_NAME,
+          },
+        });
+      }
+
+      // App Client: フロントエンド用
+      // 移行期間中は CloudFront デフォルトドメインも callback URL に含める
+      const callbackUrls = [
+        `https://${domainName}/auth/callback`,
+        `https://${distribution.distributionDomainName}/auth/callback`,
+      ];
+      const logoutUrls = [
+        `https://${domainName}/auth/login`,
+        `https://${distribution.distributionDomainName}/auth/login`,
+      ];
+      if (stageName === "dev") {
+        callbackUrls.push("http://localhost:3010/auth/callback");
+        logoutUrls.push("http://localhost:3010/auth/login");
+      }
+
+      const appClient = userPool.addClient("FrontendClient", {
+        authFlows: {
+          userPassword: true,
+          custom: true,
         },
-        scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
-        callbackUrls,
-        logoutUrls,
-      },
-      accessTokenValidity: cdk.Duration.minutes(60),
-      idTokenValidity: cdk.Duration.minutes(60),
-      refreshTokenValidity: cdk.Duration.days(30),
-      preventUserExistenceErrors: true,
-    });
+        supportedIdentityProviders: [
+          cognito.UserPoolClientIdentityProvider.COGNITO,
+          ...(hasGoogleCredentials ? [cognito.UserPoolClientIdentityProvider.GOOGLE] : []),
+        ],
+        oAuth: {
+          flows: {
+            authorizationCodeGrant: true,
+          },
+          scopes: [cognito.OAuthScope.EMAIL, cognito.OAuthScope.OPENID, cognito.OAuthScope.PROFILE],
+          callbackUrls,
+          logoutUrls,
+        },
+        accessTokenValidity: cdk.Duration.minutes(60),
+        idTokenValidity: cdk.Duration.minutes(60),
+        refreshTokenValidity: cdk.Duration.days(30),
+        preventUserExistenceErrors: true,
+      });
 
-    // Google IdP が存在する場合、App Client との依存関係を明示
-    if (googleIdP !== undefined) {
-      appClient.node.addDependency(googleIdP);
+      // Google IdP が存在する場合、App Client との依存関係を明示
+      if (googleIdP !== undefined) {
+        appClient.node.addDependency(googleIdP);
+      }
+
+      // Cognito Hosted UI ドメイン（Google OAuth のリダイレクト先として必要）
+      cognitoDomainPrefix = isProd ? "classical-music-lake" : `classical-music-lake-${stageName}`;
+      userPool.addDomain("CognitoDomain", {
+        cognitoDomain: { domainPrefix: cognitoDomainPrefix },
+      });
+
+      appClientId = appClient.userPoolClientId;
     }
-
-    // Cognito Hosted UI ドメイン（Google OAuth のリダイレクト先として必要）
-    const cognitoDomainPrefix = isProd
-      ? "classical-music-lake"
-      : `classical-music-lake-${stageName}`;
-    userPool.addDomain("CognitoDomain", {
-      cognitoDomain: { domainPrefix: cognitoDomainPrefix },
-    });
 
     // NOTE: COGNITO_USER_POOL_ID / COGNITO_CLIENT_ID は commonEnv に含めない。
     // authPreSignUp を addTrigger すると userPool → authPreSignUp の依存が生まれ、
@@ -331,7 +382,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       tableName: concertLogsTableName,
       partitionKey: { name: "id", type: dynamodb.AttributeType.STRING },
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
-      removalPolicy: this.removalPolicy(isProd),
+      removalPolicy: this.removalPolicy(isProd && !isPreview),
       pointInTimeRecoverySpecification: { pointInTimeRecoveryEnabled: true },
     });
 
@@ -372,7 +423,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       // CloudWatch Logs 保持期間を 3 ヶ月に設定（カスタムリソース不要の explicit LogGroup）
       const logGroup = new logs.LogGroup(this, `${id}LogGroup`, {
         retention: logs.RetentionDays.THREE_MONTHS,
-        removalPolicy: this.removalPolicy(isProd),
+        removalPolicy: this.removalPolicy(isProd && !isPreview),
       });
       return new lambdaNodejs.NodejsFunction(this, id, {
         ...commonFnProps,
@@ -402,7 +453,6 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const authVerifyEmail = fn("AuthVerifyEmail", "handlers/auth/verify-email.ts");
     const authResendCode = fn("AuthResendCode", "handlers/auth/resend-verification-code.ts");
     const authRefresh = fn("AuthRefresh", "handlers/auth/refresh.ts");
-    const authPreSignUp = fn("AuthPreSignUp", "handlers/auth/pre-signup.ts");
 
     const concertLogsList = fn("ConcertLogsList", "handlers/concert-logs/list.ts");
     const concertLogsCreate = fn("ConcertLogsCreate", "handlers/concert-logs/create.ts");
@@ -416,9 +466,30 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const updateComposer = fn("UpdateComposer", "handlers/composers/update.ts");
     const deleteComposer = fn("DeleteComposer", "handlers/composers/delete.ts");
 
-    // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
-    // いる場合に自動でアカウントリンクを行う
-    userPool.addTrigger(cognito.UserPoolOperation.PRE_SIGN_UP, authPreSignUp);
+    // PreSignUp Lambda + トリガー
+    // Preview デプロイでは dev の User Pool を import して使うため、トリガーを上書き
+    // できないので Lambda 自体を作らない。dev 側で既に PreSignUp トリガーが発動するので
+    // Google アカウント連携の挙動は維持される。
+    let authPreSignUp: lambdaNodejs.NodejsFunction | undefined;
+    if (!isPreview) {
+      authPreSignUp = fn("AuthPreSignUp", "handlers/auth/pre-signup.ts");
+      // PreSignUp トリガー: Google 等の外部プロバイダーで既存メールアドレスのユーザーが
+      // いる場合に自動でアカウントリンクを行う
+      (userPool as cognito.UserPool).addTrigger(
+        cognito.UserPoolOperation.PRE_SIGN_UP,
+        authPreSignUp
+      );
+
+      // auth/pre-signup: ListUsers + AdminLinkProviderForUser を実行
+      // NOTE: userPool.userPoolArn を使うと CognitoUserPool ↔ AuthPreSignUp の循環依存が
+      // 発生するため、リソースを "*" にして依存関係を断ち切る
+      const cognitoPreSignUpPolicy = new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ["cognito-idp:ListUsers", "cognito-idp:AdminLinkProviderForUser"],
+        resources: ["*"],
+      });
+      authPreSignUp.addToRolePolicy(cognitoPreSignUpPolicy);
+    }
 
     // -------------------------
     // Cognito 権限付与
@@ -462,16 +533,6 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       resources: [userPool.userPoolArn],
     });
     authRefresh.addToRolePolicy(cognitoRefreshPolicy);
-
-    // auth/pre-signup: ListUsers + AdminLinkProviderForUser を実行
-    // NOTE: userPool.userPoolArn を使うと CognitoUserPool ↔ AuthPreSignUp の循環依存が
-    // 発生するため、リソースを "*" にして依存関係を断ち切る
-    const cognitoPreSignUpPolicy = new iam.PolicyStatement({
-      effect: iam.Effect.ALLOW,
-      actions: ["cognito-idp:ListUsers", "cognito-idp:AdminLinkProviderForUser"],
-      resources: ["*"],
-    });
-    authPreSignUp.addToRolePolicy(cognitoPreSignUpPolicy);
 
     // -------------------------
     // DynamoDB 権限付与
@@ -518,7 +579,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // logGroupName を指定しない（CDK 自動生成名）ことで既存リソースとの名前衝突を回避
     const apiAccessLogGroup = new logs.LogGroup(this, "ApiAccessLogs", {
       retention: logs.RetentionDays.THREE_MONTHS,
-      removalPolicy: this.removalPolicy(isProd),
+      removalPolicy: this.removalPolicy(isProd && !isPreview),
     });
 
     const api = new apigateway.RestApi(this, "Api", {
@@ -665,7 +726,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     // （authPreSignUp は event.userPoolId から取得するため不要かつ循環依存を避けるため除外）
     authExcludedFunctions.forEach((fn) => {
       fn.addEnvironment("COGNITO_USER_POOL_ID", userPool.userPoolId);
-      fn.addEnvironment("COGNITO_CLIENT_ID", appClient.userPoolClientId);
+      fn.addEnvironment("COGNITO_CLIENT_ID", appClientId);
     });
 
     // API Gateway の CORS オリジンも CloudFront URL に限定
@@ -734,11 +795,13 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
 
     // -------------------------
     // Storybook ホスティング（/storybook/ パス）
+    // Preview デプロイでは S3 / CloudFront を作らないためスキップ
     // -------------------------
-    // /storybook/ へのアクセスを /storybook/index.html にリライトする CloudFront Function
-    const storybookRootRewrite = new cloudfront.Function(this, "StorybookRootRewrite", {
-      code: cloudfront.FunctionCode.fromInline(
-        `
+    if (!isPreview && distribution && spaBucket && storybookHeadersPolicy) {
+      // /storybook/ へのアクセスを /storybook/index.html にリライトする CloudFront Function
+      storybookRootRewrite = new cloudfront.Function(this, "StorybookRootRewrite", {
+        code: cloudfront.FunctionCode.fromInline(
+          `
 function handler(event) {
   var request = event.request;
   if (request.uri === '/storybook/' || request.uri === '/storybook') {
@@ -747,37 +810,41 @@ function handler(event) {
   return request;
 }
       `.trim()
-      ),
-      runtime: cloudfront.FunctionRuntime.JS_2_0,
-    });
+        ),
+        runtime: cloudfront.FunctionRuntime.JS_2_0,
+      });
 
-    // /storybook/* 用の CloudFront behavior を追加
-    distribution.addBehavior(
-      "/storybook/*",
-      origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
-      {
-        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
-        cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
-        responseHeadersPolicy: storybookHeadersPolicy,
-        functionAssociations: [
-          {
-            function: storybookRootRewrite,
-            eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
-          },
-        ],
-      }
-    );
+      // /storybook/* 用の CloudFront behavior を追加
+      distribution.addBehavior(
+        "/storybook/*",
+        origins.S3BucketOrigin.withOriginAccessControl(spaBucket),
+        {
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_DISABLED,
+          responseHeadersPolicy: storybookHeadersPolicy,
+          functionAssociations: [
+            {
+              function: storybookRootRewrite,
+              eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
+            },
+          ],
+        }
+      );
+    }
 
     // NOTE: Storybook ファイルの S3 アップロードも GitHub Actions ワークフローで実行する。
 
     // -------------------------
     // Route53 A レコード（カスタムドメイン → CloudFront）
+    // Preview デプロイでは作らない
     // -------------------------
-    new route53.ARecord(this, "CloudFrontAliasRecord", {
-      zone: hostedZone,
-      recordName: domainName,
-      target: route53.RecordTarget.fromAlias(new route53Targets.CloudFrontTarget(distribution)),
-    });
+    if (!isPreview && hostedZone && distribution) {
+      new route53.ARecord(this, "CloudFrontAliasRecord", {
+        zone: hostedZone,
+        recordName: domainName,
+        target: route53.RecordTarget.fromAlias(new route53Targets.CloudFrontTarget(distribution)),
+      });
+    }
 
     // -------------------------
     // CloudWatch アラーム
@@ -798,7 +865,7 @@ function handler(event) {
       authVerifyEmail,
       authResendCode,
       authRefresh,
-      authPreSignUp,
+      ...(authPreSignUp ? [authPreSignUp] : []),
       concertLogsList,
       concertLogsCreate,
       concertLogsGet,
@@ -857,45 +924,54 @@ function handler(event) {
       description: "API Gateway URL (NUXT_PUBLIC_API_BASE_URL に設定)",
     });
 
-    new cdk.CfnOutput(this, "SpaUrl", {
-      value: `https://${domainName}`,
-      description: "カスタムドメイン URL (フロントエンド)",
-    });
+    if (!isPreview && distribution && spaBucket && cognitoDomainPrefix) {
+      new cdk.CfnOutput(this, "SpaUrl", {
+        value: `https://${domainName}`,
+        description: "カスタムドメイン URL (フロントエンド)",
+      });
 
-    new cdk.CfnOutput(this, "StorybookUrl", {
-      value: `https://${domainName}/storybook/`,
-      description: "Storybook URL",
-    });
+      new cdk.CfnOutput(this, "StorybookUrl", {
+        value: `https://${domainName}/storybook/`,
+        description: "Storybook URL",
+      });
 
-    new cdk.CfnOutput(this, "CognitoUserPoolId", {
-      value: userPool.userPoolId,
-      description: "Cognito User Pool ID",
-    });
+      new cdk.CfnOutput(this, "CognitoUserPoolId", {
+        value: userPool.userPoolId,
+        description: "Cognito User Pool ID",
+      });
 
-    new cdk.CfnOutput(this, "CognitoClientId", {
-      value: appClient.userPoolClientId,
-      description: "Cognito App Client ID",
-    });
+      new cdk.CfnOutput(this, "CognitoClientId", {
+        value: appClientId,
+        description: "Cognito App Client ID",
+      });
 
-    new cdk.CfnOutput(this, "CognitoUserPoolArn", {
-      value: userPool.userPoolArn,
-      description: "Cognito User Pool ARN",
-    });
+      new cdk.CfnOutput(this, "CognitoUserPoolArn", {
+        value: userPool.userPoolArn,
+        description: "Cognito User Pool ARN",
+      });
 
-    new cdk.CfnOutput(this, "CognitoDomainName", {
-      value: `${cognitoDomainPrefix}.auth.${this.region}.amazoncognito.com`,
-      description: "Cognito Hosted UI Domain (NUXT_PUBLIC_COGNITO_DOMAIN に設定)",
-    });
+      new cdk.CfnOutput(this, "CognitoDomainName", {
+        value: `${cognitoDomainPrefix}.auth.${this.region}.amazoncognito.com`,
+        description: "Cognito Hosted UI Domain (NUXT_PUBLIC_COGNITO_DOMAIN に設定)",
+      });
 
-    new cdk.CfnOutput(this, "SpaBucketName", {
-      value: spaBucket.bucketName,
-      description: "S3 Bucket Name for SPA static files",
-    });
+      new cdk.CfnOutput(this, "SpaBucketName", {
+        value: spaBucket.bucketName,
+        description: "S3 Bucket Name for SPA static files",
+      });
 
-    new cdk.CfnOutput(this, "DistributionId", {
-      value: distribution.distributionId,
-      description: "CloudFront Distribution ID",
-    });
+      new cdk.CfnOutput(this, "DistributionId", {
+        value: distribution.distributionId,
+        description: "CloudFront Distribution ID",
+      });
+    }
+
+    if (isPreview) {
+      new cdk.CfnOutput(this, "PreviewStageName", {
+        value: stageName,
+        description: "Preview stage name (e.g., pr-260)",
+      });
+    }
   }
 
   private removalPolicy(isProd: boolean): cdk.RemovalPolicy {

--- a/cdk/lib/preview-budgets-stack.ts
+++ b/cdk/lib/preview-budgets-stack.ts
@@ -1,0 +1,75 @@
+import * as cdk from "aws-cdk-lib";
+import * as budgets from "aws-cdk-lib/aws-budgets";
+import type { Construct } from "constructs";
+
+export interface PreviewBudgetsStackProps extends cdk.StackProps {
+  /** 予算超過時の通知先メールアドレス */
+  notifyEmail: string;
+  /** 月次予算（USD） */
+  monthlyLimitUsd?: number;
+}
+
+/**
+ * PR プレビュー環境のコスト監視用スタック。
+ *
+ * 全ての PR プレビュースタック（`ClassicalMusicLakeStack-pr-*`）に共通で適用される
+ * 月次予算アラートを 1 つ作成する。`Preview` タグを持つリソースを対象にフィルタする。
+ *
+ * 重要: AWS Budgets でユーザータグをフィルタとして使うには、AWS Billing コンソールで
+ * `Preview` タグをコスト配分タグとしてアクティベートする必要がある。これは CDK では
+ * 自動化できないため、初回デプロイ後に手動で実施すること（手順は OPERATIONS.md 参照）。
+ *
+ * 通常デプロイは行わず、Preview 機能の運用準備として 1 度だけデプロイすればよい。
+ *   npx cdk deploy PreviewBudgetsStack
+ */
+export class PreviewBudgetsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props: PreviewBudgetsStackProps) {
+    super(scope, id, props);
+
+    const monthlyLimit = props.monthlyLimitUsd ?? 20;
+
+    new budgets.CfnBudget(this, "PreviewMonthlyBudget", {
+      budget: {
+        budgetName: "classical-music-lake-preview-monthly",
+        budgetType: "COST",
+        timeUnit: "MONTHLY",
+        budgetLimit: { amount: monthlyLimit, unit: "USD" },
+        costFilters: {
+          // ユーザータグ Preview=true でフィルタ
+          // CFN 構文: TagKeyValue は "user:<tagKey>$<tagValue>" の文字列リスト
+          TagKeyValue: ["user:Preview$true"],
+        },
+      },
+      notificationsWithSubscribers: [
+        {
+          notification: {
+            notificationType: "ACTUAL",
+            comparisonOperator: "GREATER_THAN",
+            threshold: 80,
+            thresholdType: "PERCENTAGE",
+          },
+          subscribers: [
+            {
+              subscriptionType: "EMAIL",
+              address: props.notifyEmail,
+            },
+          ],
+        },
+        {
+          notification: {
+            notificationType: "FORECASTED",
+            comparisonOperator: "GREATER_THAN",
+            threshold: 100,
+            thresholdType: "PERCENTAGE",
+          },
+          subscribers: [
+            {
+              subscriptionType: "EMAIL",
+              address: props.notifyEmail,
+            },
+          ],
+        },
+      ],
+    });
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -114,9 +114,10 @@ classical-music-lake/
 │       └── utils/                # DynamoDB クライアント、レスポンスヘルパーなど
 ├── cdk/
 │   └── lib/
-│       ├── classical-music-lake-stack.ts  # AWSインフラ定義（本番ランタイム）
+│       ├── classical-music-lake-stack.ts  # AWSインフラ定義（本番ランタイム + Preview 環境）
 │       ├── dns-stack.ts                   # Route53 / ACM 証明書（us-east-1）
-│       └── migrations-stack.ts            # 一時的な移行 Lambda を集約（本番スタックから分離）
+│       ├── migrations-stack.ts            # 一時的な移行 Lambda を集約（本番スタックから分離）
+│       └── preview-budgets-stack.ts       # PR プレビュー環境のコスト監視（手動デプロイ）
 ├── docs/
 │   ├── SPEC.md                   # システム仕様書
 │   ├── ARCHITECTURE.md           # 本ドキュメント
@@ -353,3 +354,13 @@ classical-music-lake/
 
 - **理由**: フロントエンド（`types/`）とバックエンド（`backend/src/types/`）が独立したパッケージ構成
 - **トレードオフ**: 重複するが、依存関係を分離することでデプロイの独立性を確保
+
+### PR プレビュー環境（実装済み）
+
+- **状態**: PR ごとに独立した試験用 AWS 環境を立てる仕組みを実装済み
+- **構成**: `ClassicalMusicLakeStack` に `isPreview` フラグを追加。`pr-{番号}` ステージ時は API Gateway + Lambda + DynamoDB のみを構築し、フロント関連リソース（S3 / CloudFront / Route53 / 新規 Cognito User Pool）はスキップ
+- **Cognito の扱い**: Preview 環境は dev の User Pool を `cognito.UserPool.fromUserPoolId` で import 参照する。新規 Pool を作らないことで管理者運用の手間とコスト増を回避
+- **トレードオフ**:
+  - 利点: フロント無しでデプロイ時間が 2〜3 分（フル構成は 10〜15 分）、CloudFront コストもゼロ。dev Cognito のテストユーザーをそのまま使える
+  - 欠点: フロントエンドの動作確認は dev フロント経由でしかできない（curl/Postman での API 検証が前提）。dev User Pool に依存しており、dev スタックが落ちていると Preview がデプロイできない
+- **詳細**: `docs/OPERATIONS.md` 「PR プレビュー環境」章を参照

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -377,3 +377,111 @@ aws dynamodb restore-table-from-backup \
 5. S3 同期（フロント差し替え）
 6. CloudFront invalidation
 7. 移行完了確認後、任意のタイミングで `cdk destroy MigrationsStack[-<stage>]` でスタック破棄
+
+---
+
+## PR プレビュー環境
+
+### 概要
+
+PR ごとに独立した試験用 AWS 環境を立てて、レビュアーが本物の API Gateway + Lambda + DynamoDB に対して動作確認できる仕組み。フロントエンドはデプロイされず、API のみが対象。
+
+| 項目             | 内容                                                                          |
+| ---------------- | ----------------------------------------------------------------------------- |
+| スタック名       | `ClassicalMusicLakeStack-pr-{PR番号}`（例: `ClassicalMusicLakeStack-pr-260`） |
+| 含むリソース     | API Gateway + Lambda + DynamoDB（GSI 含む 4 テーブル）+ CloudWatch Alarms     |
+| 含まないリソース | S3 / CloudFront / Route53 / ACM / 新規 Cognito User Pool / Storybook          |
+| Cognito          | dev 環境の User Pool を参照（新規作成しない）                                 |
+| 削除ポリシー     | 全テーブル DESTROY、空データ                                                  |
+| CORS             | `*` で公開                                                                    |
+| デプロイ時間     | 初回 2〜3 分、差分 30 秒〜2 分（フロント無しのため高速）                      |
+
+### 利用方法
+
+1. PR を作成
+2. PR に **`preview` ラベル**を付与 → GitHub Actions が自動でプレビュー環境をデプロイ
+3. デプロイ完了後、PR に Bot がコメントで API URL とログイン手順を投稿
+4. レビュアーが dev フロントエンド（<https://dev.nocturne-app.com>）にログインして ID Token をブラウザの localStorage から取得
+5. curl / Postman 等で API URL に対してリクエスト送信
+
+```bash
+# 公開 API
+curl https://abc123.execute-api.ap-northeast-1.amazonaws.com/prod/pieces
+
+# 認証必須 API
+curl -H "Authorization: <ID_TOKEN>" \
+  https://abc123.execute-api.ap-northeast-1.amazonaws.com/prod/listening-logs
+```
+
+### ライフサイクル
+
+| イベント                                  | 動作                                |
+| ----------------------------------------- | ----------------------------------- |
+| `preview` ラベル付与（PR opened/labeled） | 初回デプロイ                        |
+| ラベル付き PR への push（synchronize）    | 差分デプロイ（push のたびに自動）   |
+| `preview` ラベル削除                      | 即時 destroy                        |
+| PR クローズ                               | ラベル付きなら destroy              |
+| 最終 deploy から 48h 経過                 | スケジュール cleanup で自動 destroy |
+
+### 同時稼働の上限
+
+ハード制限は無いが、稼働中の Preview スタックが **5 件以上**になると `preview-deploy.yml` が PR に警告コメントを投稿する。コストが気になる場合は不要な PR の `preview` ラベルを外して環境を片付けること。
+
+### 初回セットアップ（リポジトリ管理者）
+
+PR プレビュー機能を有効化するために、**1 度だけ**以下の手動オペレーションが必要。
+
+#### 1. `preview` ラベルを作成
+
+```bash
+gh label create preview \
+  --color 0e8a16 \
+  --description "Deploy a preview AWS environment for this PR"
+```
+
+#### 2. `PreviewBudgetsStack` をデプロイ（コスト監視のため）
+
+```bash
+cd cdk
+npx cdk deploy PreviewBudgetsStack
+```
+
+このスタックは **us-east-1** にデプロイされる（AWS Budgets はグローバルサービス）。月次予算 $20 USD を設定し、80% 実績超過 / 100% 予測超過時に `rt.konabe@gmail.com` にメール通知する。
+
+#### 3. AWS Billing で `Preview` タグをコスト配分タグとして有効化
+
+`PreviewBudgetsStack` のフィルタは「`Preview` タグが `true` のリソース」を見るが、AWS の制約でユーザータグをコスト管理に使うには手動アクティベートが必要（CDK 自動化不可）。
+
+1. AWS Billing コンソール → 「Cost allocation tags」→ 「User-defined tags」タブ
+2. `Preview` を検索してチェックボックスを選択
+3. 「Activate」をクリック
+4. 反映まで最大 24 時間かかる場合あり
+
+### Cognito の扱い（重要）
+
+Preview スタックは **dev 環境の Cognito User Pool を参照**するため:
+
+- レビュアーは dev フロントエンドでログインして ID Token を取得する必要がある
+- Preview 環境で作成した視聴ログ・コンサート記録は **dev Cognito ユーザーに紐づくが、データ自体は Preview 専用テーブル（`-pr-{番号}` サフィックス付き）に保存**される
+- PR 環境を destroy するとデータも消える。dev 環境のデータには影響しない
+- Preview 環境で `POST /pieces` などの管理者 API を叩く場合、dev の `admin` グループに属する ID Token が必要
+
+### IAM 権限
+
+`AWS_ROLE_TO_ASSUME` シークレットの IAM ロールに必要な権限は、通常デプロイで使うものと同種（`cloudformation:*` / `lambda:*` / `apigateway:*` / `dynamodb:*` / `iam:*Role*` / `logs:*` / `cloudwatch:*` 等）。Preview スタック専用の追加権限は不要。
+
+ただし `PreviewBudgetsStack` をデプロイする際は **`budgets:CreateBudget` / `budgets:DescribeBudgets` / `budgets:ModifyBudget` / `budgets:DeleteBudget`** が必要。デプロイ時にエラーが出た場合は IAM ロールに追加すること。
+
+### トラブルシューティング
+
+#### preview-deploy が「dev スタック (ClassicalMusicLakeStack-dev) が稼働していない」で失敗する
+
+dev スタックがダウンしているか、ロールバック中で Output が読めない。dev を再デプロイしてから再度 `preview` ラベルを付け直す。
+
+#### preview-destroy が失敗する
+
+CFN が `DELETE_FAILED` 状態になっている可能性。AWS コンソールで該当スタックを開き、削除をブロックしているリソース（保護されている DynamoDB テーブル等）を手動で削除してから `aws cloudformation delete-stack --stack-name ClassicalMusicLakeStack-pr-{番号}` を再実行する。
+
+#### preview-cleanup が動いていない
+
+GitHub Actions の Schedule トリガーは pulse の重い時間帯では遅延・スキップされることがある（公式ドキュメントに明記）。手動で `Preview Cleanup (48h idle)` ワークフローを `workflow_dispatch` から起動して掃除する。

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1039,13 +1039,18 @@ GET /composers?limit=50&cursor={opaque}
 
 ### 6.1 環境構成
 
-| 環境   | スタック名                    | カスタムドメイン       | DynamoDB テーブル名（視聴ログ）      | DynamoDB テーブル名（コンサート記録） | 削除ポリシー | 用途                                     |
-| ------ | ----------------------------- | ---------------------- | ------------------------------------ | ------------------------------------- | ------------ | ---------------------------------------- |
-| `prod` | `ClassicalMusicLakeStack`     | `nocturne-app.com`     | `classical-music-listening-logs`     | `classical-music-concert-logs`        | RETAIN       | 本番環境                                 |
-| `stg`  | `ClassicalMusicLakeStack-stg` | `stg.nocturne-app.com` | `classical-music-listening-logs-stg` | `classical-music-concert-logs-stg`    | DESTROY      | リリース前の検証環境                     |
-| `dev`  | `ClassicalMusicLakeStack-dev` | `dev.nocturne-app.com` | `classical-music-listening-logs-dev` | `classical-music-concert-logs-dev`    | DESTROY      | 開発環境（ローカル環境からの接続も想定） |
+| 環境               | スタック名                       | カスタムドメイン        | DynamoDB テーブル名（視聴ログ）         | DynamoDB テーブル名（コンサート記録） | 削除ポリシー | 用途                                                             |
+| ------------------ | -------------------------------- | ----------------------- | --------------------------------------- | ------------------------------------- | ------------ | ---------------------------------------------------------------- |
+| `prod`             | `ClassicalMusicLakeStack`        | `nocturne-app.com`      | `classical-music-listening-logs`        | `classical-music-concert-logs`        | RETAIN       | 本番環境                                                         |
+| `stg`              | `ClassicalMusicLakeStack-stg`    | `stg.nocturne-app.com`  | `classical-music-listening-logs-stg`    | `classical-music-concert-logs-stg`    | DESTROY      | リリース前の検証環境                                             |
+| `dev`              | `ClassicalMusicLakeStack-dev`    | `dev.nocturne-app.com`  | `classical-music-listening-logs-dev`    | `classical-music-concert-logs-dev`    | DESTROY      | 開発環境（ローカル環境からの接続も想定）                         |
+| `pr-{N}` (Preview) | `ClassicalMusicLakeStack-pr-{N}` | なし（CloudFront 無し） | `classical-music-listening-logs-pr-{N}` | `classical-music-concert-logs-pr-{N}` | DESTROY      | PR ごとの試験用 API 環境（API Gateway + Lambda + DynamoDB のみ） |
 
 > **DNS スタック**: `NocturneAppDnsStack`（us-east-1）は全環境で共有する Route53 Hosted Zone と ACM 証明書を管理する。初回のみ手動デプロイが必要（`npx cdk deploy NocturneAppDnsStack`）。
+>
+> **Preview スタック**: `pr-{番号}` のスタックはフロントエンド関連リソース（S3 / CloudFront / Route53 / 新規 Cognito User Pool）を持たず、API Gateway + Lambda + DynamoDB のみを構築する。Cognito は dev 環境の User Pool を import して参照する。詳細運用手順は `docs/OPERATIONS.md` の「PR プレビュー環境」章を参照。
+>
+> **Preview Budgets スタック**: `PreviewBudgetsStack`（us-east-1）は Preview 環境のコスト監視用。月次予算 $20 USD でメール通知。初回のみ手動デプロイが必要（`npx cdk deploy PreviewBudgetsStack`）。
 
 ### 6.2 デプロイフロー
 
@@ -1096,6 +1101,22 @@ GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
   3. UnprocessedItems は指数バックオフで最大 5 回リトライ
 - **Secrets**:
   - `AWS_ROLE_TO_ASSUME`（prod テーブルへの `dynamodb:Scan`、stg テーブルへの `dynamodb:Scan` / `dynamodb:BatchWriteItem` 権限が必要）
+
+#### preview-deploy.yml / preview-destroy.yml / preview-cleanup.yml（PR プレビュー環境）
+
+- **概要**: PR ごとに `ClassicalMusicLakeStack-pr-{番号}` を立てて、レビュアーが API のみの試験環境で動作確認できるようにする
+- **トリガー**:
+  - `preview-deploy.yml`: PR `opened` / `labeled` / `synchronize` / `reopened` で `preview` ラベルが付いている場合
+  - `preview-destroy.yml`: PR `unlabeled`（preview ラベルが外れた）または `closed`（preview ラベル付きでクローズ）
+  - `preview-cleanup.yml`: 6 時間ごとの cron で 48h 経過した Preview スタックを destroy
+- **動作（preview-deploy.yml）**:
+  1. dev スタック（`ClassicalMusicLakeStack-dev`）の Output から Cognito User Pool ID / Client ID を取得
+  2. 稼働中 Preview スタック数をカウント（5 以上で警告コメント）
+  3. `cdk deploy ClassicalMusicLakeStack-pr-{番号} --context cognitoUserPoolId=... --context cognitoClientId=...`
+  4. API URL を取得して PR にコメント（dev Cognito でのログイン手順とサンプル curl 付き）
+- **Secrets**:
+  - `AWS_ROLE_TO_ASSUME`（既存の通常デプロイと同じ権限で動作。Preview 専用の追加権限不要）
+- **詳細**: `docs/OPERATIONS.md` 「PR プレビュー環境」章
 
 ### 6.4 ロールバック戦略
 


### PR DESCRIPTION
## Summary

- `preview` ラベル付きの PR に対して `ClassicalMusicLakeStack-pr-{番号}` を自動デプロイし、レビュアーが本物の API Gateway + Lambda + DynamoDB に対して動作確認できる仕組みを追加
- フロント関連リソース（S3 / CloudFront / Route53 / 新規 Cognito UserPool）を持たないため、デプロイは 2〜3 分で完了
- ラベル削除・PR クローズで即時 destroy、48h アイドルで自動 cleanup

Closes #260

## 主な変更

### CDK
- `cdk/lib/classical-music-lake-stack.ts`: `isPreview` フラグを追加。Preview 時はフロントエンド関連リソースをスキップし、dev 環境の Cognito UserPool を `fromUserPoolId` で import
- `cdk/bin/app.ts`: `STAGE_NAME=pr-{N}` の場合に Preview スタックのみ instantiate（DnsStack に依存しない経路）
- `cdk/lib/preview-budgets-stack.ts` (新規): 月次 \$20 USD のコスト監視。`Preview=true` タグでフィルタ

### GitHub Actions
- `.github/workflows/preview-deploy.yml` (新規): `preview` ラベル付与 / push で自動デプロイ。dev スタックから Cognito ID を取得し PR コメントで API URL 通知。同時稼働 5 件以上で警告
- `.github/workflows/preview-destroy.yml` (新規): ラベル削除 / PR クローズで `cdk destroy`
- `.github/workflows/preview-cleanup.yml` (新規): 6 時間ごとの cron。CFN の LastUpdatedTime から 48h 経過した Preview スタックを destroy

### ドキュメント
- `docs/OPERATIONS.md`: 「PR プレビュー環境」章を追加（運用手順・初回セットアップ・トラブルシューティング）
- `docs/SPEC.md`: 環境構成表に Preview 行を追加、preview-* ワークフローの仕様を追記
- `docs/ARCHITECTURE.md`: 設計上のトレードオフセクションに Preview 環境を追加

## マージ後に必要な手動オペレーション

1. `preview` ラベルを作成
   ```bash
   gh label create preview --color 0e8a16 --description \"Deploy a preview AWS environment for this PR\"
   ```
2. `PreviewBudgetsStack` を 1 度だけデプロイ
   ```bash
   cd cdk && npx cdk deploy PreviewBudgetsStack
   ```
3. AWS Billing コンソールで `Preview` タグをコスト配分タグとしてアクティベート（CDK 自動化不可）

詳細は `docs/OPERATIONS.md` 「PR プレビュー環境 → 初回セットアップ」を参照。

## Test plan

- [x] `STAGE_NAME=prod cdk synth` で既存スタックがエラーなく synth されること
- [x] `STAGE_NAME=pr-999 cdk synth ClassicalMusicLakeStack-pr-999 --context cognitoUserPoolId=... --context cognitoClientId=...` で Preview スタックが synth されること
- [x] Preview スタックに S3 / CloudFront / Route53 / Cognito UserPool が含まれていないこと
- [x] Preview スタックに Lambda 25 個（PreSignUp 除く）と DynamoDB 4 テーブルが含まれること
- [x] 既存の dev/stg/prod スタックの構成が変わらないこと（Lambda 数・テーブル数）
- [x] ESLint・Prettier・全テスト (frontend 670件 / backend 602件) が通ること
- [ ] (マージ後) `preview` ラベルを付けた PR で実際に Preview 環境がデプロイされ、API URL に curl で疎通確認できること
- [ ] (マージ後) ラベル削除で destroy が走ること
- [ ] (マージ後) `PreviewBudgetsStack` がデプロイされ、AWS Budgets コンソールで予算が確認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)