### PR TITLE
chore: dev サーバー起動修正のため @nuxtjs/storybook を外す（暫定対応 #590）

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,11 @@ export default defineNuxtConfig({
   devServer: {
     port: 3010,
   },
-  modules: ["@nuxt/eslint", "@nuxtjs/storybook", "@nuxtjs/color-mode"],
+  // NOTE: @nuxtjs/storybook@9.0.1 は storybook ~9.0.5 を peer に要求しているが、
+  // 本プロジェクトは storybook@10.3.5 を使用しているため、組み込み proxy が壊れて
+  // dev サーバーが /_nuxt/* を 500 で返す。upstream の修正待ちのため一旦外す。
+  // Storybook 自体は `pnpm storybook` でスタンドアロン起動可能。詳細は #590 を参照。
+  modules: ["@nuxt/eslint", "@nuxtjs/color-mode"],
   colorMode: {
     preference: "system",
     fallback: "light",


### PR DESCRIPTION
## Summary

- `pnpm run dev` 実行時に `/_nuxt/@vite/client` などが 500 を返し、SPA がブートストラップできない事象の暫定対応
- `nuxt.config.ts` の `modules` 配列から `@nuxtjs/storybook` を一旦外す

## 背景・原因

`@nuxtjs/storybook@9.0.1` の peer dependency は `storybook ~9.0.5` だが、本プロジェクトは `storybook@10.3.5` を使用しているため、Storybook 10 の API 変更に追従できず、モジュールが登録した `/_nuxt/*` Vite proxy が機能しない（接続先が listen しない → ECONNREFUSED）。

upstream で修正 PR ([nuxt-modules/storybook#994](https://github.com/nuxt-modules/storybook/pull/994)) がレビュー中のため、それがマージ・リリースされるまでの暫定回避。

## 影響

- ❌ `pnpm dev` 起動時に Storybook も同時起動する機能 → 動かなくなる（もともと壊れていた）
- ✅ Storybook 単独起動 (`pnpm storybook`) → 引き続き利用可能
- ✅ CI の `pnpm run build-storybook` → スタンドアロンで動くため影響なし
- ✅ デプロイされる Storybook サイト → 影響なし

## 恒久対応

追跡 issue: #590

## Test plan

- [x] `pnpm run dev` で SPA が起動し、`/auth/login` `/auth/user-register` が表示される
- [x] `pnpm run lint` 通過
- [ ] `pnpm storybook` が単独起動できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)