### PR TITLE
fix(pieces): 未認証ユーザーが楽曲マスタ詳細ページでログイン画面にリダイレクトされる問題を修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tmp/
 
 # Playwright MCP local snapshots
 .playwright-mcp/
+
+# Playwright CLI local snapshots
+.playwright-cli/

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,5 +9,6 @@ package-lock.json
 pnpm-lock.yaml
 .claude/
 .playwright-mcp/
+.playwright-cli/
 # release-please が自動生成するため除外
 CHANGELOG.md

--- a/app/composables/useListeningLogs.ts
+++ b/app/composables/useListeningLogs.ts
@@ -1,5 +1,6 @@
 import type { CreateListeningLogInput, ListeningLog, UpdateListeningLogInput } from "~/types";
 import { useCrudResource, useCrudResourceItem } from "./useCrudResource";
+import { useAuthenticatedApi } from "./useAuthenticatedApi";
 
 export const useListeningLogs = () => {
   const { deleteItem, ...rest } = useCrudResource<
@@ -12,3 +13,13 @@ export const useListeningLogs = () => {
 
 export const useListeningLog = (id: () => string) =>
   useCrudResourceItem<ListeningLog>("listening-logs", id);
+
+export const useListeningLogCreate = () => {
+  const apiBase = useApiBase();
+  const { postJson } = useAuthenticatedApi();
+
+  const create = (input: CreateListeningLogInput): Promise<ListeningLog> =>
+    postJson<ListeningLog>(`${apiBase}/listening-logs`, input);
+
+  return { create };
+};

--- a/app/pages/pieces/[id]/index.test.ts
+++ b/app/pages/pieces/[id]/index.test.ts
@@ -53,6 +53,7 @@ vi.mock("~/composables/useListeningLogs", () => ({
     deleteLog: vi.fn(),
   }),
   useListeningLog: () => ({ data: ref(null), error: ref(null) }),
+  useListeningLogCreate: () => ({ create: mockCreate }),
 }));
 
 beforeEach(() => {

--- a/app/pages/pieces/[id]/index.vue
+++ b/app/pages/pieces/[id]/index.vue
@@ -6,7 +6,7 @@ const apiBase = useApiBase();
 const { data: piece, error } = await usePiece(() => route.params.id as string);
 const { data: composers, refresh: refreshComposers } = useComposersAll();
 await refreshComposers();
-const { create } = useListeningLogs();
+const { create } = useListeningLogCreate();
 const { isAdmin } = useAuth();
 const isAdminUser = isAdmin();
 


### PR DESCRIPTION
## Summary

- `pieces/[id]/index.vue` が `useListeningLogs()` を呼び出していたため、内部で `/listening-logs` の自動フェッチが発生し、未認証ユーザーが 401 を受け取ってログイン画面へリダイレクトされていた
- `useListeningLogCreate()` 関数を `useListeningLogs.ts` に新設し、リストフェッチなしで `create` 操作のみを提供するようにした
- `pieces/[id]/index.vue` を `useListeningLogCreate()` を使うよう変更し、不要なリストフェッチを排除した

Closes #519

## Test plan

- [x] playwright-cli で未認証状態の `/pieces/{id}` アクセスが `/auth/login` にリダイレクトされないことを確認
- [x] `pnpm run test:frontend` が全件パス（716件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)