### PR TITLE
feat(sync-db): 作曲家マスタを prod → stg 同期対象に追加

### DIFF
--- a/backend/scripts/sync-dynamodb.mjs
+++ b/backend/scripts/sync-dynamodb.mjs
@@ -2,9 +2,11 @@
  * prod → stg DynamoDB 同期スクリプト
  *
  * 対象テーブル:
- *   classical-music-pieces → classical-music-pieces-stg
+ *   classical-music-pieces    → classical-music-pieces-stg
+ *   classical-music-composers → classical-music-composers-stg
  *
- * 視聴ログ（classical-music-listening-logs）は個人情報を含むため同期対象外。
+ * 視聴ログ（classical-music-listening-logs）・コンサート記録（classical-music-concert-logs）は
+ * 個人情報を含むため同期対象外。
  *
  * 使用方法:
  *   node backend/scripts/sync-dynamodb.mjs
@@ -23,6 +25,11 @@ const TABLES = [
   {
     source: "classical-music-pieces",
     dest: "classical-music-pieces-stg",
+    keyAttributes: ["id"],
+  },
+  {
+    source: "classical-music-composers",
+    dest: "classical-music-composers-stg",
     keyAttributes: ["id"],
   },
 ];

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -1104,6 +1104,7 @@ GitHub (workflow_dispatch)   → dev / stg / prod を手動選択
 - **概要**: prod の DynamoDB データを stg へ全件コピーする
 - **対象テーブル**:
   - `classical-music-pieces` → `classical-music-pieces-stg`
+  - `classical-music-composers` → `classical-music-composers-stg`
   - ※ 視聴ログ（`classical-music-listening-logs`）・コンサート記録（`classical-music-concert-logs`）は個人情報を含むため同期対象外
 - **トリガー**:
   - スケジュール: 毎日 0:00 JST（UTC 15:00）に自動実行


### PR DESCRIPTION
楽曲マスタと同様に、作曲家マスタ（classical-music-composers）を
日次の prod → stg DynamoDB 同期対象に追加する

https://claude.ai/code/session_016oMuwRSag2CuFrY1NzZqUT