### PR TITLE
chore(release): release-please-config の整理と PR タイトル検証 workflow 追加

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,36 @@
+name: Lint PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  lint:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            chore
+            docs
+            test
+            build
+            ci
+            style
+            revert
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            PR タイトルの subject は英大文字で始めないでください（commitlint の subject-case ルールに準拠）。
+            例: 「fix: 視聴ログの並び順を修正」
+          validateSingleCommit: false

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,4 @@
 {
-  "release-type": "node",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },
@@ -9,9 +8,7 @@
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
-      "release-type": "node",
-      "bump-minor-pre-major": true,
-      "bump-patch-for-minor-pre-major": true
+      "release-type": "node"
     }
   }
 }


### PR DESCRIPTION
## Summary

`release-please-config.json` のレビュー結果に基づく整理と、Squash merge 運用での Conventional Commits 取りこぼしを防ぐ仕組みの追加。

### 1. `release-please-config.json` の整理 (`0b088d3`)

- **トップレベルの `release-type` を削除**: `packages["."].release-type` と重複していた
- **`bump-minor-pre-major` / `bump-patch-for-minor-pre-major` を削除**: メジャーバージョン 0.x 系専用の設定であり、現在のバージョン `2.4.1` では一切効果がなかった

### 2. PR タイトル検証 workflow の追加 (`9f5bb48`)

`.github/workflows/lint-pr-title.yml` を新規追加。

- **背景**: Squash merge では PR タイトルが最終コミットメッセージになるため、ローカルの `commit-msg` フック（commitlint）を素通りしてしまう。実際 main 上には `Improve test coverage configuration ...` (#594) や `Add @types/node ...` (#573) のような Conventional Commits 非準拠のコミットが入っており、Release Please の version bump にも CHANGELOG にも反映されない盲点になっていた
- **対応**: `amannn/action-semantic-pull-request@v6.1.1` (SHA pin) で PR タイトルを検証
  - 許可 type: `feat / fix / perf / refactor / chore / docs / test / build / ci / style / revert`
  - subject の先頭が英大文字の場合はエラー（commitlint の `subject-case` ルールに準拠）
  - scope は任意

## マージ後の手動設定（必須）

このワークフローを実効化するため、以下を GitHub UI で設定してください:

1. **Settings → General → Pull Requests**
   - 「Default to PR title for squash merge commits」を ON
2. **Settings → Branches → Branch protection rules (`main`)**
   - 「Require status checks to pass before merging」に `Validate PR Title` を追加
   - ※ 最初の 1 PR で job が走った後でないとリストに出ない点に注意

## Test plan

- [x] `release-please-config.json` の修正が JSON として valid（Prettier の format:check 通過）
- [x] フロントエンドテスト全件パス（716 件）
- [x] バックエンドテスト全件パス（602 件）
- [ ] この PR のタイトル自体が `Validate PR Title` で OK と判定されること（CI で確認）
- [ ] マージ後、次回 `feat:` / `fix:` を含む PR で Release Please が想定どおり動くこと

https://claude.ai/code/session_01VaEjtwjTUFab3iFcoGiRWX

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaEjtwjTUFab3iFcoGiRWX)_