### PR TITLE
Upgrade TypeScript target to ES2023 and enhance compiler strictness

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,17 +1,18 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "module": "commonjs",
-    "lib": ["ES2020"],
-    "outDir": "dist",
-    "rootDir": "..",
+    "lib": ["ES2023"],
+    "noEmit": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"]
+    "types": ["node", "vitest/globals"]
   },
   "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,17 +1,21 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2023",
     "module": "commonjs",
-    "lib": ["ES2020"],
+    "lib": ["ES2023"],
     "outDir": "dist",
     "rootDir": ".",
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"],
+    // bin/app.ts の `import "source-map-support/register"` は型定義を持たない side-effect import のため、
+    // TypeScript 6.x のデフォルト（true）だと TS2882 で落ちる。明示的に無効化する。
     "noUncheckedSideEffectImports": false
   },
   "include": ["bin/**/*", "lib/**/*"],

--- a/shared/tsconfig.json
+++ b/shared/tsconfig.json
@@ -1,11 +1,12 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
-    "module": "commonjs",
+    "target": "ES2023",
+    "lib": ["ES2023"],
     "strict": true,
-    "esModuleInterop": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "noEmit": true
   },
   "include": ["**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
     "types": ["vitest/globals"]
   },
   "exclude": ["backend/**", "cdk/**", "node_modules", ".nuxt", "dist", ".output"]


### PR DESCRIPTION
## 概要

TypeScript のターゲットを ES2020 から ES2023 にアップグレードし、コンパイラの厳密性を向上させるための設定を追加しました。

## 変更の種類

- [x] リファクタリング

## 変更内容

### TypeScript ターゲットのアップグレード
- すべての `tsconfig.json` ファイルで `target` を ES2020 から ES2023 に更新
- 対応する `lib` オプションも ES2023 に統一

### コンパイラ厳密性の強化
- `noImplicitOverride`: メソッドオーバーライド時に `override` キーワードを強制（backend, cdk）
- `noFallthroughCasesInSwitch`: switch 文の fall-through を禁止（backend, cdk, root）
- `isolatedModules`: 各ファイルを独立してコンパイル可能にする（shared）
- `forceConsistentCasingInFileNames`: ファイル名の大文字小文字を統一（root）

### その他の設定変更
- **backend**: `noEmit: true` を追加、`outDir` と `rootDir` を削除、vitest グローバル型定義を追加
- **shared**: `module` と `esModuleInterop` を削除、`noEmit: true` を追加
- **cdk**: `noUncheckedSideEffectImports: false` の設定理由をコメントで明記

## テスト

- [x] 既存テストがすべて通ることを確認した（TypeScript コンパイルが成功）

## チェックリスト

- [x] コーディング規約に従っている
- [x] 実装を含まない設定変更のため、ドキュメント更新は不要

https://claude.ai/code/session_01LNiZMLs5cmAxQsKokDSwyN