### PR TITLE
chore(stryker): フロントエンド設定に shared 配下のミューテーションと閾値を追加

### DIFF
--- a/stryker.config.mjs
+++ b/stryker.config.mjs
@@ -1,7 +1,13 @@
 /** @type {import('@stryker-mutator/api/core').PartialStrykerOptions} */
 export default {
   testRunner: "vitest",
-  mutate: ["app/**/*.ts", "app/**/*.vue", "!app/**/*.test.ts", "!app/**/*.stories.ts"],
+  mutate: [
+    "app/**/*.ts",
+    "app/**/*.vue",
+    "shared/**/*.ts",
+    "!app/**/*.test.ts",
+    "!app/**/*.stories.ts",
+  ],
   vitest: {
     configFile: "vitest.config.ts",
   },
@@ -15,5 +21,6 @@ export default {
     reportType: "full",
   },
   coverageAnalysis: "perTest",
+  thresholds: { high: 80, low: 60, break: 0 },
   tempDirName: ".stryker-tmp",
 };


### PR DESCRIPTION
## 概要

Stryker の設定を更新し、mutation テストの対象を `shared/**/*.ts` に拡張し、カバレッジ品質の閾値を設定しました。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [x] テスト
- [ ] その他（　　）

## 変更内容

- `stryker.config.mjs` の `mutate` 設定に `shared/**/*.ts` を追加し、共有ディレクトリのコードも mutation テストの対象に含めるようにしました
- `mutate` 配列をより読みやすいように複数行に分割しました
- `thresholds` 設定を追加し、mutation スコアの品質基準を設定しました：
  - `high: 80` - 高品質の基準
  - `low: 60` - 低品質の基準
  - `break: 0` - ビルド失敗の閾値

## テスト

- [x] 既存テストがすべて通ることを確認した
- 設定ファイルの変更のため、追加のテストは不要です

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [ ] 実装を含む変更の場合、`docs/SPEC.md` を更新した（設定変更のため不要）

https://claude.ai/code/session_01VZsLKHwG1jQJ7SFMjEtqHG