### PR TITLE
docs(readme): 機能一覧・使い方・ディレクトリ構造・CI/CD 設定を現状に追従

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,28 @@
 
 ## 機能一覧
 
-- **視聴ログ記録** - CD・配信で聴いた演奏（作曲家・曲名・演奏家・指揮者）を記録
-- **評価・メモ** - 5段階評価とフリーテキストでの感想
-- **お気に入り管理** - 特別な演奏をお気に入りとしてマーク
+- **ユーザー認証** - メールアドレス + パスワード（Cognito、メール確認コードあり）/ Google OAuth（Cognito Hosted UI 経由）
+- **視聴ログ記録** - CD・配信で聴いた演奏を記録（作曲家・曲名・視聴日時・5段階評価・お気に入り・メモ）
+- **視聴ログの検索フィルタ** - キーワード／評価／お気に入り／期間によるクライアントサイド絞り込み
+- **視聴ログの統計ダッシュボード** - 総数・お気に入り数・平均評価・評価分布・作曲家ランキング・月別トレンド
+- **コンサート記録** - 実際に聴いたコンサートを記録（タイトル・開催日時・会場・指揮者・オーケストラ・ソリスト・プログラム）
+- **楽曲マスタ管理** - 楽曲（曲名・作曲家・ジャンル・時代・編成・地域・動画 URL）の CRUD（書き込みは管理者のみ）
+- **作曲家マスタ管理** - 作曲家（名前・時代・地域・肖像画像 URL）の CRUD（書き込みは管理者のみ）
+- **ライト/ダークモード切替** - ヘッダーのトグルで切替（システム設定追従、localStorage に永続化）
 
 ## 技術スタック
 
-| レイヤー       | 技術                                   |
-| -------------- | -------------------------------------- |
-| フロントエンド | Nuxt 3 (Vue 3 / TypeScript / SPA)      |
-| バックエンド   | AWS Lambda (Node.js 24.x / TypeScript) |
-| API            | AWS API Gateway (REST)                 |
-| DB             | AWS DynamoDB                           |
-| ホスティング   | AWS S3 + CloudFront                    |
-| IaC            | AWS CDK (TypeScript)                   |
-| CI/CD          | GitHub Actions                         |
+| レイヤー       | 技術                                                         |
+| -------------- | ------------------------------------------------------------ |
+| フロントエンド | Nuxt 3 (Vue 3 / TypeScript / SPA)                            |
+| バックエンド   | AWS Lambda (Node.js 24.x / TypeScript、DDD レイヤー構造)     |
+| API            | AWS API Gateway (REST + Cognito Authorizer)                  |
+| DB             | AWS DynamoDB                                                 |
+| 認証           | AWS Cognito User Pool（メール認証 + Google OAuth Hosted UI） |
+| ホスティング   | AWS S3 + CloudFront                                          |
+| DNS / 証明書   | AWS Route53 + ACM（カスタムドメイン `nocturne-app.com`）     |
+| IaC            | AWS CDK (TypeScript)                                         |
+| CI/CD          | GitHub Actions（OIDC によるキーレス認証）                    |
 
 ## セットアップ
 
@@ -84,11 +91,23 @@ cdk deploy
 
 以下のシークレットをリポジトリに設定してください：
 
-| シークレット名       | 説明                             |
-| -------------------- | -------------------------------- |
-| `AWS_ROLE_TO_ASSUME` | AssumeRole 対象の IAM ロール ARN |
+| シークレット名         | 必須 | 説明                                                                      |
+| ---------------------- | ---- | ------------------------------------------------------------------------- |
+| `AWS_ROLE_TO_ASSUME`   | ✅   | AssumeRole 対象の IAM ロール ARN（GitHub OIDC によるキーレス認証で使用）  |
+| `GOOGLE_CLIENT_ID`     | ✅   | Google OAuth（Cognito Hosted UI 連携）のクライアント ID                   |
+| `GOOGLE_CLIENT_SECRET` | ✅   | Google OAuth のクライアントシークレット                                   |
+| `ALERT_EMAIL`          | -    | CloudWatch アラート通知先メールアドレス（カンマ区切りで複数指定可、任意） |
 
-> **注意**: `AWS_REGION` はワークフロー内に `ap-northeast-1` でハードコードされています。API GatewayのURLはCloudFormation Outputsから自動取得するため、シークレットとして設定する必要はありません。
+> **注意**: `AWS_REGION` はワークフロー内に `ap-northeast-1` でハードコードされています。API Gateway の URL や Cognito の各種値は CloudFormation Outputs から自動取得するため、シークレットとして設定する必要はありません。
+
+#### デプロイトリガー（`deploy.yml`）
+
+| トリガー                        | デプロイ先                |
+| ------------------------------- | ------------------------- |
+| `main` ブランチへの push        | stg 環境                  |
+| GitHub Release の publish       | prod 環境                 |
+| `dev*` タグの push              | dev 環境                  |
+| `workflow_dispatch`（手動実行） | dev / stg / prod から選択 |
 
 ### GitHub OIDC + IAM ロール設定
 
@@ -102,7 +121,7 @@ cdk deploy
      - `token.actions.githubusercontent.com:sub` = `repo:<org>/<repo>:ref:refs/heads/<branch>`（例: `repo:konabe/classical-music-lake:ref:refs/heads/main`）
 3. ロール ARN を `AWS_ROLE_TO_ASSUME` シークレットに設定
 
-`main` ブランチへのプッシュで自動デプロイされます。
+`main` ブランチへのプッシュで stg 環境へ、GitHub Release の publish で prod 環境へ自動デプロイされます。
 
 ## 環境変数
 
@@ -112,10 +131,11 @@ cdk deploy
 
 ## 使い方
 
-1. トップページから「視聴ログ」に移動
-2. 「新規登録」ボタンから視聴した演奏を記録
-3. 作曲家・曲名・演奏家・指揮者・評価・メモを入力して保存
-4. 一覧画面で過去の記録を確認・編集・削除
+1. **アカウント登録**: `/auth/user-register` でメールアドレスとパスワードを入力 → メールに届いた確認コードを `/auth/verify-email` で入力すると自動ログイン（Google アカウントでのログインも可）
+2. **視聴ログ記録**: ヘッダーの「鑑賞記録」→「新規作成」から、視聴日時・作曲家・曲名・5段階評価・お気に入り・メモを入力して保存
+3. **一覧・検索・統計**: 一覧画面でキーワード／評価／お気に入り／期間で絞り込み。「統計」から評価分布・作曲家ランキング・月別トレンドを確認
+4. **コンサート記録**: ヘッダーの「コンサート記録」→「新規作成」から、タイトル・開催日時・会場・指揮者・オーケストラ・ソリスト・プログラム（楽曲マスタから選択）を入力して保存
+5. **マスタ管理（管理者のみ）**: 「楽曲マスタ」「作曲家マスタ」から CRUD を実行（admin Cognito グループに所属するユーザーのみ書き込み可能。参照は誰でも可）
 
 ## トラブルシューティング
 
@@ -133,19 +153,37 @@ API GatewayのURLが正しく設定されているか確認してください。
 
 ```text
 classical-music-lake/
-├── pages/                   # Nuxt ページ（ルーティング）
-│   └── listening-logs/      # 視聴ログ関連ページ（一覧・新規・詳細・編集）
-├── components/              # 再利用可能なUIコンポーネント
-├── composables/             # API呼び出しなどの共通ロジック
-├── types/                   # フロントエンド共通型定義
+├── app/                          # Nuxt アプリケーション
+│   ├── assets/                   # CSS（ライト/ダークモードのテーマ変数等）
+│   ├── layouts/                  # default / auth レイアウト
+│   ├── middleware/               # auth / admin ルートミドルウェア
+│   ├── pages/                    # Nuxt ページ
+│   │   ├── auth/                 # login / user-register / verify-email
+│   │   ├── listening-logs/       # 視聴ログ（一覧・新規・統計・詳細・編集）
+│   │   ├── concert-logs/         # コンサート記録（一覧・新規・詳細・編集）
+│   │   ├── pieces/               # 楽曲マスタ（一覧・新規・詳細・編集）
+│   │   └── composers/            # 作曲家マスタ（一覧・新規・詳細・編集）
+│   ├── components/               # Atomic Design（atoms / molecules / organisms / templates）
+│   ├── composables/              # API 呼び出し・認証・フィルタ・統計などの共通ロジック
+│   ├── utils/                    # フロントエンド共通ユーティリティ
+│   └── types/                    # フロントエンド型定義（shared/ から re-export）
+├── shared/                       # フロント・バックエンド共通の定数・型定義
 ├── backend/
 │   └── src/
-│       ├── listening-logs/  # Lambda 関数（create/list/get/update/delete）
-│       ├── types/           # バックエンド共通型定義
-│       └── utils/           # DynamoDB クライアントなど
-├── cdk/                     # AWSインフラ定義（CDK）
-├── docs/                    # ドキュメント類
-└── .github/workflows/       # GitHub Actions ワークフロー
+│       ├── handlers/             # Lambda エントリポイント（auth / listening-logs / concert-logs / pieces / composers）
+│       ├── usecases/             # ユースケース層
+│       ├── repositories/         # DynamoDB アクセス層
+│       ├── domain/               # エンティティ・値オブジェクト（DDD）
+│       ├── migrations/           # 一時的なデータ移行 Lambda
+│       ├── types/                # バックエンド型定義（shared/ から re-export）
+│       └── utils/                # DynamoDB クライアント、レスポンスヘルパー、Zod スキーマ等
+├── cdk/
+│   └── lib/
+│       ├── classical-music-lake-stack.ts  # 本番ランタイム（Lambda / API Gateway / DynamoDB / Cognito / S3 / CloudFront）
+│       ├── dns-stack.ts                   # Route53 Hosted Zone + ACM 証明書（us-east-1）
+│       └── migrations-stack.ts            # 移行用 Lambda（本番スタックから分離）
+├── docs/                         # ドキュメント類
+└── .github/workflows/            # GitHub Actions ワークフロー
 ```
 
 詳細は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照してください。


### PR DESCRIPTION
## 概要

README.md を大幅に更新し、実装済みの機能、技術スタック、デプロイメント構成、ディレクトリ構造を詳細に記載しました。ユーザー認証、視聴ログ・コンサート記録、マスタ管理、ダッシュボード機能などの全機能を明記し、GitHub OIDC + Cognito を用いたセキュアなデプロイメント構成を説明しています。

## 変更の種類

- [x] ドキュメント

## 変更内容

### 機能一覧の拡充
- ユーザー認証（Cognito + Google OAuth）を追加
- 視聴ログ記録の詳細化（視聴日時、5段階評価、お気に入り、メモを明記）
- 視聴ログの検索フィルタ機能を追加
- 視聴ログの統計ダッシュボード機能を追加
- コンサート記録機能を追加
- 楽曲マスタ管理（CRUD、管理者のみ書き込み）を追加
- 作曲家マスタ管理（CRUD、管理者のみ書き込み）を追加
- ライト/ダークモード切替機能を追加

### 技術スタック の更新
- バックエンド: DDD レイヤー構造を明記
- API: Cognito Authorizer を追加
- 認証: AWS Cognito User Pool の詳細を追加
- DNS / 証明書: Route53 + ACM（カスタムドメイン `nocturne-app.com`）を追加
- CI/CD: OIDC によるキーレス認証を明記

### GitHub Secrets の詳細化
- `AWS_ROLE_TO_ASSUME`、`GOOGLE_CLIENT_ID`、`GOOGLE_CLIENT_SECRET`、`ALERT_EMAIL` を表形式で整理
- 各シークレットの必須/任意を明記
- CloudFormation Outputs からの自動取得について説明を追加

### デプロイトリガーの明記
- `main` ブランチ push → stg 環境
- GitHub Release publish → prod 環境
- `dev*` タグ push → dev 環境
- `workflow_dispatch` → 手動選択

### 使い方の詳細化
- アカウント登録フロー（メール確認コード、Google OAuth）
- 視聴ログ記録・検索・統計の操作フロー
- コンサート記録の操作フロー
- マスタ管理（管理者のみ）の説明

### ディレクトリ構造の詳細化
- Atomic Design に基づくコンポーネント構成を明記
- バックエンド: DDD レイヤー構造（handlers / usecases / repositories / domain）を明記
- CDK: 本番ランタイム、DNS スタック、移行用 Lambda の分離を明記
- shared/ フォルダでのフロント・バックエンド共通定義を追加

## テスト

- [x] ドキュメント変更のため、テストは不要

## チェックリスト

- [x] ドキュメント更新のため、コーディング規約チェックは不要
- [x] 実装を含まない変更のため、`docs/SPEC.md` 更新は不要

https://claude.ai/code/session_01JHQvwCdQ7xUMvRqzPuNQEo