### PR TITLE
fix(sonar): app/ と backend/src/ 配下のテストファイルを sonar.tests に含める

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,9 @@ sonar.organization=konabe
 
 sonar.sources=app,backend/src,shared
 sonar.javascript.lcov.reportPaths=coverage/lcov.info,backend/coverage/lcov.info
-sonar.tests=tests
+# ユニットテストは app/ と backend/src/ 配下に同居しているため、
+# sonar.tests を sonar.sources と重ねて sonar.test.inclusions で振り分ける
+sonar.tests=app,backend/src,tests
 sonar.test.inclusions=**/*.test.ts,**/*.spec.ts
 sonar.exclusions=**/*.stories.ts
 


### PR DESCRIPTION
## 概要

SonarQubeの設定を修正し、`app/`と`backend/src/`配下に同居しているユニットテストを正しく認識するようにしました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- `sonar.tests`の設定を`tests`から`app,backend/src,tests`に変更
- ユニットテストが複数のディレクトリに分散していることを考慮し、`sonar.test.inclusions`で`**/*.test.ts`と`**/*.spec.ts`パターンで振り分けるよう設定
- 設定の意図を明確にするためコメントを追加

## テスト

- [x] 既存テストがすべて通ることを確認した（`pnpm test` / `pnpm -C backend test`）

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約（CLAUDE.md）に従っている
- [x] 実装を含む変更の場合、`docs/SPEC.md` を更新した

https://claude.ai/code/session_01M3Amxg2ghcd6DDPtL8hRos