### PR TITLE
Add Node.js 24 installation and setup in session-start hook

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,6 +5,24 @@ if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
   exit 0
 fi
 
+# Install / select Node.js 24 (package.json requires "node": ">=24.14.0")
+export NVM_DIR=/opt/nvm
+# shellcheck disable=SC1091
+. "$NVM_DIR/nvm.sh"
+
+if ! nvm ls 24 2>/dev/null | grep -q "v24\."; then
+  nvm install 24 --no-progress
+fi
+nvm use 24 >/dev/null
+
+NODE_BIN_DIR="$(dirname "$(nvm which 24)")"
+export PATH="$NODE_BIN_DIR:$PATH"
+
+# Persist Node 24 path for the rest of the session
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+  echo "export PATH=\"$NODE_BIN_DIR:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi
+
 # Enable corepack to use pnpm via packageManager field
 corepack enable
 


### PR DESCRIPTION
## 概要

セッション開始時に Node.js 24 をインストール・選択し、PATH を設定するロジックを追加しました。package.json の要件（`"node": ">=24.14.0"`）に対応するための変更です。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [ ] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- NVM を使用して Node.js 24 のインストール状況を確認し、未インストールの場合はインストール
- `nvm use 24` で Node.js 24 を選択
- Node.js 24 のバイナリディレクトリを PATH の先頭に追加
- セッション全体で有効になるよう、`CLAUDE_ENV_FILE` が設定されている場合は PATH をエクスポート

## テスト

- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [x] 実装を含む変更の場合、`docs/SPEC.md` を更新した（該当なし）

https://claude.ai/code/session_015TXMzbG65JWrz6uwkR5gDp