### PR TITLE
chore(editorconfig): max_line_lengthをPrettierのprintWidthと揃え.mdは除外

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,6 +7,8 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+max_line_length = 100
 
 [*.md]
 trim_trailing_whitespace = false
+max_line_length = off


### PR DESCRIPTION
## 概要

EditorConfig に max_line_length の設定を追加しました。一般的なファイルは 100 文字、Markdown ファイルは制限なしに設定しています。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- `.editorconfig` に `max_line_length = 100` を追加（全般設定）
- `[*.md]` セクションに `max_line_length = off` を追加（Markdown ファイルは行長制限なし）

## テスト

- [x] 既存テストがすべて通ることを確認した

## チェックリスト

- [x] コーディング規約に従っている
- [x] 設定ファイルの変更のため実装ドキュメント更新は不要

https://claude.ai/code/session_01FHyx9XUfepTASK2gNwgnYz