### PR TITLE
chore(npmrc): engine-strict を true に切り替えて Node バージョンを厳密化

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,2 @@
-# Claude Code Web 環境では Node.js 24 が利用できないため、
-# pnpm install / pre-push フック実行時にエンジン制約でブロックされる。
-# CI（GitHub Actions）では正しい Node.js バージョンが使われるため影響なし。
-engine-strict=false
+engine-strict=true
 auto-install-peers=true


### PR DESCRIPTION
## 概要

`.npmrc` の `engine-strict` 設定を `false` から `true` に変更し、Node.js バージョンの厳密なチェックを有効にします。

## 変更の種類

- [ ] バグ修正
- [ ] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- `.npmrc` の `engine-strict` を `true` に設定
- 環境依存の制約に関するコメントを削除
- CI 環境では正しい Node.js バージョンが使用されるため、ローカル開発環境での制約を解除する必要がなくなった

## テスト

- [x] 既存テストがすべて通ることを確認した（CI で検証）

## チェックリスト

- [x] コーディング規約に従っている
- [x] 設定ファイルの変更のため、実装更新は不要

https://claude.ai/code/session_014CBoJdLLDJxsmoxfmpSbC5