### PR TITLE
chore(prettier): trailingCommaをallに変更しendOfLineをlfで明示

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,7 @@
 {
   "semi": true,
   "singleQuote": false,
-  "trailingComma": "es5",
-  "printWidth": 100
+  "trailingComma": "all",
+  "printWidth": 100,
+  "endOfLine": "lf"
 }

--- a/app/components/atoms/ThemeToggle.vue
+++ b/app/components/atoms/ThemeToggle.vue
@@ -8,7 +8,7 @@ const toggle = () => {
 };
 
 const ariaLabel = computed(() =>
-  isDark.value ? "ライトモードに切り替え" : "ダークモードに切り替え"
+  isDark.value ? "ライトモードに切り替え" : "ダークモードに切り替え",
 );
 </script>
 

--- a/app/components/molecules/ComposerCategoryList.vue
+++ b/app/components/molecules/ComposerCategoryList.vue
@@ -11,7 +11,7 @@ const categories = computed(() =>
   [
     { kind: "era" as Kind, label: "時代", value: props.composer.era },
     { kind: "region" as Kind, label: "地域", value: props.composer.region },
-  ].filter((c): c is { kind: Kind; label: string; value: string } => c.value !== undefined)
+  ].filter((c): c is { kind: Kind; label: string; value: string } => c.value !== undefined),
 );
 </script>
 

--- a/app/components/molecules/ListeningLogFilter.vue
+++ b/app/components/molecules/ListeningLogFilter.vue
@@ -22,7 +22,7 @@ const ratingOptions = [
 function update<K extends keyof ListeningLogFilterState>(
   current: ListeningLogFilterState,
   key: K,
-  value: ListeningLogFilterState[K]
+  value: ListeningLogFilterState[K],
 ) {
   emit("update:modelValue", { ...current, [key]: value });
 }

--- a/app/components/molecules/PasswordInput.test.ts
+++ b/app/components/molecules/PasswordInput.test.ts
@@ -22,7 +22,7 @@ describe("PasswordInput", () => {
         props: { modelValue: "" },
       });
       expect(wrapper.find("button.toggle-button").attributes("aria-label")).toBe(
-        "パスワードを表示"
+        "パスワードを表示",
       );
     });
 
@@ -64,7 +64,7 @@ describe("PasswordInput", () => {
       });
       await wrapper.find("button.toggle-button").trigger("click");
       expect(wrapper.find("button.toggle-button").attributes("aria-label")).toBe(
-        "パスワードを非表示"
+        "パスワードを非表示",
       );
     });
 

--- a/app/components/molecules/PieceCategoryList.vue
+++ b/app/components/molecules/PieceCategoryList.vue
@@ -13,7 +13,7 @@ const categories = computed(() =>
     { kind: "era" as Kind, label: "時代", value: props.piece.era },
     { kind: "formation" as Kind, label: "編成", value: props.piece.formation },
     { kind: "region" as Kind, label: "地域", value: props.piece.region },
-  ].filter((c): c is { kind: Kind; label: string; value: string } => c.value !== undefined)
+  ].filter((c): c is { kind: Kind; label: string; value: string } => c.value !== undefined),
 );
 </script>
 

--- a/app/components/molecules/PieceItem.test.ts
+++ b/app/components/molecules/PieceItem.test.ts
@@ -192,7 +192,7 @@ describe("PieceItem", () => {
         props: { piece: samplePieceWithYouTubeUrl, composerName: "ベートーヴェン" },
       });
       expect(wrapper.find("img.youtube-thumbnail").attributes("alt")).toBe(
-        "交響曲第9番 ニ短調 Op.125 の動画サムネイル"
+        "交響曲第9番 ニ短調 Op.125 の動画サムネイル",
       );
     });
 
@@ -201,7 +201,7 @@ describe("PieceItem", () => {
         props: { piece: samplePieceWithYouTubeUrl, composerName: "ベートーヴェン" },
       });
       expect(wrapper.find(".piece-thumbnail").attributes("aria-label")).toBe(
-        "交響曲第9番 ニ短調 Op.125 の動画を再生"
+        "交響曲第9番 ニ短調 Op.125 の動画を再生",
       );
     });
 

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -15,7 +15,7 @@ const emit = defineEmits<{
 }>();
 
 const hasYouTubeThumbnail = computed(
-  () => props.piece.videoUrl !== undefined && isYouTubeUrl(props.piece.videoUrl)
+  () => props.piece.videoUrl !== undefined && isYouTubeUrl(props.piece.videoUrl),
 );
 
 const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイル`);

--- a/app/components/molecules/VideoPlayer.test.ts
+++ b/app/components/molecules/VideoPlayer.test.ts
@@ -18,7 +18,7 @@ describe("VideoPlayer", () => {
         props: { videoUrl: youtubeUrl },
       });
       expect(wrapper.find("iframe").attributes("src")).toContain(
-        "https://www.youtube.com/embed/abc123"
+        "https://www.youtube.com/embed/abc123",
       );
     });
 

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -21,7 +21,7 @@ declare global {
     | {
         Player: new (
           elementId: string,
-          options: { events: { onStateChange: (event: { data: number }) => void } }
+          options: { events: { onStateChange: (event: { data: number }) => void } },
         ) => YTPlayer;
         PlayerState: { PLAYING: number };
       }

--- a/app/components/organisms/ComposerForm.test.ts
+++ b/app/components/organisms/ComposerForm.test.ts
@@ -32,7 +32,7 @@ describe("ComposerForm", () => {
       expect((nameInput.element as HTMLInputElement).value).toBe("ベートーヴェン");
       expect((wrapper.find("#era").element as HTMLSelectElement).value).toBe("古典派");
       expect((wrapper.find("#region").element as HTMLSelectElement).value).toBe(
-        "ドイツ・オーストリア"
+        "ドイツ・オーストリア",
       );
     });
   });

--- a/app/components/organisms/ComposerForm.vue
+++ b/app/components/organisms/ComposerForm.vue
@@ -30,7 +30,7 @@ watch(
     form.region = initialValues?.region ?? "";
     form.imageUrl = initialValues?.imageUrl ?? "";
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 function handleSubmit() {

--- a/app/components/organisms/ConcertLogForm.test.ts
+++ b/app/components/organisms/ConcertLogForm.test.ts
@@ -35,7 +35,7 @@ describe("ConcertLogForm", () => {
     it("コンサート名入力欄が表示される", async () => {
       const wrapper = await mountSuspended(ConcertLogForm);
       expect(
-        wrapper.find('input[placeholder="例: 〇〇交響楽団 定期演奏会 第123回"]').exists()
+        wrapper.find('input[placeholder="例: 〇〇交響楽団 定期演奏会 第123回"]').exists(),
       ).toBe(true);
     });
 

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -55,7 +55,7 @@ watch(
     if (selectedPieces.value.length === 0 && props.initialValues?.pieceIds !== undefined) {
       selectedPieces.value = resolveInitialPieces();
     }
-  }
+  },
 );
 
 function addPiece() {

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -85,7 +85,7 @@ mockNuxtImport("usePiecesAll", () =>
     error: ref(null),
     pending: ref(false),
     refresh: vi.fn(),
-  })
+  }),
 );
 
 mockNuxtImport("useComposersAll", () =>
@@ -94,7 +94,7 @@ mockNuxtImport("useComposersAll", () =>
     error: ref(null),
     pending: ref(false),
     refresh: vi.fn(),
-  })
+  }),
 );
 
 describe("ListeningLogForm", () => {

--- a/app/components/organisms/ListeningLogStatistics.vue
+++ b/app/components/organisms/ListeningLogStatistics.vue
@@ -9,21 +9,21 @@ const ratingRows = computed(() =>
   ([5, 4, 3, 2, 1] as const).map((rating) => ({
     rating,
     count: props.statistics.ratingDistribution[rating],
-  }))
+  })),
 );
 
 const ratingMax = computed(() => Math.max(1, ...ratingRows.value.map((r) => r.count)));
 
 const composerMax = computed(() =>
-  Math.max(1, ...props.statistics.topComposers.map((c) => c.count))
+  Math.max(1, ...props.statistics.topComposers.map((c) => c.count)),
 );
 
 const monthlyMax = computed(() =>
-  Math.max(1, ...props.statistics.monthlyTrend.map((m) => m.count))
+  Math.max(1, ...props.statistics.monthlyTrend.map((m) => m.count)),
 );
 
 const averageDisplay = computed(() =>
-  props.statistics.total === 0 ? "-" : props.statistics.averageRating.toFixed(2)
+  props.statistics.total === 0 ? "-" : props.statistics.averageRating.toFixed(2),
 );
 
 const formatMonthLabel = (month: string): string => {

--- a/app/components/organisms/PieceForm.test.ts
+++ b/app/components/organisms/PieceForm.test.ts
@@ -88,7 +88,7 @@ describe("PieceForm", () => {
       expect((titleInput.element as HTMLInputElement).value).toBe("交響曲第9番");
       expect((composerSelect.element as HTMLSelectElement).value).toBe(COMPOSER_ID_BEETHOVEN);
       expect((videoUrlInput.element as HTMLInputElement).value).toBe(
-        "https://www.youtube.com/watch?v=abc"
+        "https://www.youtube.com/watch?v=abc",
       );
     });
 
@@ -145,7 +145,7 @@ describe("PieceForm", () => {
       expect((wrapper.find("#era").element as HTMLSelectElement).value).toBe("古典派");
       expect((wrapper.find("#formation").element as HTMLSelectElement).value).toBe("管弦楽");
       expect((wrapper.find("#region").element as HTMLSelectElement).value).toBe(
-        "ドイツ・オーストリア"
+        "ドイツ・オーストリア",
       );
     });
 

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -23,7 +23,7 @@ const props = withDefaults(
     submitLabel: undefined,
     composers: () => [],
     composersPending: false,
-  }
+  },
 );
 
 const emit = defineEmits<{
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 }>();
 
 const composerOptions = computed(() =>
-  props.composers.map((c) => ({ value: c.id, label: c.name }))
+  props.composers.map((c) => ({ value: c.id, label: c.name })),
 );
 
 const form = reactive({
@@ -55,7 +55,7 @@ watch(
     form.formation = initialValues?.formation ?? "";
     form.region = initialValues?.region ?? "";
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 function handleSubmit() {

--- a/app/components/templates/ConcertLogDetailTemplate.test.ts
+++ b/app/components/templates/ConcertLogDetailTemplate.test.ts
@@ -68,7 +68,7 @@ beforeEach(() => {
   mockDeleteLog.mockClear();
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
 });
 
@@ -127,7 +127,7 @@ describe("ConcertLogDetailTemplate", () => {
     it("confirm でキャンセルすると deleteLog が呼ばれない", async () => {
       vi.stubGlobal(
         "confirm",
-        vi.fn(() => false)
+        vi.fn(() => false),
       );
       const wrapper = await mountSuspended(ConcertLogDetailTemplate, {
         props: { log: sampleLog },

--- a/app/components/templates/ListeningLogDetailTemplate.test.ts
+++ b/app/components/templates/ListeningLogDetailTemplate.test.ts
@@ -35,7 +35,7 @@ beforeEach(() => {
   mockDeleteLog.mockClear();
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
 });
 
@@ -94,7 +94,7 @@ describe("ListeningLogDetailTemplate", () => {
     it("confirm でキャンセルすると deleteLog が呼ばれない", async () => {
       vi.stubGlobal(
         "confirm",
-        vi.fn(() => false)
+        vi.fn(() => false),
       );
       const wrapper = await mountSuspended(ListeningLogDetailTemplate, {
         props: { log: sampleLog },

--- a/app/components/templates/ListeningLogEditTemplate.test.ts
+++ b/app/components/templates/ListeningLogEditTemplate.test.ts
@@ -5,7 +5,7 @@ import type { ListeningLog } from "~/types";
 mockNuxtImport("usePiecesAll", () =>
   vi
     .fn()
-    .mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false), refresh: vi.fn() })
+    .mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false), refresh: vi.fn() }),
 );
 
 const sampleLog: ListeningLog = {

--- a/app/components/templates/ListeningLogNewTemplate.test.ts
+++ b/app/components/templates/ListeningLogNewTemplate.test.ts
@@ -4,7 +4,7 @@ import ListeningLogNewTemplate from "./ListeningLogNewTemplate.vue";
 mockNuxtImport("usePiecesAll", () =>
   vi
     .fn()
-    .mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false), refresh: vi.fn() })
+    .mockReturnValue({ data: ref([]), error: ref(null), pending: ref(false), refresh: vi.fn() }),
 );
 
 describe("ListeningLogNewTemplate", () => {

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -156,7 +156,7 @@ describe("useAuth", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ email: "user@example.com", password: "ValidPassword123" }),
-        })
+        }),
       );
     });
 
@@ -218,7 +218,7 @@ describe("useAuth", () => {
       expect(result.accessToken).toBe("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...");
       expect(localStorage.getItem(ID_TOKEN_KEY)).toBe("eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...");
       expect(localStorage.getItem(REFRESH_TOKEN_KEY)).toBe(
-        "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIi..."
+        "eyJjdHkiOiJKV1QiLCJlbmMiOiJBMjU2R0NNIi...",
       );
       expect(localStorage.getItem(TOKEN_EXPIRES_AT_KEY)).not.toBeNull();
       expect(mockFetch).toHaveBeenCalledWith(
@@ -226,7 +226,7 @@ describe("useAuth", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ email: "user@example.com", password: "ValidPassword123" }),
-        })
+        }),
       );
     });
 
@@ -545,7 +545,7 @@ describe("useAuth", () => {
       mockFetch.mockReturnValue(
         new Promise((resolve) => {
           resolveFetch = resolve;
-        })
+        }),
       );
 
       const { refreshTokens, clearTokens } = useAuth();
@@ -587,7 +587,7 @@ describe("useAuth", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ email: "user@example.com", code: "123456" }),
-        })
+        }),
       );
     });
 
@@ -637,7 +637,7 @@ describe("useAuth", () => {
       loginWithGoogle();
 
       expect(globalThis.location.href).toContain(
-        "test.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize"
+        "test.auth.ap-northeast-1.amazoncognito.com/oauth2/authorize",
       );
       expect(globalThis.location.href).toContain("identity_provider=Google");
       expect(globalThis.location.href).toContain("response_type=code");
@@ -663,7 +663,7 @@ describe("useAuth", () => {
 
       expect(mockFetch).toHaveBeenCalledWith(
         "https://test.auth.ap-northeast-1.amazoncognito.com/oauth2/token",
-        expect.objectContaining({ method: "POST" })
+        expect.objectContaining({ method: "POST" }),
       );
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBe("access-token");
       expect(localStorage.getItem(ID_TOKEN_KEY)).toBe("id-token");
@@ -704,7 +704,7 @@ describe("useAuth", () => {
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({ email: "user@example.com" }),
-        })
+        }),
       );
     });
 

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -439,7 +439,7 @@ export const useAuth = () => {
   };
 
   const handleOAuthCallback = async (
-    code: string
+    code: string,
   ): Promise<{ success: boolean; error?: string }> => {
     const redirectUri = `${globalThis.location.origin}/auth/callback`;
     const body = new URLSearchParams({

--- a/app/composables/useAuthenticatedApi.ts
+++ b/app/composables/useAuthenticatedApi.ts
@@ -48,7 +48,7 @@ export const useAuthenticatedApi = () => {
   // 同一リクエストで二重リトライは発生しない設計となっている。
   const doFetch = async (
     url: string,
-    options: { method?: string; headers?: Record<string, string>; body?: string }
+    options: { method?: string; headers?: Record<string, string>; body?: string },
   ): Promise<Response> => {
     try {
       return await fetch(url, {
@@ -59,14 +59,14 @@ export const useAuthenticatedApi = () => {
       throw new Error(
         error instanceof Error
           ? error.message
-          : "Network error occurred. Please check your connection."
+          : "Network error occurred. Please check your connection.",
       );
     }
   };
 
   const authenticatedFetch = async (
     url: string,
-    options: { method?: string; headers?: Record<string, string>; body?: string } = {}
+    options: { method?: string; headers?: Record<string, string>; body?: string } = {},
   ): Promise<Response> => {
     const response = await doFetch(url, options);
 

--- a/app/composables/useComposers.test.ts
+++ b/app/composables/useComposers.test.ts
@@ -104,7 +104,7 @@ describe("useComposersPaginated", () => {
             Authorization: "Bearer test-id-token",
             "Content-Type": "application/json",
           }),
-        })
+        }),
       );
     });
 
@@ -122,7 +122,7 @@ describe("useComposersPaginated", () => {
             Authorization: "Bearer test-id-token",
             "Content-Type": "application/json",
           }),
-        })
+        }),
       );
     });
 
@@ -138,13 +138,13 @@ describe("useComposersPaginated", () => {
           headers: expect.objectContaining({
             Authorization: "Bearer test-id-token",
           }),
-        })
+        }),
       );
     });
 
     it("createComposer が 401 を返したら throwResponseError がエラーにする", async () => {
       mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 })
+        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 }),
       );
       const c = useComposersPaginated();
       await expect(c.createComposer({ name: "x" })).rejects.toThrow();

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -20,7 +20,7 @@ export const useComposersPaginated = () => {
     putJson<Composer>(`${apiBase}/composers/${id}`, input);
 
   const pagination = usePaginatedList<Composer>((cursor) =>
-    fetchComposersPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_DEFAULT, cursor })
+    fetchComposersPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_DEFAULT, cursor }),
   );
 
   const createComposer = async (input: CreateComposerInput) => {
@@ -67,7 +67,7 @@ export const useComposersAll = () => {
       const res = await fetchComposersPage(apiBase, { limit: COMPOSERS_PAGE_SIZE_MAX });
       if (res.nextCursor !== null) {
         throw new Error(
-          `useComposersAll: composers exceed single-scan limit (${COMPOSERS_PAGE_SIZE_MAX}). Switch to paginated/search UI.`
+          `useComposersAll: composers exceed single-scan limit (${COMPOSERS_PAGE_SIZE_MAX}). Switch to paginated/search UI.`,
         );
       }
       data.value = res.items;

--- a/app/composables/useConcertLogs.test.ts
+++ b/app/composables/useConcertLogs.test.ts
@@ -60,11 +60,11 @@ describe("useConcertLogs", () => {
       mockUseFetch.mockImplementation(
         (
           _url: unknown,
-          options: { onResponseError?: (ctx: { response: { status: number } }) => Promise<void> }
+          options: { onResponseError?: (ctx: { response: { status: number } }) => Promise<void> },
         ) => {
           capturedOnResponseError = options?.onResponseError;
           return { data: null, error: null, pending: false, refresh: vi.fn() };
-        }
+        },
       );
 
       useConcertLogs();
@@ -83,11 +83,11 @@ describe("useConcertLogs", () => {
       mockUseFetch.mockImplementation(
         (
           _url: unknown,
-          options: { onResponseError?: (ctx: { response: { status: number } }) => void }
+          options: { onResponseError?: (ctx: { response: { status: number } }) => void },
         ) => {
           capturedOnResponseError = options?.onResponseError;
           return { data: null, error: null, pending: false, refresh: vi.fn() };
-        }
+        },
       );
 
       useConcertLogs();
@@ -121,7 +121,7 @@ describe("useConcertLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 
@@ -140,7 +140,7 @@ describe("useConcertLogs", () => {
           title: "定期演奏会",
           concertDate: "2024-01-15T19:00:00.000Z",
           venue: "サントリーホール",
-        })
+        }),
       ).rejects.toThrow("Unauthorized");
 
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
@@ -162,7 +162,7 @@ describe("useConcertLogs", () => {
           title: "定期演奏会",
           concertDate: "2024-01-15T19:00:00.000Z",
           venue: "サントリーホール",
-        })
+        }),
       ).rejects.toThrow("Bad Request");
     });
   });
@@ -187,7 +187,7 @@ describe("useConcertLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 
@@ -240,7 +240,7 @@ describe("useConcertLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 

--- a/app/composables/useListeningLogFilter.test.ts
+++ b/app/composables/useListeningLogFilter.test.ts
@@ -59,7 +59,7 @@ describe("filterListeningLogs", () => {
   it("日付範囲でフィルタする", () => {
     const result = filterListeningLogs(
       logs,
-      makeState({ fromDate: "2024-02-01", toDate: "2024-04-30" })
+      makeState({ fromDate: "2024-02-01", toDate: "2024-04-30" }),
     );
     expect(result.map((l) => l.id)).toEqual(["2"]);
   });
@@ -67,7 +67,7 @@ describe("filterListeningLogs", () => {
   it("条件を組み合わせて AND で評価する", () => {
     const result = filterListeningLogs(
       logs,
-      makeState({ keyword: "交響曲", favoriteOnly: true, rating: "4" })
+      makeState({ keyword: "交響曲", favoriteOnly: true, rating: "4" }),
     );
     expect(result.map((l) => l.id)).toEqual(["3"]);
   });
@@ -102,7 +102,7 @@ describe("useListeningLogFilter", () => {
 });
 
 function makeState(
-  overrides: Partial<ReturnType<typeof useListeningLogFilter>["state"]["value"]> = {}
+  overrides: Partial<ReturnType<typeof useListeningLogFilter>["state"]["value"]> = {},
 ): ReturnType<typeof useListeningLogFilter>["state"]["value"] {
   return {
     keyword: "",

--- a/app/composables/useListeningLogFilter.ts
+++ b/app/composables/useListeningLogFilter.ts
@@ -62,14 +62,14 @@ const matchesDateRange = (log: ListeningLog, fromDate: string, toDate: string): 
 
 export const filterListeningLogs = (
   logs: ListeningLog[],
-  state: ListeningLogFilterState
+  state: ListeningLogFilterState,
 ): ListeningLog[] =>
   logs.filter(
     (log) =>
       matchesKeyword(log, state.keyword) &&
       matchesRating(log, state.rating) &&
       matchesFavorite(log, state.favoriteOnly) &&
-      matchesDateRange(log, state.fromDate, state.toDate)
+      matchesDateRange(log, state.fromDate, state.toDate),
   );
 
 export const useListeningLogFilter = (logs: Ref<ListeningLog[] | null | undefined>) => {

--- a/app/composables/useListeningLogStatistics.test.ts
+++ b/app/composables/useListeningLogStatistics.test.ts
@@ -58,7 +58,7 @@ describe("computeStatistics", () => {
         log({ id: "5", composer: "ブラームス" }),
         log({ id: "6", composer: "ブラームス" }),
       ],
-      { topComposerLimit: 2 }
+      { topComposerLimit: 2 },
     );
     expect(stats.topComposers).toEqual([
       { composer: "ブラームス", count: 3 },

--- a/app/composables/useListeningLogStatistics.ts
+++ b/app/composables/useListeningLogStatistics.ts
@@ -44,7 +44,7 @@ const formatMonth = (iso: string): string | null => {
 
 export const computeStatistics = (
   logs: ListeningLog[],
-  options: { topComposerLimit?: number; monthlyTrendLimit?: number } = {}
+  options: { topComposerLimit?: number; monthlyTrendLimit?: number } = {},
 ): ListeningLogStatistics => {
   const topComposerLimit = options.topComposerLimit ?? 5;
   const monthlyTrendLimit = options.monthlyTrendLimit ?? 12;
@@ -99,7 +99,7 @@ export const computeStatistics = (
 
 export const useListeningLogStatistics = (
   logs: Ref<ListeningLog[] | null | undefined>,
-  options: { topComposerLimit?: number; monthlyTrendLimit?: number } = {}
+  options: { topComposerLimit?: number; monthlyTrendLimit?: number } = {},
 ) => {
   const statistics = computed(() => computeStatistics(logs.value ?? [], options));
   return { statistics };

--- a/app/composables/useListeningLogs.test.ts
+++ b/app/composables/useListeningLogs.test.ts
@@ -60,11 +60,11 @@ describe("useListeningLogs", () => {
       mockUseFetch.mockImplementation(
         (
           _url: unknown,
-          options: { onResponseError?: (ctx: { response: { status: number } }) => Promise<void> }
+          options: { onResponseError?: (ctx: { response: { status: number } }) => Promise<void> },
         ) => {
           capturedOnResponseError = options?.onResponseError;
           return { data: null, error: null, pending: false, refresh: vi.fn() };
-        }
+        },
       );
 
       useListeningLogs();
@@ -83,11 +83,11 @@ describe("useListeningLogs", () => {
       mockUseFetch.mockImplementation(
         (
           _url: unknown,
-          options: { onResponseError?: (ctx: { response: { status: number } }) => void }
+          options: { onResponseError?: (ctx: { response: { status: number } }) => void },
         ) => {
           capturedOnResponseError = options?.onResponseError;
           return { data: null, error: null, pending: false, refresh: vi.fn() };
-        }
+        },
       );
 
       useListeningLogs();
@@ -123,7 +123,7 @@ describe("useListeningLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 
@@ -144,7 +144,7 @@ describe("useListeningLogs", () => {
           piece: "ゴルトベルク変奏曲",
           rating: 5,
           isFavorite: false,
-        })
+        }),
       ).rejects.toThrow("Unauthorized");
 
       expect(localStorage.getItem(ACCESS_TOKEN_KEY)).toBeNull();
@@ -168,7 +168,7 @@ describe("useListeningLogs", () => {
           piece: "ゴルトベルク変奏曲",
           rating: 5,
           isFavorite: false,
-        })
+        }),
       ).rejects.toThrow("Bad Request");
     });
   });
@@ -193,7 +193,7 @@ describe("useListeningLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 
@@ -246,7 +246,7 @@ describe("useListeningLogs", () => {
           headers: expect.objectContaining({
             Authorization: `Bearer ${token}`,
           }),
-        })
+        }),
       );
     });
 

--- a/app/composables/usePaginatedList.ts
+++ b/app/composables/usePaginatedList.ts
@@ -11,7 +11,7 @@ export type PageResult<T> = { items: T[]; nextCursor: string | null };
  */
 export const fetchCursorPage = <T>(
   url: string,
-  options: { limit: number; cursor?: string }
+  options: { limit: number; cursor?: string },
 ): Promise<PageResult<T>> => {
   const query: { limit: number; cursor?: string } = { limit: options.limit };
   if (options.cursor !== undefined) {

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -134,7 +134,7 @@ describe("usePiecesPaginated", () => {
       mockDollarFetch.mockReturnValueOnce(
         new Promise<PageResult<Piece>>((resolve) => {
           resolvePage = resolve;
-        })
+        }),
       );
       const p = usePiecesPaginated();
       const first = p.loadMore();
@@ -218,7 +218,7 @@ describe("usePiecesPaginated", () => {
             Authorization: "Bearer test-id-token",
             "Content-Type": "application/json",
           }),
-        })
+        }),
       );
     });
 
@@ -236,17 +236,17 @@ describe("usePiecesPaginated", () => {
             Authorization: "Bearer test-id-token",
             "Content-Type": "application/json",
           }),
-        })
+        }),
       );
     });
 
     it("createPiece が 401 を返したら throwResponseError がエラーにする", async () => {
       mockFetch.mockResolvedValueOnce(
-        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 })
+        new Response(JSON.stringify({ message: "Unauthorized" }), { status: 401 }),
       );
       const p = usePiecesPaginated();
       await expect(
-        p.createPiece({ title: "x", composerId: "00000000-0000-4000-8000-000000000001" })
+        p.createPiece({ title: "x", composerId: "00000000-0000-4000-8000-000000000001" }),
       ).rejects.toThrow();
     });
   });

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -34,7 +34,7 @@ export const usePiecesPaginated = () => {
   const apiBase = useApiBase();
   const { postPiece, putPiece } = usePieceMutations();
   const pagination = usePaginatedList<Piece>((cursor) =>
-    fetchPiecesPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor })
+    fetchPiecesPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor }),
   );
 
   const createPiece = async (input: CreatePieceInput) => {
@@ -87,7 +87,7 @@ export const usePiecesAll = () => {
           consecutiveEmpty += 1;
           if (consecutiveEmpty > PIECES_ALL_MAX_EMPTY_PAGES) {
             throw new Error(
-              `usePiecesAll: exceeded consecutive empty pages (${PIECES_ALL_MAX_EMPTY_PAGES})`
+              `usePiecesAll: exceeded consecutive empty pages (${PIECES_ALL_MAX_EMPTY_PAGES})`,
             );
           }
         } else {

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -6,7 +6,7 @@ watch(
   () => route.path,
   () => {
     isLoggedIn.value = isAuthenticated();
-  }
+  },
 );
 </script>
 

--- a/app/pages/auth/callback.test.ts
+++ b/app/pages/auth/callback.test.ts
@@ -31,7 +31,7 @@ describe("CallbackPage", () => {
       mockHandleOAuthCallback.mockReturnValue(
         new Promise<{ success: boolean }>((resolve) => {
           resolveCallback = resolve;
-        })
+        }),
       );
 
       const wrapper = await mountSuspended(CallbackPage, {

--- a/app/pages/composers/index.test.ts
+++ b/app/pages/composers/index.test.ts
@@ -20,7 +20,7 @@ const { sampleComposers, mockLoadMore, mockReset, mockRetry, mockDeleteComposer 
       mockRetry: vi.fn(),
       mockDeleteComposer: vi.fn(),
     };
-  }
+  },
 );
 
 const composersItems = ref<Composer[]>([]);
@@ -41,7 +41,7 @@ mockNuxtImport("useComposersPaginated", () =>
     createComposer: vi.fn(),
     updateComposer: vi.fn(),
     deleteComposer: mockDeleteComposer,
-  }))
+  })),
 );
 
 const mockFetch = vi.fn();
@@ -72,7 +72,7 @@ beforeEach(() => {
   vi.stubGlobal("$fetch", mockFetch);
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
   vi.stubGlobal("alert", vi.fn());
   vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
@@ -120,7 +120,7 @@ describe("ComposersPage", () => {
     it("削除キャンセル時は deleteComposer が呼ばれない", async () => {
       vi.stubGlobal(
         "confirm",
-        vi.fn(() => false)
+        vi.fn(() => false),
       );
       const wrapper = await mountSuspended(ComposersPage);
       await flushPromises();

--- a/app/pages/listening-logs/[id]/index.test.ts
+++ b/app/pages/listening-logs/[id]/index.test.ts
@@ -39,7 +39,7 @@ beforeEach(() => {
   mockDeleteLog.mockClear();
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
 });
 
@@ -69,7 +69,7 @@ describe("ListeningLogDetailPage（結合）", () => {
   it("キャンセル時は deleteLog が呼ばれない", async () => {
     vi.stubGlobal(
       "confirm",
-      vi.fn(() => false)
+      vi.fn(() => false),
     );
     const wrapper = await mountSuspended(ListeningLogDetailPage);
     await wrapper.find(".btn-danger").trigger("click");

--- a/app/pages/listening-logs/index.test.ts
+++ b/app/pages/listening-logs/index.test.ts
@@ -48,7 +48,7 @@ beforeEach(() => {
   mockRefresh.mockClear();
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
 });
 
@@ -92,7 +92,7 @@ describe("ListeningLogsPage（削除フロー結合）", () => {
   it("キャンセル時は deleteLog が呼ばれない", async () => {
     vi.stubGlobal(
       "confirm",
-      vi.fn(() => false)
+      vi.fn(() => false),
     );
     const wrapper = await mountSuspended(ListeningLogsPage);
     await wrapper.findAll(".btn-danger")[0].trigger("click");

--- a/app/pages/pieces/[id]/index.test.ts
+++ b/app/pages/pieces/[id]/index.test.ts
@@ -81,7 +81,7 @@ describe("PieceDetailPage", () => {
         rating: 5,
         isFavorite: true,
         memo: "最高",
-      })
+      }),
     );
   });
 });

--- a/app/pages/pieces/index.test.ts
+++ b/app/pages/pieces/index.test.ts
@@ -48,7 +48,7 @@ mockNuxtImport("usePiecesPaginated", () =>
     retry: mockRetry,
     createPiece: vi.fn(),
     updatePiece: vi.fn(),
-  }))
+  })),
 );
 
 mockNuxtImport("useComposersAll", () =>
@@ -57,7 +57,7 @@ mockNuxtImport("useComposersAll", () =>
     pending: ref(false),
     error: ref(null),
     refresh: vi.fn().mockResolvedValue(undefined),
-  }))
+  })),
 );
 
 const mockFetch = vi.fn();
@@ -88,7 +88,7 @@ beforeEach(() => {
   vi.stubGlobal("$fetch", mockFetch);
   vi.stubGlobal(
     "confirm",
-    vi.fn(() => true)
+    vi.fn(() => true),
   );
   vi.stubGlobal("alert", vi.fn());
   vi.stubGlobal("IntersectionObserver", MockIntersectionObserver);
@@ -178,7 +178,7 @@ describe("PiecesPage", () => {
     it("削除キャンセル時は $fetch が呼ばれない", async () => {
       vi.stubGlobal(
         "confirm",
-        vi.fn(() => false)
+        vi.fn(() => false),
       );
       const wrapper = await mountSuspended(PiecesPage);
       await flushPromises();

--- a/app/utils/select-options.ts
+++ b/app/utils/select-options.ts
@@ -3,7 +3,7 @@
  * Piece / Composer など、列挙型の定数配列をフォームの選択肢に流し込むときに使う。
  */
 export function toSelectOptions<T extends string>(
-  values: readonly T[]
+  values: readonly T[],
 ): { value: T; label: string }[] {
   return values.map((v) => ({ value: v, label: v }));
 }

--- a/app/utils/video.test.ts
+++ b/app/utils/video.test.ts
@@ -39,13 +39,13 @@ describe("extractYouTubeVideoId", () => {
 describe("toYouTubeEmbedUrl", () => {
   it("youtube.com URL を embed URL に変換する", () => {
     expect(toYouTubeEmbedUrl("https://www.youtube.com/watch?v=abc123")).toBe(
-      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0"
+      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0",
     );
   });
 
   it("youtu.be URL を embed URL に変換する", () => {
     expect(toYouTubeEmbedUrl("https://youtu.be/abc123")).toBe(
-      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0"
+      "https://www.youtube.com/embed/abc123?enablejsapi=1&rel=0&fs=0",
     );
   });
 });

--- a/backend/scripts/setup-test-db.mjs
+++ b/backend/scripts/setup-test-db.mjs
@@ -52,7 +52,7 @@ async function main() {
       AttributeDefinitions: [{ AttributeName: "id", AttributeType: "S" }],
       KeySchema: [{ AttributeName: "id", KeyType: "HASH" }],
       BillingMode: "PAY_PER_REQUEST",
-    })
+    }),
   );
 
   console.log(`テーブルを作成しました: ${TABLE_NAME}`);

--- a/backend/scripts/sync-dynamodb.mjs
+++ b/backend/scripts/sync-dynamodb.mjs
@@ -76,7 +76,7 @@ async function batchWrite(tableName, writeRequests) {
       const result = await client.send(
         new BatchWriteItemCommand({
           RequestItems: { [tableName]: unprocessed },
-        })
+        }),
       );
 
       unprocessed = result.UnprocessedItems?.[tableName] ?? [];
@@ -85,7 +85,7 @@ async function batchWrite(tableName, writeRequests) {
         retries++;
         if (retries > 5) {
           throw new Error(
-            `BatchWriteItem: ${unprocessed.length} 件の処理に失敗しました（${retries} 回リトライ）`
+            `BatchWriteItem: ${unprocessed.length} 件の処理に失敗しました（${retries} 回リトライ）`,
           );
         }
         const waitMs = Math.pow(2, retries) * 100;
@@ -148,7 +148,7 @@ async function syncTable(sourceTable, destTable, keyAttributes, transform) {
   if (destItems.length > 0) {
     const sourceKeySet = new Set(sourceItems.map((item) => itemKey(item, keyAttributes)));
     const deleteTargets = destItems.filter(
-      (item) => !sourceKeySet.has(itemKey(item, keyAttributes))
+      (item) => !sourceKeySet.has(itemKey(item, keyAttributes)),
     );
 
     if (deleteTargets.length > 0) {

--- a/backend/src/domain/auth-error.ts
+++ b/backend/src/domain/auth-error.ts
@@ -99,7 +99,7 @@ export type AuthContext = "register" | "login" | "verify" | "refresh" | "resend"
 
 export const mapCognitoError = (
   errorName: string,
-  context: AuthContext
+  context: AuthContext,
 ): AuthErrorResponse | undefined => {
   // TooManyRequestsException は全コンテキスト共通
   if (errorName === "TooManyRequestsException") {

--- a/backend/src/domain/auth.ts
+++ b/backend/src/domain/auth.ts
@@ -21,12 +21,12 @@ export type AuthRepository = {
   refreshToken(token: string): Promise<RefreshedTokens>;
   listUsersByEmail(
     userPoolId: string,
-    email: string
+    email: string,
   ): Promise<{ username: string; status: string }[]>;
   linkProviderForUser(
     userPoolId: string,
     destinationUsername: string,
     providerName: string,
-    providerUserId: string
+    providerUserId: string,
   ): Promise<void>;
 };

--- a/backend/src/domain/entity-helpers.ts
+++ b/backend/src/domain/entity-helpers.ts
@@ -7,7 +7,7 @@ type BaseEntityFields = { id: string; createdAt: string; updatedAt: string };
 export function buildUpdateProps<TProps extends BaseEntityFields>(
   current: TProps,
   input: Partial<TProps>,
-  clearableFields: readonly string[]
+  clearableFields: readonly string[],
 ): TProps {
   const merged: TProps = {
     ...current,
@@ -17,6 +17,6 @@ export function buildUpdateProps<TProps extends BaseEntityFields>(
     updatedAt: new Date().toISOString(),
   };
   return Object.fromEntries(
-    Object.entries(merged).filter(([key, value]) => !clearableFields.includes(key) || value !== "")
+    Object.entries(merged).filter(([key, value]) => !clearableFields.includes(key) || value !== ""),
   ) as TProps;
 }

--- a/backend/src/domain/value-objects/ids.test.ts
+++ b/backend/src/domain/value-objects/ids.test.ts
@@ -10,7 +10,7 @@ describe("IdValueObject", () => {
         const id = Ctor.generate();
         expect(id.value).toBeUUID();
         expect(String(id)).toBe(id.value);
-      }
+      },
     );
 
     it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
@@ -18,14 +18,14 @@ describe("IdValueObject", () => {
       (Ctor) => {
         const id = Ctor.from("abc-123");
         expect(id.value).toBe("abc-123");
-      }
+      },
     );
 
     it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
       "%s.from() は空文字列を拒否する",
       (Ctor) => {
         expect(() => Ctor.from("")).toThrow(TypeError);
-      }
+      },
     );
 
     it.each([ListeningLogId, ConcertLogId, PieceId, ComposerId, UserId] as const)(
@@ -35,7 +35,7 @@ describe("IdValueObject", () => {
         expect(() => Ctor.from(undefined as unknown as string)).toThrow(TypeError);
         expect(() => Ctor.from(null as unknown as string)).toThrow(TypeError);
         expect(() => Ctor.from(123 as unknown as string)).toThrow(TypeError);
-      }
+      },
     );
   });
 

--- a/backend/src/handlers/auth/login.test.ts
+++ b/backend/src/handlers/auth/login.test.ts
@@ -45,7 +45,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -59,7 +59,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -74,7 +74,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -90,7 +90,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -103,7 +103,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -126,7 +126,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(200);
@@ -154,7 +154,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(401);
@@ -175,7 +175,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(401);
@@ -196,7 +196,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(403);
@@ -217,7 +217,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(429);
@@ -238,7 +238,7 @@ describe("POST /auth/login", () => {
           path: "/auth/login",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(500);

--- a/backend/src/handlers/auth/pre-signup.test.ts
+++ b/backend/src/handlers/auth/pre-signup.test.ts
@@ -68,13 +68,13 @@ describe("pre-signup", () => {
       expect(result).toEqual(event);
       expect(mockRepo.listUsersByEmail).toHaveBeenCalledWith(
         "ap-northeast-1_testPoolId",
-        "user@example.com"
+        "user@example.com",
       );
       expect(mockRepo.linkProviderForUser).toHaveBeenCalledWith(
         "ap-northeast-1_testPoolId",
         "existing-user",
         "Google",
-        "100749370741417953110"
+        "100749370741417953110",
       );
     });
 
@@ -83,7 +83,7 @@ describe("pre-signup", () => {
         { username: "existing-user", status: "CONFIRMED" },
       ]);
       mockRepo.linkProviderForUser.mockRejectedValueOnce(
-        new Error("SourceProviderName must match a Provider that is configured for the User Pool")
+        new Error("SourceProviderName must match a Provider that is configured for the User Pool"),
       );
 
       const event = makeEvent({ userName: "google_100749370741417953110" });

--- a/backend/src/handlers/auth/refresh.test.ts
+++ b/backend/src/handlers/auth/refresh.test.ts
@@ -44,7 +44,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("refreshToken");
@@ -58,7 +58,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -80,7 +80,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(200);
@@ -107,7 +107,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(401);
@@ -128,7 +128,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(429);
@@ -149,7 +149,7 @@ describe("POST /auth/refresh", () => {
           path: "/auth/refresh",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(500);

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -45,7 +45,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -59,7 +59,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -73,7 +73,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -89,7 +89,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -103,7 +103,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -117,7 +117,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -131,7 +131,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -145,7 +145,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("password");
@@ -163,7 +163,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(201);
@@ -187,7 +187,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -207,7 +207,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -228,7 +228,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(500);
@@ -247,7 +247,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(429);
@@ -264,7 +264,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -277,7 +277,7 @@ describe("POST /auth/register", () => {
           path: "/auth/register",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -44,7 +44,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -57,7 +57,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -75,7 +75,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(200);
@@ -99,7 +99,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -119,7 +119,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -138,7 +138,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(429);
@@ -157,7 +157,7 @@ describe("POST /auth/resend-verification-code", () => {
           path: "/auth/resend-verification-code",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(500);

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -45,7 +45,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -58,7 +58,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -71,7 +71,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toContain("email");
@@ -85,7 +85,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -102,7 +102,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(200);
@@ -124,7 +124,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -142,7 +142,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -162,7 +162,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(400);
@@ -182,7 +182,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(429);
@@ -201,7 +201,7 @@ describe("POST /auth/verify-email", () => {
           path: "/auth/verify-email",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(result?.statusCode).toBe(500);

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -47,7 +47,7 @@ describe("POST /composers (create)", () => {
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/composers" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -62,7 +62,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("name is required");
@@ -78,11 +78,11 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("name is required");
-    }
+    },
   );
 
   it("name が 100 文字を超える場合は 400 を返す", async () => {
@@ -93,7 +93,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be 100 characters or less");
@@ -108,7 +108,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
 
@@ -130,7 +130,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBeUUID();
@@ -149,7 +149,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.createdAt).toBe(now.toISOString());
@@ -171,7 +171,7 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
       const body = JSON.parse(result?.body ?? "{}");
@@ -187,7 +187,7 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -200,7 +200,7 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -217,12 +217,12 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
       const body = JSON.parse(result?.body ?? "{}");
       expect(body.imageUrl).toBe(
-        "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg"
+        "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg",
       );
     });
 
@@ -234,7 +234,7 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("imageUrl must be a valid URL");
@@ -250,7 +250,7 @@ describe("POST /composers (create)", () => {
         path: "/composers",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });
@@ -264,7 +264,7 @@ describe("POST /composers (create)", () => {
           path: "/composers",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
@@ -275,7 +275,7 @@ describe("POST /composers (create)", () => {
       const result = await handler(
         makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/composers" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.save).not.toHaveBeenCalled();

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -79,7 +79,7 @@ describe("DELETE /composers/{id} (delete)", () => {
       const result = await handler(
         makeEvent("test-id-123", "non-admin"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.remove).not.toHaveBeenCalled();

--- a/backend/src/handlers/composers/list.test.ts
+++ b/backend/src/handlers/composers/list.test.ts
@@ -69,7 +69,7 @@ describe("GET /composers (list)", () => {
       await handler(
         makeEvent({ queryStringParameters: { limit: "20" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(mockRepo.findPage).toHaveBeenCalledWith({
@@ -109,7 +109,7 @@ describe("GET /composers (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: "0" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -118,7 +118,7 @@ describe("GET /composers (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: String(COMPOSERS_PAGE_SIZE_MAX + 1) } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -127,7 +127,7 @@ describe("GET /composers (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: "abc" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -136,7 +136,7 @@ describe("GET /composers (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { cursor: "!!!invalid!!!" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });

--- a/backend/src/handlers/composers/list.ts
+++ b/backend/src/handlers/composers/list.ts
@@ -9,7 +9,7 @@ const usecase = createComposerUsecase();
 export const handler = createHandler(async (event) => {
   const { limit, exclusiveStartKey } = parseListQuery(
     event.queryStringParameters,
-    listComposersQuerySchema
+    listComposersQuerySchema,
   );
   const page = await usecase.list({ limit, exclusiveStartKey });
   return ok(page);

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -32,7 +32,7 @@ type AuthMode = "admin" | "non-admin" | "none";
 function makeEvent(
   id?: string,
   body?: string | null,
-  auth: AuthMode = "admin"
+  auth: AuthMode = "admin",
 ): APIGatewayProxyEvent {
   const overrides: Partial<APIGatewayProxyEvent> = {
     body: body === undefined ? null : body,
@@ -65,7 +65,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent(undefined, JSON.stringify({ name: "新しい名前" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -77,18 +77,18 @@ describe("PUT /composers/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ name: invalidName })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be a non-empty string");
-    }
+    },
   );
 
   it("name が 100 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "あ".repeat(101) })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("name must be 100 characters or less");
@@ -99,7 +99,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ name: "新しい名前" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -111,7 +111,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
 
@@ -127,7 +127,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}") as Composer;
     expect(body.createdAt).toBe(existingComposer.createdAt);
@@ -140,7 +140,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ era: "古典派", region: "ドイツ・オーストリア" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Composer;
@@ -160,7 +160,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ era: "", region: "" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Composer;
@@ -177,10 +177,10 @@ describe("PUT /composers/{id} (update)", () => {
         "abc-123",
         JSON.stringify({
           imageUrl: "https://upload.wikimedia.org/wikipedia/commons/6/6f/Beethoven.jpg",
-        })
+        }),
       ),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Composer;
@@ -198,7 +198,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ imageUrl: "" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Composer;
@@ -209,7 +209,7 @@ describe("PUT /composers/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ imageUrl: "not-a-url" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("imageUrl must be a valid URL");
@@ -218,13 +218,13 @@ describe("PUT /composers/{id} (update)", () => {
   it("楽観的ロック競合時に 409 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
     mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(
-      new createError.Conflict("Composer was updated by another request")
+      new createError.Conflict("Composer was updated by another request"),
     );
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(409);
   });
@@ -234,7 +234,7 @@ describe("PUT /composers/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "non-admin"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.findById).not.toHaveBeenCalled();
@@ -245,7 +245,7 @@ describe("PUT /composers/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "none"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.findById).not.toHaveBeenCalled();

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -44,7 +44,7 @@ describe("POST /concert-logs (create)", () => {
       const result = await handler(
         makeEvent({ body, httpMethod: "POST", path: "/concert-logs" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -61,11 +61,11 @@ describe("POST /concert-logs (create)", () => {
           path: "/concert-logs",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("venue must be a non-empty string");
-    }
+    },
   );
 
   it("venue が 200 文字を超える場合は 400 を返す", async () => {
@@ -76,7 +76,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("venue must be 200 characters or less");
@@ -90,11 +90,11 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
-      "conductor must be 100 characters or less"
+      "conductor must be 100 characters or less",
     );
   });
 
@@ -106,11 +106,11 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
-      "orchestra must be 100 characters or less"
+      "orchestra must be 100 characters or less",
     );
   });
 
@@ -122,7 +122,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("soloist must be 100 characters or less");
@@ -137,7 +137,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
 
@@ -162,7 +162,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
 
@@ -181,7 +181,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBeUUID();
@@ -196,7 +196,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.createdAt).toBe(body.updatedAt);
@@ -211,7 +211,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
 
     const savedItem = mockRepo.save.mock.calls[0][0];
@@ -227,7 +227,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.userId).toBe(TEST_USER_ID);
@@ -242,7 +242,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });
@@ -260,7 +260,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
     const body = JSON.parse(result?.body ?? "{}");
@@ -276,7 +276,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
     const body = JSON.parse(result?.body ?? "{}");
@@ -291,7 +291,7 @@ describe("POST /concert-logs (create)", () => {
         path: "/concert-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
   });

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -43,7 +43,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("concert-logs", undefined, TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -54,7 +54,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("concert-logs", "not-found-id", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -64,7 +64,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", OTHER_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
     expect(mockRepo.remove).not.toHaveBeenCalled();
@@ -76,7 +76,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
@@ -88,7 +88,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -71,7 +71,7 @@ describe("GET /concert-logs/:id (get)", () => {
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });

--- a/backend/src/handlers/concert-logs/integration.test.ts
+++ b/backend/src/handlers/concert-logs/integration.test.ts
@@ -89,7 +89,7 @@ describe("DynamoDB 統合テスト（concert-logs）", () => {
       await listHandler(
         makeEvent({ method: "GET", path: "/concert-logs", userId: TEST_USER_ID }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(QueryCommand).toHaveBeenCalledWith(
@@ -98,7 +98,7 @@ describe("DynamoDB 統合テスト（concert-logs）", () => {
           IndexName: "GSI1",
           KeyConditionExpression: "userId = :userId",
           ExpressionAttributeValues: { ":userId": TEST_USER_ID },
-        })
+        }),
       );
     });
   });
@@ -115,7 +115,7 @@ describe("DynamoDB 統合テスト（concert-logs）", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(GetCommand).toHaveBeenCalledWith({
@@ -144,7 +144,7 @@ describe("DynamoDB 統合テスト（concert-logs）", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(PutCommand).toHaveBeenCalledWith({
@@ -175,7 +175,7 @@ describe("DynamoDB 統合テスト（concert-logs）", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(GetCommand).toHaveBeenCalledWith({

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -64,7 +64,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent(undefined, JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -80,7 +80,7 @@ describe("PUT /concert-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", body, TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -93,18 +93,18 @@ describe("PUT /concert-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ venue: whitespaceVenue }), TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("venue must be a non-empty string");
-    }
+    },
   );
 
   it("venue が 200 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "あ".repeat(201) }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("venue must be 200 characters or less");
@@ -114,11 +114,11 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ conductor: "あ".repeat(101) }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
-      "conductor must be 100 characters or less"
+      "conductor must be 100 characters or less",
     );
   });
 
@@ -126,7 +126,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ concertDate: "2024-01-15" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
   });
@@ -136,7 +136,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), OTHER_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
     expect(mockRepo.update).not.toHaveBeenCalled();
@@ -147,7 +147,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -164,7 +164,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
 
@@ -184,7 +184,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
   });
@@ -195,7 +195,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(409);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("Item was updated by another request");
@@ -206,7 +206,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });
@@ -224,7 +224,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [pieceId] }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}");
@@ -247,7 +247,7 @@ describe("PUT /concert-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [] }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}");

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -47,7 +47,7 @@ describe("POST /listening-logs (create)", () => {
       const result = await handler(
         makeEvent({ body, httpMethod: "POST", path: "/listening-logs" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -64,11 +64,11 @@ describe("POST /listening-logs (create)", () => {
           path: "/listening-logs",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("rating must be between 1 and 5");
-    }
+    },
   );
 
   it.each(["   ", "\t", "\n"])(
@@ -81,11 +81,11 @@ describe("POST /listening-logs (create)", () => {
           path: "/listening-logs",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("composer must be a non-empty string");
-    }
+    },
   );
 
   it("composer が 100 文字を超える場合は 400 を返す", async () => {
@@ -96,11 +96,11 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
-      "composer must be 100 characters or less"
+      "composer must be 100 characters or less",
     );
   });
 
@@ -114,11 +114,11 @@ describe("POST /listening-logs (create)", () => {
           path: "/listening-logs",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("piece must be a non-empty string");
-    }
+    },
   );
 
   it("piece が 200 文字を超える場合は 400 を返す", async () => {
@@ -129,7 +129,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("piece must be 200 characters or less");
@@ -143,7 +143,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("memo must be 1000 characters or less");
@@ -158,7 +158,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
 
@@ -179,7 +179,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toMatch(/^[0-9a-f-]{36}$/);
@@ -194,7 +194,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.createdAt).toBe(body.updatedAt);
@@ -209,7 +209,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
 
     const savedItem = mockRepo.save.mock.calls[0][0];
@@ -225,7 +225,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.userId).toBe(TEST_USER_ID);
@@ -240,7 +240,7 @@ describe("POST /listening-logs (create)", () => {
         path: "/listening-logs",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/listening-logs/delete.test.ts
+++ b/backend/src/handlers/listening-logs/delete.test.ts
@@ -44,7 +44,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", undefined, TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -55,7 +55,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", "not-found-id", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -65,7 +65,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", OTHER_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
     expect(mockRepo.remove).not.toHaveBeenCalled();
@@ -77,7 +77,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -88,7 +88,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
@@ -100,7 +100,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -72,7 +72,7 @@ describe("GET /listening-logs/:id (get)", () => {
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });

--- a/backend/src/handlers/listening-logs/integration.test.ts
+++ b/backend/src/handlers/listening-logs/integration.test.ts
@@ -91,7 +91,7 @@ describe("DynamoDB 統合テスト", () => {
       await listHandler(
         makeEvent({ method: "GET", path: "/listening-logs", userId: TEST_USER_ID }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(QueryCommand).toHaveBeenCalledWith(
@@ -100,7 +100,7 @@ describe("DynamoDB 統合テスト", () => {
           IndexName: "GSI1",
           KeyConditionExpression: "userId = :userId",
           ExpressionAttributeValues: { ":userId": TEST_USER_ID },
-        })
+        }),
       );
     });
   });
@@ -117,7 +117,7 @@ describe("DynamoDB 統合テスト", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(GetCommand).toHaveBeenCalledWith({
@@ -147,7 +147,7 @@ describe("DynamoDB 統合テスト", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(PutCommand).toHaveBeenCalledWith({
@@ -178,7 +178,7 @@ describe("DynamoDB 統合テスト", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(GetCommand).toHaveBeenCalledWith({
@@ -208,7 +208,7 @@ describe("DynamoDB 統合テスト", () => {
           userId: TEST_USER_ID,
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(GetCommand).toHaveBeenCalledTimes(2);

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -66,7 +66,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent(undefined, JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -82,7 +82,7 @@ describe("PUT /listening-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", body, TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -95,11 +95,11 @@ describe("PUT /listening-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ rating: invalidRating }), TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("rating must be between 1 and 5");
-    }
+    },
   );
 
   it.each(["   ", "\t", "\n"])(
@@ -108,22 +108,22 @@ describe("PUT /listening-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ composer: whitespaceComposer }), TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("composer must be a non-empty string");
-    }
+    },
   );
 
   it("composer が 100 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ composer: "あ".repeat(101) }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
-      "composer must be 100 characters or less"
+      "composer must be 100 characters or less",
     );
   });
 
@@ -133,18 +133,18 @@ describe("PUT /listening-logs/:id (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ piece: whitespacePiece }), TEST_USER_ID),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("piece must be a non-empty string");
-    }
+    },
   );
 
   it("piece が 200 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ piece: "あ".repeat(201) }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("piece must be 200 characters or less");
@@ -154,7 +154,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ memo: "あ".repeat(1001) }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("memo must be 1000 characters or less");
@@ -164,7 +164,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ listenedAt: "2024-01-15" }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
   });
@@ -174,7 +174,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), OTHER_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
     expect(mockRepo.update).not.toHaveBeenCalled();
@@ -186,7 +186,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
     expect(mockRepo.update).not.toHaveBeenCalled();
@@ -197,7 +197,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -213,7 +213,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ isFavorite: true }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
   });
@@ -231,7 +231,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4, isFavorite: true }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
 
@@ -253,7 +253,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(new Date(body.updatedAt).getTime()).toBeGreaterThanOrEqual(before);
@@ -269,7 +269,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ id: "tampered-id", rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBe("abc-123");
@@ -281,7 +281,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(409);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("Item was updated by another request");
@@ -292,7 +292,7 @@ describe("PUT /listening-logs/:id (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -49,7 +49,7 @@ describe("POST /pieces (create)", () => {
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/pieces" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
@@ -64,7 +64,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("title is required");
@@ -80,11 +80,11 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("title is required");
-    }
+    },
   );
 
   it("title が 200 文字を超える場合は 400 を返す", async () => {
@@ -95,7 +95,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("title must be 200 characters or less");
@@ -109,7 +109,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("composerId must be a valid UUID");
@@ -125,11 +125,11 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("composerId must be a valid UUID");
-    }
+    },
   );
 
   it("videoUrl が不正な URL の場合は 400 を返す", async () => {
@@ -140,7 +140,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("videoUrl must be a valid URL");
@@ -155,7 +155,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
 
@@ -177,7 +177,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(201);
     const body = JSON.parse(result?.body ?? "{}");
@@ -193,7 +193,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBeUUID();
@@ -212,7 +212,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.createdAt).toBe(now.toISOString());
@@ -236,7 +236,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
       const body = JSON.parse(result?.body ?? "{}");
@@ -255,7 +255,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
       const body = JSON.parse(result?.body ?? "{}");
@@ -274,7 +274,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
       const body = JSON.parse(result?.body ?? "{}");
@@ -292,7 +292,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -305,7 +305,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -318,7 +318,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -331,7 +331,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -346,7 +346,7 @@ describe("POST /pieces (create)", () => {
         path: "/pieces",
       }),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });
@@ -360,7 +360,7 @@ describe("POST /pieces (create)", () => {
           path: "/pieces",
         }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
@@ -371,7 +371,7 @@ describe("POST /pieces (create)", () => {
       const result = await handler(
         makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
@@ -383,10 +383,10 @@ describe("POST /pieces (create)", () => {
         makeAuthEvent(
           TEST_USER_ID,
           { body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" },
-          "viewer,editor"
+          "viewer,editor",
         ),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.save).not.toHaveBeenCalled();
@@ -398,10 +398,10 @@ describe("POST /pieces (create)", () => {
         makeAuthEvent(
           TEST_USER_ID,
           { body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" },
-          "admin,editor"
+          "admin,editor",
         ),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(201);
     });

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -79,7 +79,7 @@ describe("DELETE /pieces/{id} (delete)", () => {
       const result = await handler(
         makeEvent("test-id-123", "non-admin"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");

--- a/backend/src/handlers/pieces/list.test.ts
+++ b/backend/src/handlers/pieces/list.test.ts
@@ -70,7 +70,7 @@ describe("GET /pieces (list)", () => {
       await handler(
         makeEvent({ queryStringParameters: { limit: "20" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(mockRepo.findPage).toHaveBeenCalledWith({
@@ -144,7 +144,7 @@ describe("GET /pieces (list)", () => {
       await handler(
         makeEvent({ queryStringParameters: { cursor: nextCursor ?? "" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
 
       expect(mockRepo.findPage).toHaveBeenLastCalledWith({
@@ -159,7 +159,7 @@ describe("GET /pieces (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: "0" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -168,7 +168,7 @@ describe("GET /pieces (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: String(PIECES_PAGE_SIZE_MAX + 1) } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -177,7 +177,7 @@ describe("GET /pieces (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { limit: "abc" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -186,7 +186,7 @@ describe("GET /pieces (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { cursor: "!!!invalid!!!" } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -196,19 +196,19 @@ describe("GET /pieces (list)", () => {
       const result = await handler(
         makeEvent({ queryStringParameters: { cursor } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
 
     it("cursor のバージョンが未知の場合は 400 を返す", async () => {
       const cursor = Buffer.from(JSON.stringify({ v: 999, k: { id: "1" } }), "utf8").toString(
-        "base64url"
+        "base64url",
       );
       const result = await handler(
         makeEvent({ queryStringParameters: { cursor } }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });

--- a/backend/src/handlers/pieces/list.ts
+++ b/backend/src/handlers/pieces/list.ts
@@ -9,7 +9,7 @@ const usecase = createPieceUsecase();
 export const handler = createHandler(async (event) => {
   const { limit, exclusiveStartKey } = parseListQuery(
     event.queryStringParameters,
-    listPiecesQuerySchema
+    listPiecesQuerySchema,
   );
   const page = await usecase.list({ limit, exclusiveStartKey });
   return ok(page);

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -33,7 +33,7 @@ type AuthMode = "admin" | "non-admin" | "none";
 function makeEvent(
   id?: string,
   body?: string | null,
-  auth: AuthMode = "admin"
+  auth: AuthMode = "admin",
 ): APIGatewayProxyEvent {
   const overrides: Partial<APIGatewayProxyEvent> = {
     body: body === undefined ? null : body,
@@ -74,7 +74,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent(undefined, JSON.stringify({ title: "新タイトル" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
@@ -99,18 +99,18 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ title: invalidTitle })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("title must be a non-empty string");
-    }
+    },
   );
 
   it("title が 200 文字を超える場合は 400 を返す", async () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "あ".repeat(201) })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("title must be 200 characters or less");
@@ -122,11 +122,11 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ composerId: invalidComposerId })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("composerId must be a valid UUID");
-    }
+    },
   );
 
   it("title を含まない更新は title のバリデーションをスキップする", async () => {
@@ -136,7 +136,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ composerId: OTHER_COMPOSER_ID })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
   });
@@ -146,7 +146,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ title: "新タイトル" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(404);
   });
@@ -158,7 +158,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番", composerId: OTHER_COMPOSER_ID })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
 
@@ -176,7 +176,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}") as Piece;
     expect(new Date(body.updatedAt).getTime()).toBeGreaterThanOrEqual(before);
@@ -189,7 +189,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}") as Piece;
     expect(body.createdAt).toBe(existingPiece.createdAt);
@@ -202,7 +202,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     const body = JSON.parse(result?.body ?? "{}") as Piece;
     expect(body.id).toBe("abc-123");
@@ -211,13 +211,13 @@ describe("PUT /pieces/{id} (update)", () => {
   it("楽観的ロック競合時に 409 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingPiece);
     mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(
-      new createError.Conflict("Piece was updated by another request")
+      new createError.Conflict("Piece was updated by another request"),
     );
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(409);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("Piece was updated by another request");
@@ -228,7 +228,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ title: "交響曲第5番" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(500);
   });
@@ -240,7 +240,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ videoUrl: "https://www.youtube.com/watch?v=xyz" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -254,7 +254,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ videoUrl: "" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -274,10 +274,10 @@ describe("PUT /pieces/{id} (update)", () => {
             era: "古典派",
             formation: "管弦楽",
             region: "ドイツ・オーストリア",
-          })
+          }),
         ),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(200);
       const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -299,7 +299,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ genre: "協奏曲", era: "ロマン派" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(200);
       const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -321,7 +321,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ genre: "", era: "", formation: "", region: "" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(200);
       const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -338,7 +338,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ genre: "室内楽" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(200);
       const body = JSON.parse(result?.body ?? "{}") as Piece;
@@ -350,7 +350,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ genre: "不正な値" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -359,7 +359,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ era: "不正な値" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -368,7 +368,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ formation: "不正な値" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -377,7 +377,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ region: "不正な値" })),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(400);
     });
@@ -387,7 +387,7 @@ describe("PUT /pieces/{id} (update)", () => {
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ videoUrl: "not-a-url" })),
       mockContext,
-      mockCallback
+      mockCallback,
     );
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("videoUrl must be a valid URL");
@@ -398,7 +398,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ title: "新タイトル" }), "non-admin"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
@@ -410,7 +410,7 @@ describe("PUT /pieces/{id} (update)", () => {
       const result = await handler(
         makeEvent("abc-123", JSON.stringify({ title: "新タイトル" }), "none"),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(403);
       expect(mockRepo.findById).not.toHaveBeenCalled();

--- a/backend/src/migrations/piece-composer-id/index.test.ts
+++ b/backend/src/migrations/piece-composer-id/index.test.ts
@@ -22,7 +22,7 @@ type LegacyPiece = {
 const makeLegacyPiece = (
   id: string,
   composer: string | undefined,
-  overrides: Partial<LegacyPiece> = {}
+  overrides: Partial<LegacyPiece> = {},
 ): LegacyPiece => ({
   id,
   title: `曲 ${id}`,
@@ -46,7 +46,7 @@ describe("runMigration", () => {
   const runWithFixtures = (
     pieces: LegacyPiece[],
     composers: Composer[],
-    options: { dryRun?: boolean } = {}
+    options: { dryRun?: boolean } = {},
   ) =>
     runMigration(
       {
@@ -55,7 +55,7 @@ describe("runMigration", () => {
         savePiece,
         saveComposer,
       },
-      options
+      options,
     );
 
   beforeEach(() => {

--- a/backend/src/migrations/piece-composer-id/index.ts
+++ b/backend/src/migrations/piece-composer-id/index.ts
@@ -64,7 +64,7 @@ export type MigrationDeps = {
 
 export async function runMigration(
   deps: MigrationDeps,
-  event: MigrateEvent = {}
+  event: MigrateEvent = {},
 ): Promise<MigrateSummary> {
   const dryRun = event.dryRun === true;
   const [pieces, composers] = await Promise.all([deps.scanAllPieces(), deps.scanAllComposers()]);
@@ -161,7 +161,7 @@ function makeDefaultDeps(): MigrationDeps {
     let cursor: Record<string, unknown> | undefined;
     do {
       const result = await dynamo.send(
-        new ScanCommand({ TableName: tableName, ExclusiveStartKey: cursor })
+        new ScanCommand({ TableName: tableName, ExclusiveStartKey: cursor }),
       );
       items.push(...((result.Items ?? []) as T[]));
       cursor = result.LastEvaluatedKey as Record<string, unknown> | undefined;

--- a/backend/src/repositories/cognito-auth-repository.ts
+++ b/backend/src/repositories/cognito-auth-repository.ts
@@ -22,7 +22,7 @@ export class CognitoAuthRepository implements AuthRepository {
         Username: email,
         Password: password,
         UserAttributes: [{ Name: "email", Value: email }],
-      })
+      }),
     );
   }
 
@@ -36,7 +36,7 @@ export class CognitoAuthRepository implements AuthRepository {
           USERNAME: email,
           PASSWORD: password,
         },
-      })
+      }),
     );
     const result = response.AuthenticationResult;
     return {
@@ -55,7 +55,7 @@ export class CognitoAuthRepository implements AuthRepository {
         ClientId: env.cognitoClientId,
         Username: email,
         ConfirmationCode: code,
-      })
+      }),
     );
   }
 
@@ -65,7 +65,7 @@ export class CognitoAuthRepository implements AuthRepository {
       new ResendConfirmationCodeCommand({
         ClientId: env.cognitoClientId,
         Username: email,
-      })
+      }),
     );
   }
 
@@ -78,7 +78,7 @@ export class CognitoAuthRepository implements AuthRepository {
         AuthParameters: {
           REFRESH_TOKEN: token,
         },
-      })
+      }),
     );
     const result = response.AuthenticationResult;
     return {
@@ -91,14 +91,14 @@ export class CognitoAuthRepository implements AuthRepository {
 
   async listUsersByEmail(
     userPoolId: string,
-    email: string
+    email: string,
   ): Promise<{ username: string; status: string }[]> {
     const result = await cognito.send(
       new ListUsersCommand({
         UserPoolId: userPoolId,
         Filter: `email = "${email}"`,
         Limit: 1,
-      })
+      }),
     );
     return (result.Users ?? [])
       .filter((u) => u.Username !== undefined)
@@ -109,7 +109,7 @@ export class CognitoAuthRepository implements AuthRepository {
     userPoolId: string,
     destinationUsername: string,
     providerName: string,
-    providerUserId: string
+    providerUserId: string,
   ): Promise<void> {
     await cognito.send(
       new AdminLinkProviderForUserCommand({
@@ -124,7 +124,7 @@ export class CognitoAuthRepository implements AuthRepository {
           ProviderAttributeName: "Cognito_Subject",
           ProviderAttributeValue: providerUserId,
         },
-      })
+      }),
     );
   }
 }

--- a/backend/src/repositories/composer-repository.ts
+++ b/backend/src/repositories/composer-repository.ts
@@ -8,7 +8,7 @@ import type { ComposerRepository } from "../domain/composer";
 export class DynamoDBComposerRepository implements ComposerRepository {
   async findById(id: ComposerId): Promise<Composer | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_COMPOSERS, Key: { id: id.value } })
+      new GetCommand({ TableName: TABLE_COMPOSERS, Key: { id: id.value } }),
     );
     return result.Item as Composer | undefined;
   }

--- a/backend/src/repositories/concert-log-repository.ts
+++ b/backend/src/repositories/concert-log-repository.ts
@@ -8,7 +8,7 @@ import type { ConcertLogRepository } from "../domain/concert-log";
 export class DynamoDBConcertLogRepository implements ConcertLogRepository {
   async findById(id: ConcertLogId): Promise<ConcertLog | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id: id.value } })
+      new GetCommand({ TableName: TABLE_CONCERT_LOGS, Key: { id: id.value } }),
     );
     return result.Item as ConcertLog | undefined;
   }

--- a/backend/src/repositories/listening-log-repository.ts
+++ b/backend/src/repositories/listening-log-repository.ts
@@ -8,7 +8,7 @@ import type { ListeningLogRepository } from "../domain/listening-log";
 export class DynamoDBListeningLogRepository implements ListeningLogRepository {
   async findById(id: ListeningLogId): Promise<ListeningLog | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } })
+      new GetCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } }),
     );
     return result.Item as ListeningLog | undefined;
   }
@@ -27,7 +27,7 @@ export class DynamoDBListeningLogRepository implements ListeningLogRepository {
 
   async remove(id: ListeningLogId): Promise<void> {
     await dynamo.send(
-      new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } })
+      new DeleteCommand({ TableName: TABLE_LISTENING_LOGS, Key: { id: id.value } }),
     );
   }
 }

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -15,7 +15,7 @@ import type { PieceRepository } from "../domain/piece";
 export class DynamoDBPieceRepository implements PieceRepository {
   async findById(id: PieceId): Promise<Piece | undefined> {
     const result = await dynamo.send(
-      new GetCommand({ TableName: TABLE_PIECES, Key: { id: id.value } })
+      new GetCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }),
     );
     return result.Item as Piece | undefined;
   }

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -5,7 +5,7 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 export const makeLog = (
   id: string,
   listenedAt: string,
-  userId: string | null = "user-123"
+  userId: string | null = "user-123",
 ): ListeningLog => ({
   id,
   listenedAt,
@@ -55,7 +55,7 @@ export const makeEvent = (overrides?: Partial<APIGatewayProxyEvent>): APIGateway
 export const makeAuthEvent = (
   userId: string,
   overrides?: Partial<APIGatewayProxyEvent>,
-  groups?: string[] | string
+  groups?: string[] | string,
 ): APIGatewayProxyEvent => {
   const claims: Record<string, unknown> = { sub: userId };
   if (groups !== undefined) {
@@ -71,7 +71,7 @@ export const makeAuthEvent = (
 
 export const makeAdminEvent = (
   userId: string,
-  overrides?: Partial<APIGatewayProxyEvent>
+  overrides?: Partial<APIGatewayProxyEvent>,
 ): APIGatewayProxyEvent => makeAuthEvent(userId, overrides, ["admin"]);
 
 export const mockContext: Context = {} as Context;
@@ -83,7 +83,7 @@ export const OTHER_USER_ID = "cognito-sub-other-user";
 export const makeDeleteEvent = (
   pathPrefix: string,
   id?: string,
-  userId?: string
+  userId?: string,
 ): APIGatewayProxyEvent => ({
   body: null,
   headers: {},
@@ -104,7 +104,7 @@ export const makeDeleteEvent = (
 type HandlerFn = (
   event: APIGatewayProxyEvent,
   context: Context,
-  callback: unknown
+  callback: unknown,
 ) => Promise<{ statusCode?: number; body?: string } | null | undefined>;
 
 export const describeInvalidBodyCases = (handler: HandlerFn, path: string) => {
@@ -118,7 +118,7 @@ export const describeInvalidBodyCases = (handler: HandlerFn, path: string) => {
       const result = await handler(
         makeEvent({ body, httpMethod: "POST", path }),
         mockContext,
-        mockCallback
+        mockCallback,
       );
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);

--- a/backend/src/usecases/auth-usecase.ts
+++ b/backend/src/usecases/auth-usecase.ts
@@ -18,7 +18,7 @@ const tryCognito = async <T>(
   context: AuthContext,
   successCode: number,
   successBodyFactory: (result: T) => unknown,
-  fn: () => Promise<T>
+  fn: () => Promise<T>,
 ): Promise<AuthResponse> => {
   try {
     const result = await fn();
@@ -40,7 +40,7 @@ export class AuthUsecase {
       "login",
       StatusCodes.OK,
       (tokens) => tokens,
-      () => this.repo.initiateAuth(email, password)
+      () => this.repo.initiateAuth(email, password),
     );
   }
 
@@ -51,7 +51,7 @@ export class AuthUsecase {
       () => ({
         message: "User created successfully. Please check your email to verify your account.",
       }),
-      () => this.repo.signUp(email, password)
+      () => this.repo.signUp(email, password),
     );
   }
 
@@ -60,7 +60,7 @@ export class AuthUsecase {
       "verify",
       StatusCodes.OK,
       () => ({ message: "Email confirmed successfully." }),
-      () => this.repo.confirmSignUp(email, code)
+      () => this.repo.confirmSignUp(email, code),
     );
   }
 
@@ -69,7 +69,7 @@ export class AuthUsecase {
       "refresh",
       StatusCodes.OK,
       (tokens) => tokens,
-      () => this.repo.refreshToken(token)
+      () => this.repo.refreshToken(token),
     );
   }
 
@@ -78,14 +78,14 @@ export class AuthUsecase {
       "resend",
       StatusCodes.OK,
       () => ({ message: "Verification code resent. Please check your email." }),
-      () => this.repo.resendConfirmationCode(email)
+      () => this.repo.resendConfirmationCode(email),
     );
   }
 
   async linkExternalProvider(
     userPoolId: string,
     email: string,
-    userName: string
+    userName: string,
   ): Promise<boolean> {
     const users = await this.repo.listUsersByEmail(userPoolId, email);
     const existingUser = users.find((u) => u.status === "CONFIRMED");
@@ -106,7 +106,7 @@ export class AuthUsecase {
       userPoolId,
       existingUser.username,
       providerName,
-      providerUserId
+      providerUserId,
     );
 
     return true;

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -23,7 +23,7 @@ export function toPaginatedResult<T>(page: {
 export async function findByIdOrNotFound<T, I extends EntityId>(
   findById: (id: I) => Promise<T | undefined>,
   id: I,
-  entityName: string
+  entityName: string,
 ): Promise<T> {
   const item = await findById(id);
   if (item === undefined) {

--- a/backend/src/usecases/listening-log-usecase.ts
+++ b/backend/src/usecases/listening-log-usecase.ts
@@ -45,7 +45,7 @@ export class ListeningLogUsecase {
   async update(
     id: ListeningLogId,
     input: Partial<ListeningLog>,
-    userId: UserId
+    userId: UserId,
   ): Promise<ListeningLog> {
     await this.loadOwnedEntity(id, userId);
     return this.repo.update(id, input);

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -49,27 +49,27 @@ describe("getUserGroups", () => {
 
   it("cognito:groups が配列形式の場合はそのまま返す", () => {
     expect(
-      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", "editor"] } }))
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", "editor"] } })),
     ).toEqual(["admin", "editor"]);
   });
 
   it("cognito:groups が配列の場合、文字列以外の要素は除外する", () => {
     expect(
       getUserGroups(
-        makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", 42, null, "editor"] } })
-      )
+        makeEvent({ claims: { sub: "u", "cognito:groups": ["admin", 42, null, "editor"] } }),
+      ),
     ).toEqual(["admin", "editor"]);
   });
 
   it("cognito:groups がカンマ区切り文字列の場合は配列に分割する", () => {
     expect(
-      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": "admin,editor" } }))
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": "admin,editor" } })),
     ).toEqual(["admin", "editor"]);
   });
 
   it("cognito:groups の文字列分割時に前後の空白をトリムする", () => {
     expect(
-      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": " admin , editor " } }))
+      getUserGroups(makeEvent({ claims: { sub: "u", "cognito:groups": " admin , editor " } })),
     ).toEqual(["admin", "editor"]);
   });
 });
@@ -81,7 +81,7 @@ describe("isAdmin", () => {
 
   it("admin がカンマ区切り文字列に含まれる場合は true を返す", () => {
     expect(isAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": "editor,admin" } }))).toBe(
-      true
+      true,
     );
   });
 
@@ -101,19 +101,19 @@ describe("isAdmin", () => {
 describe("requireAdmin", () => {
   it("admin グループに所属している場合は throw しない", () => {
     expect(() =>
-      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin"] } }))
+      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["admin"] } })),
     ).not.toThrow();
   });
 
   it("admin グループに所属していない場合は 403 を投げる", () => {
     expect(() =>
-      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["editor"] } }))
+      requireAdmin(makeEvent({ claims: { sub: "u", "cognito:groups": ["editor"] } })),
     ).toThrow("Admin privilege required");
   });
 
   it("cognito:groups が未設定の場合は 403 を投げる", () => {
     expect(() => requireAdmin(makeEvent({ claims: { sub: "u" } }))).toThrow(
-      "Admin privilege required"
+      "Admin privilege required",
     );
   });
 

--- a/backend/src/utils/cursor.test.ts
+++ b/backend/src/utils/cursor.test.ts
@@ -34,8 +34,8 @@ describe("encodeCursor / decodeCursor", () => {
         (key) => {
           const decoded = decodeCursor(encodeCursor(key));
           expect(decoded).toEqual(key);
-        }
-      )
+        },
+      ),
     );
   });
 
@@ -62,14 +62,14 @@ describe("encodeCursor / decodeCursor", () => {
     it("JSON は有効だが未知のバージョン番号の場合は InvalidCursorError を投げる", () => {
       const futureVersion = Buffer.from(
         JSON.stringify({ v: 999, k: { id: "1" } }),
-        "utf8"
+        "utf8",
       ).toString("base64url");
       expect(() => decodeCursor(futureVersion)).toThrow(InvalidCursorError);
     });
 
     it("JSON は有効だがバージョン番号が欠損している場合は InvalidCursorError を投げる", () => {
       const noVersion = Buffer.from(JSON.stringify({ k: { id: "1" } }), "utf8").toString(
-        "base64url"
+        "base64url",
       );
       expect(() => decodeCursor(noVersion)).toThrow(InvalidCursorError);
     });
@@ -81,7 +81,7 @@ describe("encodeCursor / decodeCursor", () => {
 
     it("k がオブジェクトでない場合は InvalidCursorError を投げる", () => {
       const badKey = Buffer.from(JSON.stringify({ v: 1, k: "not an object" }), "utf8").toString(
-        "base64url"
+        "base64url",
       );
       expect(() => decodeCursor(badKey)).toThrow(InvalidCursorError);
     });

--- a/backend/src/utils/dynamodb.test.ts
+++ b/backend/src/utils/dynamodb.test.ts
@@ -202,7 +202,7 @@ describe("putItemWithOptimisticLock", () => {
 
   it("ConditionalCheckFailedException が発生した場合は 409 を投げる", async () => {
     mockSend.mockRejectedValueOnce(
-      new ConditionalCheckFailedException({ message: "Condition failed", $metadata: {} })
+      new ConditionalCheckFailedException({ message: "Condition failed", $metadata: {} }),
     );
 
     await expect(
@@ -211,7 +211,7 @@ describe("putItemWithOptimisticLock", () => {
         item: { id: "x" },
         prevUpdatedAt: "prev",
         conflictMessage: "Custom was updated by another request",
-      })
+      }),
     ).rejects.toThrow("Custom was updated by another request");
   });
 
@@ -224,7 +224,7 @@ describe("putItemWithOptimisticLock", () => {
         item: { id: "x" },
         prevUpdatedAt: "prev",
         conflictMessage: "Whatever",
-      })
+      }),
     ).rejects.toThrow("DynamoDB connection error");
   });
 });
@@ -241,7 +241,7 @@ describe("updateItem", () => {
     mockSend.mockResolvedValueOnce({ Item: undefined });
 
     await expect(updateItem<TestItem>("test-table", "item-1", { name: "updated" })).rejects.toThrow(
-      "Item not found"
+      "Item not found",
     );
   });
 
@@ -280,11 +280,11 @@ describe("updateItem", () => {
     mockSend
       .mockResolvedValueOnce({ Item: existing })
       .mockRejectedValueOnce(
-        new ConditionalCheckFailedException({ message: "Condition failed", $metadata: {} })
+        new ConditionalCheckFailedException({ message: "Condition failed", $metadata: {} }),
       );
 
     await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
-      "Item was updated by another request"
+      "Item was updated by another request",
     );
   });
 
@@ -294,7 +294,7 @@ describe("updateItem", () => {
       .mockRejectedValueOnce(new Error("DynamoDB connection error"));
 
     await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
-      "DynamoDB connection error"
+      "DynamoDB connection error",
     );
   });
 });

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -36,7 +36,7 @@ export async function queryItemsByUserId<T>(tableName: string, userId: string): 
         KeyConditionExpression: "userId = :userId",
         ExpressionAttributeValues: { ":userId": userId },
         ExclusiveStartKey: lastEvaluatedKey,
-      })
+      }),
     );
     items.push(...((result.Items ?? []) as T[]));
     lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
@@ -58,7 +58,7 @@ export async function scanAllItems<T>(tableName: string): Promise<T[]> {
 
   do {
     const result = await dynamo.send(
-      new ScanCommand({ TableName: tableName, ExclusiveStartKey: lastEvaluatedKey })
+      new ScanCommand({ TableName: tableName, ExclusiveStartKey: lastEvaluatedKey }),
     );
     items.push(...((result.Items ?? []) as T[]));
     lastEvaluatedKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
@@ -76,14 +76,14 @@ export async function scanAllItems<T>(tableName: string): Promise<T[]> {
  */
 export async function scanPage<T>(
   tableName: string,
-  options: { limit: number; exclusiveStartKey?: Record<string, unknown> }
+  options: { limit: number; exclusiveStartKey?: Record<string, unknown> },
 ): Promise<{ items: T[]; lastEvaluatedKey?: Record<string, unknown> }> {
   const result = await dynamo.send(
     new ScanCommand({
       TableName: tableName,
       Limit: options.limit,
       ExclusiveStartKey: options.exclusiveStartKey,
-    })
+    }),
   );
   return {
     items: (result.Items ?? []) as T[],
@@ -109,7 +109,7 @@ export async function putItemWithOptimisticLock<T>(options: {
         Item: options.item,
         ConditionExpression: "updatedAt = :prevUpdatedAt",
         ExpressionAttributeValues: { ":prevUpdatedAt": options.prevUpdatedAt },
-      })
+      }),
     );
   } catch (err) {
     if (err instanceof ConditionalCheckFailedException) {
@@ -122,7 +122,7 @@ export async function putItemWithOptimisticLock<T>(options: {
 export async function updateItem<T extends { id: string; createdAt: string; updatedAt: string }>(
   tableName: string,
   id: string,
-  input: Partial<T>
+  input: Partial<T>,
 ): Promise<T> {
   const existing = await dynamo.send(new GetCommand({ TableName: tableName, Key: { id } }));
   if (existing.Item === undefined) {

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -10,7 +10,7 @@ import { getEnv } from "./env";
 
 export type LambdaHandler = (
   event: APIGatewayProxyEvent,
-  context: Context
+  context: Context,
 ) => Promise<{ statusCode: number; body: unknown }>;
 
 /**
@@ -57,14 +57,14 @@ export const createHandler = (handler: LambdaHandler) =>
     // `body: string`. The cast is safe because httpResponseSerializer will
     // JSON.stringify the body at runtime before the response is returned.
     .handler(
-      handler as unknown as middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult>
+      handler as unknown as middy.MiddyfiedHandler<APIGatewayProxyEvent, APIGatewayProxyResult>,
     )
     .use(
       httpCors({
         origins: getEnv().corsAllowOrigins,
         headers: "Content-Type",
         methods: "GET,POST,PUT,DELETE,OPTIONS",
-      })
+      }),
     )
     .use(httpErrorMiddleware())
     .use(
@@ -79,7 +79,7 @@ export const createHandler = (handler: LambdaHandler) =>
           },
         ],
         defaultContentType: "application/json",
-      })
+      }),
     );
 
 /**

--- a/backend/src/utils/parsing.test.ts
+++ b/backend/src/utils/parsing.test.ts
@@ -20,7 +20,7 @@ describe("parseRequestBody", () => {
 
   it("文字列の場合は 400 を投げる", () => {
     expect(() => parseRequestBody<TestInput>("string")).toThrow(
-      "Request body must be a JSON object"
+      "Request body must be a JSON object",
     );
   });
 
@@ -103,13 +103,13 @@ describe("parseListQuery", () => {
 
   it("base64url として不正な cursor は 400 を投げる", () => {
     expect(() => parseListQuery({ cursor: "!!!invalid!!!" }, schema)).toThrow(
-      "cursor must be a base64url string"
+      "cursor must be a base64url string",
     );
   });
 
   it("バージョン不一致の cursor は 400 を投げる", () => {
     const cursor = Buffer.from(JSON.stringify({ v: 999, k: { id: "1" } }), "utf8").toString(
-      "base64url"
+      "base64url",
     );
     expect(() => parseListQuery({ cursor }, schema)).toThrow(/Unsupported cursor version/);
   });

--- a/backend/src/utils/parsing.ts
+++ b/backend/src/utils/parsing.ts
@@ -36,7 +36,7 @@ export interface ListQueryOutput {
  */
 export function parseListQuery(
   queryParams: Record<string, string | undefined> | null | undefined,
-  schema: ZodType<ListQueryInput>
+  schema: ZodType<ListQueryInput>,
 ): ListQueryOutput {
   const parsed = schema.safeParse(queryParams ?? {});
   if (!parsed.success) {

--- a/backend/src/utils/schemas.test.ts
+++ b/backend/src/utils/schemas.test.ts
@@ -60,8 +60,8 @@ describe("createListeningLogSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 101, maxLength: 200 }).filter((s) => s.trim().length > 100),
-        (composer) => fails(createListeningLogSchema.safeParse({ ...validLog, composer }))
-      )
+        (composer) => fails(createListeningLogSchema.safeParse({ ...validLog, composer })),
+      ),
     );
   });
 
@@ -74,24 +74,24 @@ describe("createListeningLogSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 201, maxLength: 400 }).filter((s) => s.trim().length > 200),
-        (piece) => fails(createListeningLogSchema.safeParse({ ...validLog, piece }))
-      )
+        (piece) => fails(createListeningLogSchema.safeParse({ ...validLog, piece })),
+      ),
     );
   });
 
   it("rating が 1〜5 の整数は常に有効", () => {
     fc.assert(
       fc.property(fc.integer({ min: 1, max: 5 }), (rating) =>
-        succeeds(createListeningLogSchema.safeParse({ ...validLog, rating }))
-      )
+        succeeds(createListeningLogSchema.safeParse({ ...validLog, rating })),
+      ),
     );
   });
 
   it("rating が 1〜5 の範囲外の整数は常にエラー", () => {
     fc.assert(
       fc.property(fc.oneof(fc.integer({ max: 0 }), fc.integer({ min: 6 })), (rating) =>
-        fails(createListeningLogSchema.safeParse({ ...validLog, rating }))
-      )
+        fails(createListeningLogSchema.safeParse({ ...validLog, rating })),
+      ),
     );
   });
 
@@ -99,8 +99,8 @@ describe("createListeningLogSchema", () => {
     fc.assert(
       fc.property(
         fc.integer().map((n) => n + 0.5),
-        (rating) => fails(createListeningLogSchema.safeParse({ ...validLog, rating }))
-      )
+        (rating) => fails(createListeningLogSchema.safeParse({ ...validLog, rating })),
+      ),
     );
   });
 
@@ -108,8 +108,8 @@ describe("createListeningLogSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 1001, maxLength: 2000 }).filter((s) => s.trim().length > 1000),
-        (memo) => fails(createListeningLogSchema.safeParse({ ...validLog, memo }))
-      )
+        (memo) => fails(createListeningLogSchema.safeParse({ ...validLog, memo })),
+      ),
     );
   });
 
@@ -169,8 +169,8 @@ describe("createPieceSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 201, maxLength: 400 }).filter((s) => s.trim().length > 200),
-        (title) => fails(createPieceSchema.safeParse({ ...validPiece, title }))
-      )
+        (title) => fails(createPieceSchema.safeParse({ ...validPiece, title })),
+      ),
     );
   });
 
@@ -233,8 +233,8 @@ describe("registerSchema", () => {
   it("8 文字未満の password は常にエラー", () => {
     fc.assert(
       fc.property(fc.string({ minLength: 1, maxLength: 7 }), (password) =>
-        fails(registerSchema.safeParse({ ...validAuth, password }))
-      )
+        fails(registerSchema.safeParse({ ...validAuth, password })),
+      ),
     );
   });
 
@@ -242,8 +242,8 @@ describe("registerSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 8 }).filter((s) => !/[A-Z]/.test(s)),
-        (password) => fails(registerSchema.safeParse({ ...validAuth, password }))
-      )
+        (password) => fails(registerSchema.safeParse({ ...validAuth, password })),
+      ),
     );
   });
 
@@ -251,8 +251,8 @@ describe("registerSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 8 }).filter((s) => !/[a-z]/.test(s)),
-        (password) => fails(registerSchema.safeParse({ ...validAuth, password }))
-      )
+        (password) => fails(registerSchema.safeParse({ ...validAuth, password })),
+      ),
     );
   });
 
@@ -260,8 +260,8 @@ describe("registerSchema", () => {
     fc.assert(
       fc.property(
         fc.string({ minLength: 8 }).filter((s) => !/\d/.test(s)),
-        (password) => fails(registerSchema.safeParse({ ...validAuth, password }))
-      )
+        (password) => fails(registerSchema.safeParse({ ...validAuth, password })),
+      ),
     );
   });
 });
@@ -399,7 +399,7 @@ describe("listPiecesQuerySchema", () => {
         fc.property(fc.constantFrom("abc+", "abc/", "abc=", "abc!"), (invalid) => {
           const result = listPiecesQuerySchema.safeParse({ cursor: invalid });
           return fails(result);
-        })
+        }),
       );
     });
 
@@ -427,8 +427,8 @@ describe("listPiecesQuerySchema", () => {
           (limit) => {
             const result = listPiecesQuerySchema.safeParse({ limit });
             return succeeds(result);
-          }
-        )
+          },
+        ),
       );
     });
   });

--- a/cdk/bin/app.ts
+++ b/cdk/bin/app.ts
@@ -11,7 +11,7 @@ const validStages: StageName[] = ["dev", "stg", "prod"];
 const rawStageName = process.env.STAGE_NAME ?? "prod";
 if (!validStages.includes(rawStageName as StageName)) {
   throw new Error(
-    `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${validStages.join(", ")}`
+    `Invalid STAGE_NAME: "${rawStageName}". Must be one of: ${validStages.join(", ")}`,
   );
 }
 

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -169,7 +169,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
             override: true,
           },
         },
-      }
+      },
     );
 
     // Storybook 用セキュリティヘッダポリシー（X-Frame-Options を除外: iframe プレビューに必要）
@@ -194,7 +194,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
             override: true,
           },
         },
-      }
+      },
     );
 
     const distribution = new cloudfront.Distribution(this, "SpaDistribution", {
@@ -509,7 +509,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       assumedBy: new iam.ServicePrincipal("apigateway.amazonaws.com"),
       managedPolicies: [
         iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+          "service-role/AmazonAPIGatewayPushToCloudWatchLogs",
         ),
       ],
     });
@@ -676,35 +676,35 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     this.addCors(
       concertLogsResource,
       ["GET", "POST", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     this.addCors(
       concertLogResource,
       ["GET", "PUT", "DELETE", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     this.addCors(
       listeningLogsResource,
       ["GET", "POST", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     this.addCors(
       listeningLogResource,
       ["GET", "PUT", "DELETE", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     // 書き込み系（POST/PUT/DELETE）は Authorization ヘッダーが必要
     this.addCors(piecesResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
     this.addCors(
       pieceResource,
       ["GET", "PUT", "DELETE", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     this.addCors(composersResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
     this.addCors(
       composerResource,
       ["GET", "PUT", "DELETE", "OPTIONS"],
-      ["Content-Type", "Authorization"]
+      ["Content-Type", "Authorization"],
     );
     this.addCors(authRegisterResource, ["POST", "OPTIONS"]);
     this.addCors(authLoginResource, ["POST", "OPTIONS"]);
@@ -749,7 +749,7 @@ function handler(event) {
   }
   return request;
 }
-      `.trim()
+      `.trim(),
       ),
       runtime: cloudfront.FunctionRuntime.JS_2_0,
     });
@@ -768,7 +768,7 @@ function handler(event) {
             eventType: cloudfront.FunctionEventType.VIEWER_REQUEST,
           },
         ],
-      }
+      },
     );
 
     // NOTE: Storybook ファイルの S3 アップロードも GitHub Actions ワークフローで実行する。
@@ -969,7 +969,7 @@ function handler(event) {
   private addCors(
     resource: IResource,
     methods: string[],
-    allowHeaders: string[] = ["Content-Type"]
+    allowHeaders: string[] = ["Content-Type"],
   ): void {
     resource.addCorsPreflight({
       allowOrigins: this.corsAllowOrigins,

--- a/cdk/lib/migrations-stack.ts
+++ b/cdk/lib/migrations-stack.ts
@@ -88,7 +88,7 @@ export class MigrationsStack extends cdk.Stack {
       assumedBy: new cdk.aws_iam.ServicePrincipal("lambda.amazonaws.com"),
       managedPolicies: [
         cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName(
-          "service-role/AWSLambdaBasicExecutionRole"
+          "service-role/AWSLambdaBasicExecutionRole",
         ),
         cdk.aws_iam.ManagedPolicy.fromAwsManagedPolicyName("AWSXRayDaemonWriteAccess"),
       ],
@@ -107,7 +107,7 @@ export class MigrationsStack extends cdk.Stack {
           "dynamodb:Query",
         ],
         resources: tables.map((t) => t.tableArn),
-      })
+      }),
     );
     return role;
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -305,5 +305,5 @@ export default withNuxt(
         },
       ],
     },
-  }
+  },
 );

--- a/tests/e2e/auth-logout.test.ts
+++ b/tests/e2e/auth-logout.test.ts
@@ -17,7 +17,7 @@ describe("ユーザーログアウト E2E テスト", () => {
       await page.addInitScript(() => localStorage.setItem("accessToken", "fake-token-for-test"));
 
       await page.route("http://api.test/listening-logs", (route) =>
-        route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+        route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -45,7 +45,7 @@ describe("ユーザーログアウト E2E テスト", () => {
       await page.addInitScript(() => localStorage.setItem("accessToken", "fake-token-for-test"));
 
       await page.route("http://api.test/listening-logs", (route) =>
-        route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+        route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -66,7 +66,7 @@ describe("ユーザーログアウト E2E テスト", () => {
       await page.addInitScript(() => localStorage.setItem("accessToken", "fake-token-for-test"));
 
       await page.route("http://api.test/listening-logs", (route) =>
-        route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+        route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -86,7 +86,7 @@ describe("ユーザーログアウト E2E テスト", () => {
       await page.addInitScript(() => localStorage.setItem("accessToken", "fake-token-for-test"));
 
       await page.route("http://api.test/listening-logs", (route) =>
-        route.fulfill({ status: 200, contentType: "application/json", body: "[]" })
+        route.fulfill({ status: 200, contentType: "application/json", body: "[]" }),
       );
 
       await page.goto(url("/listening-logs"));

--- a/tests/e2e/listening-logs.test.ts
+++ b/tests/e2e/listening-logs.test.ts
@@ -52,7 +52,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify([]),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -71,7 +71,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify([testLog, testLog2]),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -92,7 +92,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify([testLog]),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -111,7 +111,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify([]),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs"));
@@ -153,7 +153,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify(testLog),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs/e2e-test-id-001"));
@@ -172,7 +172,7 @@ describe("鑑賞記録 E2E テスト", () => {
           status: 200,
           contentType: "application/json",
           body: JSON.stringify(testLog),
-        })
+        }),
       );
 
       await page.goto(url("/listening-logs/e2e-test-id-001"));


### PR DESCRIPTION
## 概要

Prettier の設定を更新し、`trailingComma` を `"es5"` から `"all"` に変更しました。これに伴い、全ファイルに対して Prettier フォーマッティングを適用しました。

## 変更の種類

- [x] リファクタリング

## 変更内容

- `.prettierrc` の設定を更新
  - `trailingComma`: `"es5"` → `"all"` に変更
  - `endOfLine`: `"lf"` を追加
  - `printWidth`: `100` を明示的に指定

- 全ファイルに Prettier フォーマッティングを適用
  - 関数呼び出しの最後の引数の後に末尾カンマを追加
  - 関数定義のパラメータリストの最後に末尾カンマを追加
  - オブジェクトリテラルの最後のプロパティに末尾カンマを追加
  - その他の Prettier フォーマッティング規則に従った調整

## テスト

- [x] 既存テストがすべて通ることを確認した
- [x] Prettier フォーマッティングが正しく適用されたことを確認した

## チェックリスト

- [x] コーディング規約に従っている
- [x] 実装を含まない変更のため、ドキュメント更新は不要

https://claude.ai/code/session_0142qzuiXtyFH5m82A1BZoNo