### PR TITLE
refactor(frontend): theme.css を Nuxt 標準の css オプションで読み込む

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -5,8 +5,6 @@
 </template>
 
 <style>
-@import "~/assets/css/theme.css";
-
 * {
   box-sizing: border-box;
   margin: 0;

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,6 +21,7 @@ export default defineNuxtConfig({
     storageKey: "nocturne-color-mode",
   },
   components: [{ path: "~/components", pathPrefix: false }],
+  css: ["~/assets/css/theme.css"],
   typescript: {
     strict: true,
   },


### PR DESCRIPTION
## 概要

theme.css のインポート方法を app.vue のスタイルブロックから Nuxt の css 設定に移行しました。

## 変更の種類

- [ ] バグ修正
- [x] 新機能
- [x] リファクタリング
- [ ] ドキュメント
- [ ] テスト
- [ ] その他（　　）

## 変更内容

- `app.vue` の `<style>` ブロックから `@import "~/assets/css/theme.css";` を削除
- `nuxt.config.ts` の `css` 配列に `"~/assets/css/theme.css"` を追加

この変更により、グローバルスタイルの管理が Nuxt の設定ファイルに一元化され、より標準的な Nuxt プロジェクト構成に統一されます。

## テスト

- [x] 動作確認をローカルで実施した

## チェックリスト

- [x] `any` 型を使用していない
- [x] コーディング規約に従っている
- [ ] 実装を含む変更の場合、`docs/SPEC.md` を更新した（設定変更のため不要）

https://claude.ai/code/session_017SjJNr1QuVAZ1hbxoVpx8L