### PR TITLE
docs: コミット規約・自動チェック・PRルールをCONTRIBUTING.mdに追記

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,9 +2,15 @@
 
 ## ブランチ戦略
 
-- `main` ブランチへの直接 push 禁止
-- 作業ブランチの命名: `feature/xxx`、`fix/xxx`、`docs/xxx`
-- 必ずPRを作成してマージすること
+- `main` ブランチへの直接 push 禁止。必ず PR を作成してマージすること
+- 作業ブランチの prefix は Conventional Commits の type と揃える:
+  - `feat/xxx` - 新機能
+  - `fix/xxx` - バグ修正
+  - `docs/xxx` - ドキュメント
+  - `refactor/xxx` - リファクタリング
+  - `test/xxx` - テスト
+  - `chore/xxx` - ビルド・依存関係などその他
+- prod / stg / dev の自動デプロイトリガー（`main` push で stg、Release publish で prod、`dev*` タグ push で dev）は [README.md](README.md#デプロイトリガーdeployyml) を参照
 
 ## 開発フロー
 
@@ -13,33 +19,83 @@
    ```bash
    git checkout main
    git pull origin main
-   git checkout -b feature/your-feature-name
+   git checkout -b feat/your-feature-name
    ```
 
 2. 実装・動作確認
 
+   PR を出す前に最低限以下を実行すること（pre-push フックでも自動実行されるが、事前に通しておくとフィードバックが早い）:
+
+   ```bash
+   pnpm run lint           # ESLint + Stylelint
+   pnpm run format:check   # Prettier
+   pnpm run test:frontend  # フロントエンドのテスト
+   pnpm run test:backend   # バックエンドのテスト
+   ```
+
+   > **注意**: `pnpm test` はバックエンドのみ実行される。両方テストしたい場合は `test:frontend` と `test:backend` を個別に実行すること。
+
 3. コミット
 
    ```bash
-   git add <ファイル>
-   git commit -m "feat: 変更内容の要約"
+   git add <ファイル>      # `.env` 等の混入を避けるため個別指定を推奨
+   git commit -m "feat: 変更内容を日本語で記述"
    ```
 
-4. PRを作成してレビュー後にマージ
+4. PR を作成してレビュー後にマージ
 
-## PRのルール
+## コミットメッセージ規約
 
-- 実装を含むPRは `docs/SPEC.md` を同じPR内で更新すること
-- PRタイトルはコミットメッセージ規約に準拠すること
+[Conventional Commits](https://www.conventionalcommits.org/) を採用しており、`commitlint`（`@commitlint/config-conventional`）と husky `commit-msg` フックで自動検証される。
+
+### フォーマット
+
+```text
+type(scope): 日本語の説明
+```
+
+- `scope` は省略可能
+- 説明（subject）は**日本語で記述**する
+- subject の先頭を**英大文字にしない**（`subject-case` ルール）。ファイル名等を先頭に置く場合は日本語から始める形に言い換える
+- 末尾に**ピリオド（`.`・`。`）を付けない**
+- ヘッダー全体は**100 文字以内**
+
+### type の例
+
+`feat` / `fix` / `docs` / `refactor` / `test` / `chore` / `style` / `perf` / `build` / `ci` / `revert`
+
+## 自動化されているチェック
+
+ローカルで以下のフックが自動実行される。失敗すると commit / push が止まる。
+
+| タイミング   | 実行内容                                                                                                                          |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| `pre-commit` | `lint-staged`（ステージ済みファイルに ESLint / Stylelint / Prettier を `--fix` で適用）                                           |
+| `commit-msg` | `commitlint`（Conventional Commits 検証）                                                                                         |
+| `pre-push`   | `pnpm run format:check` + `pnpm run test:frontend` + `pnpm -C backend test`（フロント・バック両方のテストが走るので時間がかかる） |
+
+## PR のルール
+
+- **タイトル**は Conventional Commits の規約に準拠すること（マージ後の changelog に反映される）
+- **実装を含む PR は `docs/SPEC.md` を同じ PR 内で更新する**こと（CLAUDE.md 基本ルール）
+- **`CHANGELOG.md` は手動更新しない**。Release Please（`release-please-config.json`）が自動生成する
+- フロント・バック両方のテストがグリーンであること
+- レビュー観点:
+  - DDD のレイヤー境界（`handlers/` → `usecases/` → `repositories/` → `domain/`）を守っているか（詳細は [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)）
+  - 型定義の配置ルール（`shared/` の共通定数、フロント・バック分離）に沿っているか（詳細は [docs/SPEC.md](docs/SPEC.md) §8）
+  - `any` 型を使っていないか（ESLint で error）
+
+## 設計方針
+
+このプロジェクトは **DDD（ドメイン駆動設計）** を採用している。エンティティ・値オブジェクト・レイヤー構造の詳細は以下を参照:
+
+- ディレクトリ構造・レイヤー境界: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- ID 値オブジェクト・エンティティ基底クラス・型定義管理方針: [docs/SPEC.md](docs/SPEC.md) §8
 
 ## ローカル開発環境
 
 [README.md](README.md) のセットアップ手順を参照してください。
 
-## ディレクトリ構造・設計方針
-
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) を参照してください。
-
-## API仕様・データモデル
+## API 仕様・データモデル
 
 [docs/SPEC.md](docs/SPEC.md) を参照してください。


### PR DESCRIPTION
## 概要

CONTRIBUTING.md を大幅に改訂し、開発フロー・コミットメッセージ規約・自動化されているチェック・PR ルール・設計方針を明確化しました。Conventional Commits の採用を明示し、ブランチ命名規則を `feature/xxx` から `feat/xxx` に統一しました。

## 変更の種類

- [x] ドキュメント

## 変更内容

- **ブランチ戦略の明確化**
  - `main` ブランチへの直接 push 禁止を強調
  - 作業ブランチの prefix を Conventional Commits の type と揃える（`feat/`、`fix/`、`docs/`、`refactor/`、`test/`、`chore/`）
  - 自動デプロイトリガーについて README.md への参照を追加

- **開発フロー の詳細化**
  - ブランチ名を `feature/your-feature-name` から `feat/your-feature-name` に更新
  - PR 前の必須チェック（lint、format、テスト）を明記
  - コミット時の `.env` 等の混入回避を注記

- **コミットメッセージ規約の新規追加**
  - Conventional Commits の採用を明示
  - `commitlint` と husky `commit-msg` フックによる自動検証を説明
  - フォーマット・type の例・日本語記述ルール（英大文字禁止、ピリオド禁止、100 文字以内）を詳細化

- **自動化されているチェック の新規追加**
  - `pre-commit`、`commit-msg`、`pre-push` の各フックと実行内容を表で整理

- **PR ルール の拡充**
  - タイトルが Conventional Commits に準拠することを強調
  - `CHANGELOG.md` は手動更新しないこと（Release Please による自動生成）を明記
  - レビュー観点（DDD レイヤー境界、型定義配置、`any` 型禁止）を追加

- **設計方針 セクションの新規追加**
  - DDD 採用を明示
  - ARCHITECTURE.md・SPEC.md への参照を整理

- **その他**
  - 「ローカル開発環境」「API 仕様・データモデル」セクションを整理・統合

## テスト

N/A（ドキュメント変更のため）

## チェックリスト

- [x] コーディング規約（CLAUDE.md）に従っている

https://claude.ai/code/session_01T6XgJwoK1dgtTu4YcQYP5m