### PR TITLE
refactor(atoms): カテゴリーバッジの色を theme.css のセマンティックトークンに移行

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -7,10 +7,12 @@ fi
 
 # Install / select Node.js 24 (package.json requires "node": ">=24.15.0")
 export NVM_DIR=/opt/nvm
+# nvm.sh は default alias が未解決の状態で読み込むと内部の nvm_auto が
+# return 3 で抜けるため、`set -e` の元では即死する。失敗を許容して読み込む。
 # shellcheck disable=SC1091
-. "$NVM_DIR/nvm.sh"
+. "$NVM_DIR/nvm.sh" || true
 
-if ! nvm ls 24 2>/dev/null | grep -q "v24\."; then
+if ! nvm version 24 >/dev/null 2>&1; then
   nvm install 24 --no-progress
 fi
 nvm use 24 >/dev/null

--- a/app/assets/css/theme.css
+++ b/app/assets/css/theme.css
@@ -63,6 +63,31 @@
   --color-header-text: #fff;
   --color-header-text-muted: #9aa5b4;
 
+  /* バッジ: デフォルト */
+  --color-badge-default-bg: #f0ebe0;
+  --color-badge-default-border: #e0d8cc;
+  --color-badge-default-text: #555;
+
+  /* バッジ: ジャンル */
+  --color-badge-genre-bg: #eef2fb;
+  --color-badge-genre-border: #c9d5ec;
+  --color-badge-genre-text: #2a3f6e;
+
+  /* バッジ: 時代 */
+  --color-badge-era-bg: #f4efe5;
+  --color-badge-era-border: #d9c9a8;
+  --color-badge-era-text: #6a5424;
+
+  /* バッジ: 編成 */
+  --color-badge-formation-bg: #eaf2ec;
+  --color-badge-formation-border: #c3d9c9;
+  --color-badge-formation-text: #28623e;
+
+  /* バッジ: 地域 */
+  --color-badge-region-bg: #f8ecec;
+  --color-badge-region-border: #e6c9c9;
+  --color-badge-region-text: #7b3a3a;
+
   /* 影 */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --shadow-md: 0 2px 8px rgba(0, 0, 0, 0.06);
@@ -130,6 +155,31 @@
   --color-header-bg: #0a1020;
   --color-header-text: #f0f3f9;
   --color-header-text-muted: #8b95a8;
+
+  /* バッジ: デフォルト */
+  --color-badge-default-bg: #2a2820;
+  --color-badge-default-border: #3d3a30;
+  --color-badge-default-text: #c9c2b0;
+
+  /* バッジ: ジャンル */
+  --color-badge-genre-bg: #1c2540;
+  --color-badge-genre-border: #2c3e6b;
+  --color-badge-genre-text: #b8c8e8;
+
+  /* バッジ: 時代 */
+  --color-badge-era-bg: #2a2418;
+  --color-badge-era-border: #4a3f25;
+  --color-badge-era-text: #d9c280;
+
+  /* バッジ: 編成 */
+  --color-badge-formation-bg: #1c2a1f;
+  --color-badge-formation-border: #2e4a35;
+  --color-badge-formation-text: #a8d6b0;
+
+  /* バッジ: 地域 */
+  --color-badge-region-bg: #2c1f1f;
+  --color-badge-region-border: #4a2c2c;
+  --color-badge-region-text: #e0a8a8;
 
   /* 影（ダーク用、より深く） */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);

--- a/app/components/atoms/ButtonDanger.test.ts
+++ b/app/components/atoms/ButtonDanger.test.ts
@@ -3,36 +3,63 @@ import ButtonDanger from "./ButtonDanger.vue";
 
 describe("ButtonDanger", () => {
   describe("表示", () => {
-    it("label が表示される", async () => {
+    it("スロットのテキストが描画される", async () => {
       const wrapper = await mountSuspended(ButtonDanger, {
-        props: { label: "削除" },
+        slots: { default: "削除" },
       });
       expect(wrapper.text()).toBe("削除");
     });
 
     it("btn-danger クラスが付いている", async () => {
       const wrapper = await mountSuspended(ButtonDanger, {
-        props: { label: "削除" },
+        slots: { default: "削除" },
       });
       expect(wrapper.find("button.btn-danger").exists()).toBe(true);
     });
+  });
 
-    it("type は button", async () => {
+  describe("props による挙動の変化", () => {
+    it("デフォルトの type は button", async () => {
       const wrapper = await mountSuspended(ButtonDanger, {
-        props: { label: "削除" },
+        slots: { default: "削除" },
       });
       expect(wrapper.find("button").attributes("type")).toBe("button");
+    });
+
+    it("type=submit を渡せる", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { type: "submit" },
+        slots: { default: "送信" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("submit");
+    });
+
+    it("disabled=true のとき button に disabled 属性が付く", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { disabled: true },
+        slots: { default: "処理中..." },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeDefined();
+    });
+
+    it("disabled=false のとき disabled 属性が付かない", async () => {
+      const wrapper = await mountSuspended(ButtonDanger, {
+        props: { disabled: false },
+        slots: { default: "削除" },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
     });
   });
 
   describe("イベント", () => {
-    it("クリック時に click イベントが emit される", async () => {
+    it("クリックで親に渡された onClick が呼ばれる", async () => {
+      const onClick = vi.fn();
       const wrapper = await mountSuspended(ButtonDanger, {
-        props: { label: "削除" },
+        slots: { default: "削除" },
+        attrs: { onClick },
       });
       await wrapper.find("button").trigger("click");
-      expect(wrapper.emitted("click")).toBeDefined();
-      expect(wrapper.emitted("click")).toHaveLength(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/atoms/ButtonDanger.test.ts
+++ b/app/components/atoms/ButtonDanger.test.ts
@@ -19,19 +19,11 @@ describe("ButtonDanger", () => {
   });
 
   describe("props による挙動の変化", () => {
-    it("デフォルトの type は button", async () => {
+    it("type は常に button 固定", async () => {
       const wrapper = await mountSuspended(ButtonDanger, {
         slots: { default: "削除" },
       });
       expect(wrapper.find("button").attributes("type")).toBe("button");
-    });
-
-    it("type=submit を渡せる", async () => {
-      const wrapper = await mountSuspended(ButtonDanger, {
-        props: { type: "submit" },
-        slots: { default: "送信" },
-      });
-      expect(wrapper.find("button").attributes("type")).toBe("submit");
     });
 
     it("disabled=true のとき button に disabled 属性が付く", async () => {

--- a/app/components/atoms/ButtonDanger.vue
+++ b/app/components/atoms/ButtonDanger.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-defineProps<{
-  type?: "button" | "submit";
-  disabled?: boolean;
-}>();
+import type { CommonButtonProps, ButtonSlots } from "./button-props";
+
+defineProps<CommonButtonProps>();
+defineSlots<ButtonSlots>();
 </script>
 
 <template>
-  <button class="btn-danger" :type="type ?? 'button'" :disabled="disabled">
+  <button class="btn-danger" type="button" :disabled="disabled">
     <slot />
   </button>
 </template>

--- a/app/components/atoms/ButtonDanger.vue
+++ b/app/components/atoms/ButtonDanger.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 defineProps<{
-  label: string;
-}>();
-
-const emit = defineEmits<{
-  click: [];
+  type?: "button" | "submit";
+  disabled?: boolean;
 }>();
 </script>
 
 <template>
-  <button type="button" class="btn-danger" @click="emit('click')">{{ label }}</button>
+  <button class="btn-danger" :type="type ?? 'button'" :disabled="disabled">
+    <slot />
+  </button>
 </template>
 
 <style scoped>
@@ -21,10 +20,20 @@ const emit = defineEmits<{
   border-radius: 6px;
   font-size: 0.85rem;
   cursor: pointer;
-  transition: background 0.2s;
+  transition: background-color 0.2s;
 }
 
-.btn-danger:hover {
+.btn-danger:hover:not(:disabled) {
   background: var(--color-danger-bg-strong);
+}
+
+.btn-danger:focus-visible {
+  outline: 2px solid var(--color-danger);
+  outline-offset: 2px;
+}
+
+.btn-danger:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 </style>

--- a/app/components/atoms/ButtonPrimary.test.ts
+++ b/app/components/atoms/ButtonPrimary.test.ts
@@ -2,48 +2,64 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ButtonPrimary from "./ButtonPrimary.vue";
 
 describe("ButtonPrimary", () => {
-  it("スロットのテキストが描画される", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      slots: { default: "保存する" },
+  describe("表示", () => {
+    it("スロットのテキストが描画される", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        slots: { default: "保存する" },
+      });
+      expect(wrapper.text()).toBe("保存する");
     });
-    expect(wrapper.text()).toBe("保存する");
+
+    it("btn-primary クラスが付いている", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        slots: { default: "保存する" },
+      });
+      expect(wrapper.find("button.btn-primary").exists()).toBe(true);
+    });
   });
 
-  it("btn-primary クラスが付いている", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      slots: { default: "保存する" },
+  describe("props による挙動の変化", () => {
+    it("デフォルトの type は button", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        slots: { default: "ボタン" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("button");
     });
-    expect(wrapper.find("button.btn-primary").exists()).toBe(true);
+
+    it("type=submit を渡せる", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        props: { type: "submit" },
+        slots: { default: "送信" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("submit");
+    });
+
+    it("disabled=true のとき button に disabled 属性が付く", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        props: { disabled: true },
+        slots: { default: "ログイン中..." },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeDefined();
+    });
+
+    it("disabled=false のとき disabled 属性が付かない", async () => {
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        props: { disabled: false },
+        slots: { default: "ログイン" },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
+    });
   });
 
-  it("デフォルトの type は button", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      slots: { default: "ボタン" },
+  describe("イベント", () => {
+    it("クリックで親に渡された onClick が呼ばれる", async () => {
+      const onClick = vi.fn();
+      const wrapper = await mountSuspended(ButtonPrimary, {
+        slots: { default: "保存する" },
+        attrs: { onClick },
+      });
+      await wrapper.find("button").trigger("click");
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
-    expect(wrapper.find("button").attributes("type")).toBe("button");
-  });
-
-  it("type=submit を渡せる", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      props: { type: "submit" },
-      slots: { default: "送信" },
-    });
-    expect(wrapper.find("button").attributes("type")).toBe("submit");
-  });
-
-  it("disabled=true のとき button に disabled 属性が付く", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      props: { disabled: true },
-      slots: { default: "ログイン中..." },
-    });
-    expect(wrapper.find("button").attributes("disabled")).toBeDefined();
-  });
-
-  it("disabled=false のとき disabled 属性が付かない", async () => {
-    const wrapper = await mountSuspended(ButtonPrimary, {
-      props: { disabled: false },
-      slots: { default: "ログイン" },
-    });
-    expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
   });
 });

--- a/app/components/atoms/ButtonPrimary.vue
+++ b/app/components/atoms/ButtonPrimary.vue
@@ -21,10 +21,24 @@ defineProps<{
   font-size: 0.95rem;
   cursor: pointer;
   text-decoration: none;
-  transition: background 0.2s;
+  transition: background-color 0.2s;
 }
 
-.btn-primary:hover {
+.btn-primary:hover:not(:disabled) {
   background: var(--color-primary-hover);
+}
+
+.btn-primary:active:not(:disabled) {
+  background: var(--color-primary-active);
+}
+
+.btn-primary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.btn-primary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 </style>

--- a/app/components/atoms/ButtonPrimary.vue
+++ b/app/components/atoms/ButtonPrimary.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-defineProps<{
-  type?: "button" | "submit";
-  disabled?: boolean;
-}>();
+import type { SubmittableButtonProps, ButtonSlots } from "./button-props";
+
+defineProps<SubmittableButtonProps>();
+defineSlots<ButtonSlots>();
 </script>
 
 <template>

--- a/app/components/atoms/ButtonSecondary.test.ts
+++ b/app/components/atoms/ButtonSecondary.test.ts
@@ -3,36 +3,63 @@ import ButtonSecondary from "./ButtonSecondary.vue";
 
 describe("ButtonSecondary", () => {
   describe("表示", () => {
-    it("label が表示される", async () => {
+    it("スロットのテキストが描画される", async () => {
       const wrapper = await mountSuspended(ButtonSecondary, {
-        props: { label: "戻る" },
+        slots: { default: "戻る" },
       });
       expect(wrapper.text()).toBe("戻る");
     });
 
     it("btn-secondary クラスが付いている", async () => {
       const wrapper = await mountSuspended(ButtonSecondary, {
-        props: { label: "戻る" },
+        slots: { default: "戻る" },
       });
       expect(wrapper.find("button.btn-secondary").exists()).toBe(true);
     });
+  });
 
-    it("type は button", async () => {
+  describe("props による挙動の変化", () => {
+    it("デフォルトの type は button", async () => {
       const wrapper = await mountSuspended(ButtonSecondary, {
-        props: { label: "戻る" },
+        slots: { default: "戻る" },
       });
       expect(wrapper.find("button").attributes("type")).toBe("button");
+    });
+
+    it("type=submit を渡せる", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { type: "submit" },
+        slots: { default: "送信" },
+      });
+      expect(wrapper.find("button").attributes("type")).toBe("submit");
+    });
+
+    it("disabled=true のとき button に disabled 属性が付く", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { disabled: true },
+        slots: { default: "処理中..." },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeDefined();
+    });
+
+    it("disabled=false のとき disabled 属性が付かない", async () => {
+      const wrapper = await mountSuspended(ButtonSecondary, {
+        props: { disabled: false },
+        slots: { default: "戻る" },
+      });
+      expect(wrapper.find("button").attributes("disabled")).toBeUndefined();
     });
   });
 
   describe("イベント", () => {
-    it("クリック時に click イベントが emit される", async () => {
+    it("クリックで親に渡された onClick が呼ばれる", async () => {
+      const onClick = vi.fn();
       const wrapper = await mountSuspended(ButtonSecondary, {
-        props: { label: "戻る" },
+        slots: { default: "戻る" },
+        attrs: { onClick },
       });
       await wrapper.find("button").trigger("click");
-      expect(wrapper.emitted("click")).toBeDefined();
-      expect(wrapper.emitted("click")).toHaveLength(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/app/components/atoms/ButtonSecondary.test.ts
+++ b/app/components/atoms/ButtonSecondary.test.ts
@@ -19,19 +19,11 @@ describe("ButtonSecondary", () => {
   });
 
   describe("props による挙動の変化", () => {
-    it("デフォルトの type は button", async () => {
+    it("type は常に button 固定", async () => {
       const wrapper = await mountSuspended(ButtonSecondary, {
         slots: { default: "戻る" },
       });
       expect(wrapper.find("button").attributes("type")).toBe("button");
-    });
-
-    it("type=submit を渡せる", async () => {
-      const wrapper = await mountSuspended(ButtonSecondary, {
-        props: { type: "submit" },
-        slots: { default: "送信" },
-      });
-      expect(wrapper.find("button").attributes("type")).toBe("submit");
     });
 
     it("disabled=true のとき button に disabled 属性が付く", async () => {

--- a/app/components/atoms/ButtonSecondary.vue
+++ b/app/components/atoms/ButtonSecondary.vue
@@ -1,15 +1,14 @@
 <script setup lang="ts">
 defineProps<{
-  label: string;
-}>();
-
-const emit = defineEmits<{
-  click: [];
+  type?: "button" | "submit";
+  disabled?: boolean;
 }>();
 </script>
 
 <template>
-  <button type="button" class="btn-secondary" @click="emit('click')">{{ label }}</button>
+  <button class="btn-secondary" :type="type ?? 'button'" :disabled="disabled">
+    <slot />
+  </button>
 </template>
 
 <style scoped>
@@ -22,10 +21,20 @@ const emit = defineEmits<{
   font-size: 0.95rem;
   cursor: pointer;
   text-decoration: none;
-  transition: background 0.2s;
+  transition: background-color 0.2s;
 }
 
-.btn-secondary:hover {
+.btn-secondary:hover:not(:disabled) {
   background: var(--color-border-strong);
+}
+
+.btn-secondary:focus-visible {
+  outline: 2px solid var(--color-primary);
+  outline-offset: 2px;
+}
+
+.btn-secondary:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
 }
 </style>

--- a/app/components/atoms/ButtonSecondary.vue
+++ b/app/components/atoms/ButtonSecondary.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-defineProps<{
-  type?: "button" | "submit";
-  disabled?: boolean;
-}>();
+import type { CommonButtonProps, ButtonSlots } from "./button-props";
+
+defineProps<CommonButtonProps>();
+defineSlots<ButtonSlots>();
 </script>
 
 <template>
-  <button class="btn-secondary" :type="type ?? 'button'" :disabled="disabled">
+  <button class="btn-secondary" type="button" :disabled="disabled">
     <slot />
   </button>
 </template>

--- a/app/components/atoms/CategoryBadge.vue
+++ b/app/components/atoms/CategoryBadge.vue
@@ -26,62 +26,32 @@ const ariaLabel = computed(() => `${props.label}: ${props.value}`);
 }
 
 .kind-default {
-  background: #f0ebe0;
-  border-color: #e0d8cc;
-  color: #555;
+  background: var(--color-badge-default-bg);
+  border-color: var(--color-badge-default-border);
+  color: var(--color-badge-default-text);
 }
 
 .kind-genre {
-  background: #eef2fb;
-  border-color: #c9d5ec;
-  color: #2a3f6e;
+  background: var(--color-badge-genre-bg);
+  border-color: var(--color-badge-genre-border);
+  color: var(--color-badge-genre-text);
 }
 
 .kind-era {
-  background: #f4efe5;
-  border-color: #d9c9a8;
-  color: #6a5424;
+  background: var(--color-badge-era-bg);
+  border-color: var(--color-badge-era-border);
+  color: var(--color-badge-era-text);
 }
 
 .kind-formation {
-  background: #eaf2ec;
-  border-color: #c3d9c9;
-  color: #28623e;
+  background: var(--color-badge-formation-bg);
+  border-color: var(--color-badge-formation-border);
+  color: var(--color-badge-formation-text);
 }
 
 .kind-region {
-  background: #f8ecec;
-  border-color: #e6c9c9;
-  color: #7b3a3a;
-}
-
-:global(.dark) .kind-default {
-  background: #2a2820;
-  border-color: #3d3a30;
-  color: #c9c2b0;
-}
-
-:global(.dark) .kind-genre {
-  background: #1c2540;
-  border-color: #2c3e6b;
-  color: #b8c8e8;
-}
-
-:global(.dark) .kind-era {
-  background: #2a2418;
-  border-color: #4a3f25;
-  color: #d9c280;
-}
-
-:global(.dark) .kind-formation {
-  background: #1c2a1f;
-  border-color: #2e4a35;
-  color: #a8d6b0;
-}
-
-:global(.dark) .kind-region {
-  background: #2c1f1f;
-  border-color: #4a2c2c;
-  color: #e0a8a8;
+  background: var(--color-badge-region-bg);
+  border-color: var(--color-badge-region-border);
+  color: var(--color-badge-region-text);
 }
 </style>

--- a/app/components/atoms/button-props.ts
+++ b/app/components/atoms/button-props.ts
@@ -1,0 +1,28 @@
+/**
+ * Button atom 群が共通で受け取る props。
+ *
+ * 新しい Button atom を追加するときは、defineProps の型引数として
+ * CommonButtonProps もしくはそれを拡張した型（SubmittableButtonProps 等）を
+ * 必ず使うこと。インラインの型リテラルで宣言するとドリフトの原因になる。
+ */
+export type CommonButtonProps = {
+  disabled?: boolean;
+};
+
+/**
+ * フォーム送信ボタンとしても使われる Button が追加で受け取る props。
+ * `type="submit"` を許容するのは Primary のような主アクション用ボタンに限る
+ * （Secondary / Danger 等の補助・破壊操作ボタンには付けない）。
+ */
+export type SubmittableButtonProps = CommonButtonProps & {
+  type?: "button" | "submit";
+};
+
+/**
+ * Button atom 群が共通で公開する slot 契約。
+ * `default` slot 経由でラベルを受け取るため、`label` props 等への逸脱を
+ * 型レベルで防ぐ目的で定義している。
+ */
+export type ButtonSlots = {
+  default(): unknown;
+};

--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -30,8 +30,8 @@ const emit = defineEmits<{
     </div>
     <div class="composer-actions">
       <button type="button" class="btn-detail" @click="emit('detail')">詳細</button>
-      <ButtonSecondary label="編集" @click="emit('edit')" />
-      <ButtonDanger label="削除" @click="emit('delete')" />
+      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
     </div>
   </div>
 </template>

--- a/app/components/molecules/ConcertLogItem.vue
+++ b/app/components/molecules/ConcertLogItem.vue
@@ -30,7 +30,7 @@ const emit = defineEmits<{
       <div v-if="concertLog.soloist" class="log-sub">ソリスト: {{ concertLog.soloist }}</div>
     </div>
     <div class="log-actions">
-      <ButtonSecondary label="詳細" @click="emit('detail')" />
+      <ButtonSecondary @click="emit('detail')">詳細</ButtonSecondary>
     </div>
   </div>
 </template>

--- a/app/components/molecules/FormActions.vue
+++ b/app/components/molecules/FormActions.vue
@@ -11,7 +11,7 @@ const emit = defineEmits<{
 
 <template>
   <div class="form-actions">
-    <ButtonSecondary label="キャンセル" @click="emit('cancel')" />
+    <ButtonSecondary @click="emit('cancel')">キャンセル</ButtonSecondary>
     <ButtonPrimary type="submit" :disabled="isSubmitting">
       {{ submitLabel ?? "保存する" }}
     </ButtonPrimary>

--- a/app/components/molecules/ListeningLogFilter.vue
+++ b/app/components/molecules/ListeningLogFilter.vue
@@ -84,12 +84,9 @@ function update<K extends keyof ListeningLogFilterState>(
         />
         <span>お気に入りのみ</span>
       </label>
-      <ButtonSecondary
-        v-if="isActive"
-        class="filter-reset"
-        label="条件をクリア"
-        @click="emit('reset')"
-      />
+      <ButtonSecondary v-if="isActive" class="filter-reset" @click="emit('reset')">
+        条件をクリア
+      </ButtonSecondary>
     </div>
   </div>
 </template>

--- a/app/components/molecules/ListeningLogItem.vue
+++ b/app/components/molecules/ListeningLogItem.vue
@@ -31,8 +31,8 @@ const emit = defineEmits<{
       <p v-if="listeningLog.memo" class="log-memo">{{ listeningLog.memo }}</p>
     </div>
     <div class="log-actions">
-      <ButtonSecondary label="編集" @click="emit('edit')" />
-      <ButtonDanger label="削除" @click="emit('delete')" />
+      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
     </div>
   </div>
 </template>

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -41,8 +41,8 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
     </div>
     <div class="piece-actions">
       <button type="button" class="btn-detail" @click="emit('detail')">詳細</button>
-      <ButtonSecondary label="編集" @click="emit('edit')" />
-      <ButtonDanger label="削除" @click="emit('delete')" />
+      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
     </div>
   </div>
 </template>

--- a/app/components/templates/ConcertLogDetailTemplate.vue
+++ b/app/components/templates/ConcertLogDetailTemplate.vue
@@ -35,8 +35,10 @@ const handleDelete = async () => {
     <div class="page-header">
       <NuxtLink to="/concert-logs" class="back-link">← コンサート記録一覧</NuxtLink>
       <div class="actions">
-        <ButtonSecondary label="編集" @click="router.push(`/concert-logs/${props.log.id}/edit`)" />
-        <ButtonDanger label="削除" @click="handleDelete" />
+        <ButtonSecondary @click="router.push(`/concert-logs/${props.log.id}/edit`)">
+          編集
+        </ButtonSecondary>
+        <ButtonDanger @click="handleDelete">削除</ButtonDanger>
       </div>
     </div>
 

--- a/app/components/templates/ListeningLogDetailTemplate.vue
+++ b/app/components/templates/ListeningLogDetailTemplate.vue
@@ -22,11 +22,10 @@ const handleDelete = async () => {
     <div class="page-header">
       <NuxtLink to="/listening-logs" class="back-link">← 鑑賞記録一覧</NuxtLink>
       <div class="actions">
-        <ButtonSecondary
-          label="編集"
-          @click="router.push(`/listening-logs/${props.log.id}/edit`)"
-        />
-        <ButtonDanger label="削除" @click="handleDelete" />
+        <ButtonSecondary @click="router.push(`/listening-logs/${props.log.id}/edit`)">
+          編集
+        </ButtonSecondary>
+        <ButtonDanger @click="handleDelete">削除</ButtonDanger>
       </div>
     </div>
 


### PR DESCRIPTION
CategoryBadge.vue が生のカラーコード（#f0ebe0 等）と :global(.dark)
セレクタで独自にダーク対応していたため、theme.css 単一情報源の規約から
逸脱していた。バッジ用トークン（--color-badge-{kind}-bg / -border / -text）
をライト・ダーク両モードに追加し、CategoryBadge.vue を var(--...) 参照に
置換した。