### PR TITLE
fix(ui): 探索的レビューで見つけた UI 問題をまとめて修正

### DIFF
--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -94,7 +94,7 @@ const emit = defineEmits<{
   background: var(--color-border);
 }
 
-:global(.dark) .btn-detail {
+:global(.dark .btn-detail) {
   border-color: #6e5a3d;
 }
 

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -125,11 +125,11 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
   background: var(--color-border);
 }
 
-:global(.dark) .piece-thumbnail:focus-visible {
+:global(.dark .piece-thumbnail:focus-visible) {
   outline-color: #6e5a3d;
 }
 
-:global(.dark) .btn-detail {
+:global(.dark .btn-detail) {
   border-color: #6e5a3d;
 }
 

--- a/app/components/molecules/RatingSelector.vue
+++ b/app/components/molecules/RatingSelector.vue
@@ -46,7 +46,7 @@ const emit = defineEmits<{
   color: var(--color-warning);
 }
 
-:global(.dark) .star-btn {
+:global(.dark .star-btn) {
   color: #6e5a3d;
 }
 </style>

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -252,11 +252,11 @@ function handleSubmit() {
   color: var(--color-on-primary);
 }
 
-:global(.dark) .btn-add-piece {
+:global(.dark .btn-add-piece) {
   background: #6a8fc5;
 }
 
-:global(.dark) .btn-add-piece:hover {
+:global(.dark .btn-add-piece:hover) {
   background: #7a9fd5;
 }
 </style>

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -88,9 +88,17 @@ form {
   color: #7a5c38;
 }
 
+.register-link p {
+  margin: 0;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
 .register-link a {
+  display: inline-block;
   color: var(--color-primary-soft);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .register-link a:hover {
@@ -130,20 +138,25 @@ form {
   background-color: var(--color-bg-elevated);
 }
 
-:global(.dark) .register-link {
-  color: #c8a878;
+:global(.dark .register-link) {
+  color: var(--color-text-secondary);
 }
 
-:global(.dark) .divider {
-  color: #c8a878;
+:global(.dark .register-link a) {
+  color: var(--color-link);
 }
 
-:global(.dark) .divider::before,
-:global(.dark) .divider::after {
-  border-bottom-color: #6e5435;
+:global(.dark .divider) {
+  color: var(--color-text-muted);
 }
 
-:global(.dark) .btn-google-login {
-  border-color: #6e5435;
+:global(.dark .divider::before),
+:global(.dark .divider::after) {
+  border-bottom-color: var(--color-border-strong);
+}
+
+:global(.dark .btn-google-login) {
+  border-color: var(--color-border-strong);
+  color: var(--color-text);
 }
 </style>

--- a/app/components/organisms/UserRegisterForm.vue
+++ b/app/components/organisms/UserRegisterForm.vue
@@ -107,29 +107,41 @@ form {
   color: #7a5c38;
 }
 
+.login-link p {
+  margin: 0;
+  word-break: keep-all;
+  overflow-wrap: anywhere;
+}
+
 .login-link a {
+  display: inline-block;
   color: var(--color-primary-soft);
   text-decoration: none;
+  white-space: nowrap;
 }
 
 .login-link a:hover {
   text-decoration: underline;
 }
 
-:global(.dark) .password-requirements {
+:global(.dark .password-requirements) {
   color: #c8a878;
 }
 
-:global(.dark) .success-message {
+:global(.dark .success-message) {
   background-color: #2a5218;
   color: #d8e8c0;
 }
 
-:global(.dark) .success-message a {
+:global(.dark .success-message a) {
   color: #d8e8c0;
 }
 
-:global(.dark) .login-link {
-  color: #c8a878;
+:global(.dark .login-link) {
+  color: var(--color-text-secondary);
+}
+
+:global(.dark .login-link a) {
+  color: var(--color-link);
 }
 </style>

--- a/app/components/organisms/VerifyEmailForm.vue
+++ b/app/components/organisms/VerifyEmailForm.vue
@@ -143,20 +143,20 @@ input[type="text"]:focus {
   text-decoration: none;
 }
 
-:global(.dark) .description {
+:global(.dark .description) {
   color: #c8a878;
 }
 
-:global(.dark) .info-message {
+:global(.dark .info-message) {
   color: #d8e8c0;
   background-color: #2a5218;
 }
 
-:global(.dark) .resend-section {
+:global(.dark .resend-section) {
   color: #c8a878;
 }
 
-:global(.dark) .resend-button:disabled {
+:global(.dark .resend-button:disabled) {
   color: #6e5435;
 }
 </style>

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -262,7 +262,7 @@ defineProps<{
 .cta-primary {
   display: inline-block;
   padding: 0.75rem 2rem;
-  background: var(--color-bg-surface);
+  background: #fff;
   color: var(--color-primary);
   border-radius: 6px;
   text-decoration: none;
@@ -413,12 +413,12 @@ defineProps<{
 }
 
 /* ── Dark mode overrides for purple-themed admin cards ── */
-:global(.dark) .admin-card {
+:global(.dark .admin-card) {
   background: #2a1f3a;
   border-color: #6e4ea8;
 }
 
-:global(.dark) .admin-card h3 {
+:global(.dark .admin-card h3) {
   color: #c4a8e0;
 }
 </style>

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -100,45 +100,47 @@ describe("useAuth", () => {
       expect(getPasswordValidationError("ValidPassword123")).toBeNull();
     });
 
-    it("パスワードが空のとき 'Password is required' を返す", () => {
+    it("パスワードが空のとき入力を促すエラーメッセージを返す", () => {
       const { getPasswordValidationError } = useAuth();
-      expect(getPasswordValidationError("")).toBe("Password is required");
+      expect(getPasswordValidationError("")).toBe("パスワードを入力してください");
     });
 
     it("8文字未満のとき文字数エラーメッセージを返す", () => {
       const { getPasswordValidationError } = useAuth();
-      expect(getPasswordValidationError("Short1A")).toContain("8 characters");
+      expect(getPasswordValidationError("Short1A")).toContain("8文字以上");
     });
 
     it("大文字を含まないとき大文字エラーメッセージを返す", () => {
       const { getPasswordValidationError } = useAuth();
-      expect(getPasswordValidationError("lowercase123")).toContain("uppercase");
+      expect(getPasswordValidationError("lowercase123")).toContain("大文字");
     });
 
     it("小文字を含まないとき小文字エラーメッセージを返す", () => {
       const { getPasswordValidationError } = useAuth();
-      expect(getPasswordValidationError("UPPERCASE123")).toContain("lowercase");
+      expect(getPasswordValidationError("UPPERCASE123")).toContain("小文字");
     });
 
     it("数字を含まないとき数字エラーメッセージを返す", () => {
       const { getPasswordValidationError } = useAuth();
-      expect(getPasswordValidationError("NoNumbersHere")).toContain("digit");
+      expect(getPasswordValidationError("NoNumbersHere")).toContain("数字");
     });
   });
 
   describe("register", () => {
-    it("メールアドレスが無効なとき success: false を返す", async () => {
+    it("メールアドレスが無効なとき success: false と errorType: email を返す", async () => {
       const { register } = useAuth();
       const result = await register("invalid-email", "ValidPassword123");
       expect(result.success).toBe(false);
-      expect(result.error).toContain("email");
+      expect(result.errorType).toBe("email");
+      expect(result.error).toContain("メールアドレス");
     });
 
-    it("パスワードが無効なとき success: false を返す", async () => {
+    it("パスワードが無効なとき success: false と errorType: password を返す", async () => {
       const { register } = useAuth();
       const result = await register("user@example.com", "weak");
       expect(result.success).toBe(false);
-      expect(result.error).toBeDefined();
+      expect(result.errorType).toBe("password");
+      expect(result.error).toContain("パスワード");
     });
 
     it("API 呼び出しが成功したとき success: true を返す", async () => {

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -39,9 +39,12 @@ const PASSWORD_UPPERCASE_REGEX = /[A-Z]/;
 const PASSWORD_LOWERCASE_REGEX = /[a-z]/;
 const PASSWORD_DIGIT_REGEX = /\d/;
 
+export type RegisterErrorType = "email" | "password" | "general";
+
 export interface RegisterResult {
   success: boolean;
   error?: string;
+  errorType?: RegisterErrorType;
 }
 
 export type LoginErrorType = "email" | "password" | "credentials" | "not_confirmed" | "general";
@@ -111,19 +114,19 @@ export const useAuth = () => {
 
   const getPasswordValidationError = (password: string): string | null => {
     if (password === "") {
-      return "Password is required";
+      return "パスワードを入力してください";
     }
     if (password.length < PASSWORD_MIN_LENGTH) {
-      return `Password must be at least ${PASSWORD_MIN_LENGTH} characters long`;
+      return `パスワードは${PASSWORD_MIN_LENGTH}文字以上で入力してください`;
     }
     if (!PASSWORD_UPPERCASE_REGEX.test(password)) {
-      return "Password must contain at least one uppercase letter";
+      return "パスワードには大文字を1文字以上含めてください";
     }
     if (!PASSWORD_LOWERCASE_REGEX.test(password)) {
-      return "Password must contain at least one lowercase letter";
+      return "パスワードには小文字を1文字以上含めてください";
     }
     if (!PASSWORD_DIGIT_REGEX.test(password)) {
-      return "Password must contain at least one digit";
+      return "パスワードには数字を1文字以上含めてください";
     }
     return null;
   };
@@ -132,7 +135,8 @@ export const useAuth = () => {
     if (!validateEmail(email)) {
       return {
         success: false,
-        error: "Please enter a valid email address",
+        error: "有効なメールアドレスを入力してください",
+        errorType: "email",
       };
     }
 
@@ -141,6 +145,7 @@ export const useAuth = () => {
       return {
         success: false,
         error: passwordError,
+        errorType: "password",
       };
     }
 
@@ -160,7 +165,8 @@ export const useAuth = () => {
         const errorData = await response.json().catch(() => ({}));
         return {
           success: false,
-          error: errorData.message ?? "Registration failed. Please try again.",
+          error: errorData.message ?? "登録に失敗しました。時間をおいて再度お試しください",
+          errorType: "general",
         };
       }
 
@@ -171,7 +177,10 @@ export const useAuth = () => {
       return {
         success: false,
         error:
-          error instanceof Error ? error.message : "A network error occurred. Please try again.",
+          error instanceof Error
+            ? error.message
+            : "ネットワークエラーが発生しました。時間をおいて再度お試しください",
+        errorType: "general",
       };
     }
   };
@@ -180,7 +189,7 @@ export const useAuth = () => {
     if (!validateEmail(email)) {
       return {
         success: false,
-        error: "Please enter a valid email address",
+        error: "有効なメールアドレスを入力してください",
         errorType: "email",
       };
     }
@@ -188,7 +197,7 @@ export const useAuth = () => {
     if (password === "") {
       return {
         success: false,
-        error: "Password is required",
+        error: "パスワードを入力してください",
         errorType: "password",
       };
     }
@@ -208,7 +217,7 @@ export const useAuth = () => {
           errorData.error === "UserNotConfirmed" ? "not_confirmed" : "credentials";
         return {
           success: false,
-          error: errorData.message ?? "Login failed. Please try again.",
+          error: errorData.message ?? "ログインに失敗しました。時間をおいて再度お試しください",
           errorType,
         };
       }
@@ -217,28 +226,28 @@ export const useAuth = () => {
       if (typeof data.accessToken !== "string" || data.accessToken.trim() === "") {
         return {
           success: false,
-          error: "Invalid session data received. Please try again.",
+          error: "セッション情報の取得に失敗しました。時間をおいて再度お試しください",
           errorType: "general",
         };
       }
       if (typeof data.idToken !== "string" || data.idToken.trim() === "") {
         return {
           success: false,
-          error: "Invalid session data received. Please try again.",
+          error: "セッション情報の取得に失敗しました。時間をおいて再度お試しください",
           errorType: "general",
         };
       }
       if (typeof data.refreshToken !== "string" || data.refreshToken.trim() === "") {
         return {
           success: false,
-          error: "Invalid session data received. Please try again.",
+          error: "セッション情報の取得に失敗しました。時間をおいて再度お試しください",
           errorType: "general",
         };
       }
       if (typeof data.expiresIn !== "number") {
         return {
           success: false,
-          error: "Invalid session data received. Please try again.",
+          error: "セッション情報の取得に失敗しました。時間をおいて再度お試しください",
           errorType: "general",
         };
       }
@@ -248,7 +257,7 @@ export const useAuth = () => {
       } catch {
         return {
           success: false,
-          error: "Failed to save session. Please try again.",
+          error: "セッションの保存に失敗しました。時間をおいて再度お試しください",
           errorType: "general",
         };
       }
@@ -261,7 +270,9 @@ export const useAuth = () => {
       return {
         success: false,
         error:
-          error instanceof Error ? error.message : "A network error occurred. Please try again.",
+          error instanceof Error
+            ? error.message
+            : "ネットワークエラーが発生しました。時間をおいて再度お試しください",
         errorType: "general",
       };
     }
@@ -283,7 +294,7 @@ export const useAuth = () => {
           VERIFY_EMAIL_ERROR_TYPE_MAP[errorData.error] ?? "general";
         return {
           success: false,
-          error: errorData.message ?? "Verification failed. Please try again.",
+          error: errorData.message ?? "確認に失敗しました。時間をおいて再度お試しください",
           errorType,
         };
       }
@@ -293,7 +304,9 @@ export const useAuth = () => {
       return {
         success: false,
         error:
-          error instanceof Error ? error.message : "A network error occurred. Please try again.",
+          error instanceof Error
+            ? error.message
+            : "ネットワークエラーが発生しました。時間をおいて再度お試しください",
         errorType: "general",
       };
     }
@@ -313,7 +326,8 @@ export const useAuth = () => {
         const errorData = await response.json().catch(() => ({}));
         return {
           success: false,
-          error: errorData.message ?? "Failed to resend verification code. Please try again.",
+          error:
+            errorData.message ?? "確認コードの再送信に失敗しました。時間をおいて再度お試しください",
         };
       }
 
@@ -322,7 +336,9 @@ export const useAuth = () => {
       return {
         success: false,
         error:
-          error instanceof Error ? error.message : "A network error occurred. Please try again.",
+          error instanceof Error
+            ? error.message
+            : "ネットワークエラーが発生しました。時間をおいて再度お試しください",
       };
     }
   };

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -144,14 +144,15 @@ watch(
   padding: 2rem;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
   .app-header {
-    padding: 0.75rem 0.75rem;
+    padding: 0.5rem 0.75rem;
   }
 
   .app-header nav {
-    gap: 0.5rem;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
+    row-gap: 0.5rem;
   }
 
   .logo {
@@ -159,15 +160,21 @@ watch(
   }
 
   .logo-img {
-    height: 26px;
+    height: 24px;
   }
 
   .logo-text {
-    display: none;
+    font-size: 1.1rem;
   }
 
   .nav-links {
-    gap: 0.6rem;
+    order: 3;
+    flex-basis: 100%;
+    justify-content: space-between;
+    gap: 0.5rem;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: 0.25rem;
   }
 
   .nav-links a,
@@ -176,16 +183,24 @@ watch(
   }
 
   .auth-links {
+    margin-left: auto;
     gap: 0.6rem;
   }
 
   .logout-button {
+    margin-left: auto;
     padding: 0.3rem 0.6rem;
     font-size: 0.8rem;
   }
 
   .app-main {
     padding: 1rem;
+  }
+}
+
+@media (max-width: 380px) {
+  .logo-text {
+    display: none;
   }
 }
 </style>

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -59,7 +59,7 @@ onMounted(async () => {
   font-size: 1rem;
 }
 
-:global(.dark) .loading-message {
+:global(.dark .loading-message) {
   color: #d4c5b0;
 }
 </style>

--- a/app/pages/auth/user-register.vue
+++ b/app/pages/auth/user-register.vue
@@ -28,15 +28,19 @@ async function handleSubmit(email: string, password: string) {
     if (result.success === true) {
       sessionStorage.setItem("pendingPassword", password);
       router.push({ path: "/auth/verify-email", state: { email } });
-    } else if (result.error?.includes("email") === true) {
-      errors.email = result.error;
-    } else if (result.error?.includes("password") === true) {
-      errors.password = result.error;
-    } else if (result.error?.includes("already") === true) {
+      return;
+    }
+
+    const message = result.error ?? "登録に失敗しました";
+
+    if (result.errorType === "email") {
+      errors.email = message;
+    } else if (result.errorType === "password") {
+      errors.password = message;
+    } else if (message.includes("already") === true || message.includes("既に") === true) {
       errors.email = "このメールアドレスは既に登録されています";
     } else {
-      errors.email =
-        result.error !== undefined && result.error !== "" ? result.error : "登録に失敗しました";
+      errors.email = message;
     }
   } finally {
     isLoading.value = false;


### PR DESCRIPTION
## Summary

Playwright を使った探索的レビューで発見した複数の UI 問題をまとめて修正します。

### 修正内容

#### 1. 新規登録のエラーメッセージ修正
- \`useAuth.ts\` の \`register\` / \`login\` / \`verifyEmail\` / \`resendVerificationCode\` のローカルバリデーションメッセージを **日本語化**（他の UI が日本語で統一されているのにここだけ英語だった）
- \`RegisterResult\` に \`errorType\` フィールド（\`'email' | 'password' | 'general'\`）を追加
- \`pages/auth/user-register.vue\` のエラー振り分けを \`errorType\` ベースに変更
  - **修正前**: \`result.error?.includes(\"password\")\` で大文字 \`P\` にマッチせず、パスワードエラーが**メールアドレス欄の下**に表示されていた
  - **修正後**: パスワードエラーは正しくパスワード欄の下に表示

#### 2. モバイルヘッダーのレスポンシブ対応
- \`layouts/default.vue\`：375px 画面で **180px の横オーバーフロー** が発生していた
- 720px 以下で 2 段組レイアウト（ロゴ・認証リンク・テーマ切替が 1 段目、ナビが 2 段目）
- 380px 以下では \`Nocturne\` ロゴテキストを非表示

#### 3. ログインカード下部リンクの折り返し
- モバイルで「アカウントをお持ちでない方は **新規登録**」のリンクが折り返してカード外にはみ出していた
- リンクに \`white-space: nowrap\` + \`display: inline-block\`、本文に \`word-break: keep-all\` を適用
- \`UserRegisterForm.vue\` の \"既にアカウントをお持ちですか？\" にも同様の対応

#### 4. ダークモードのコントラスト改善
- TOP ヒーローの「鑑賞記録を残す」ボタンが背景画像と同化していた → 背景を \`#fff\` 固定に
- ログインの「Google でログイン」ボタンの文字色を \`var(--color-text)\` に
- 登録/ログインの \"新規登録\" / \"ログイン\" リンクを \`var(--color-link)\` に

#### 5. \`:global(.dark) .x\` 構文の修正（副次的な発見）
- Vue 3 の SFC scoped style で \`:global(.dark) .x { ... }\` と書くと、コンパイラ出力が \`.dark { ... }\` に縮約されてしまい、後ろのセレクタが消えてダークモード CSS が効かない状態になっていた
- 9 ファイル分、すべて \`:global(.dark .x) { ... }\` 形式に統一（これにより既存のダーク用スタイルが正しく適用されるようになった）

### 検証

- \`pnpm run test:frontend\`: 103 ファイル / 721 テスト すべてパス
- \`pnpm run lint\`: エラーなし
- Playwright で実機検証
  - ライト / ダーク × デスクトップ / モバイル すべて確認済み
  - 修正前後のスクリーンショットあり

## Test plan

- [ ] CI （test / lint / build）のグリーン確認
- [ ] dev へのデプロイ後、実機（特にスマホ）でヘッダーがオーバーフローしないことを確認
- [ ] ダークモードでのコントラストを目視確認（ヒーロー CTA / Google ログイン / 認証リンク）
- [ ] 弱いパスワードで新規登録してエラーがパスワード欄の下に日本語で表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)