### PR TITLE
feat(ui): フロントエンド全画面を Editorial Quarterly 風にリデザイン

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -11,12 +11,194 @@
   padding: 0;
 }
 
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-rendering: optimizeLegibility;
+  scroll-behavior: smooth;
+}
+
+/* スムーススクロールは reduced-motion 利用者にはオフ */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
-  font-family: "Georgia", serif;
+  font-family: var(--font-sans);
+  font-feature-settings:
+    "ss01" 1,
+    "ss02" 1,
+    "cv11" 1;
+  font-weight: 400;
   background-color: var(--color-bg-base);
   color: var(--color-text);
   transition:
-    background-color 0.2s ease,
-    color 0.2s ease;
+    background-color 0.3s ease,
+    color 0.3s ease;
+  position: relative;
+  min-height: 100vh;
+}
+
+/* 紙の繊維感: 縦横に走る極細のライン + 微細なノイズ */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 3px,
+      rgba(19, 28, 56, 0.012) 3px,
+      rgba(19, 28, 56, 0.012) 4px
+    ),
+    radial-gradient(circle at 20% 0%, rgba(176, 138, 62, 0.04) 0%, transparent 50%),
+    radial-gradient(circle at 80% 100%, rgba(110, 31, 43, 0.03) 0%, transparent 50%);
+}
+
+:root.dark body::before {
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent 0,
+      transparent 3px,
+      rgba(240, 232, 210, 0.015) 3px,
+      rgba(240, 232, 210, 0.015) 4px
+    ),
+    radial-gradient(circle at 20% 0%, rgba(212, 173, 92, 0.05) 0%, transparent 50%),
+    radial-gradient(circle at 80% 100%, rgba(184, 89, 104, 0.04) 0%, transparent 50%);
+}
+
+#__nuxt {
+  position: relative;
+  z-index: 1;
+}
+
+/* ディスプレイ・見出しの基底 */
+h1,
+h2,
+h3 {
+  font-family: var(--font-display);
+  font-weight: 400;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  line-height: 1.1;
+}
+
+h4,
+h5,
+h6 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+  letter-spacing: var(--tracking-base);
+  color: var(--color-text);
+}
+
+/* 数字のタブラー化（揃え用） */
+.numeric,
+time {
+  font-variant-numeric: tabular-nums;
+  font-feature-settings: "tnum" 1;
+}
+
+/* スモールキャップ（雑誌風キャプション） */
+.smallcaps {
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-widest);
+  color: var(--color-text-muted);
+}
+
+/* セレクションカラー */
+::selection {
+  background: var(--color-accent);
+  color: var(--color-on-primary);
+}
+
+/* ページトランジション — フェード + 微小なリフト */
+.page-enter-active,
+.page-leave-active {
+  transition:
+    opacity 0.32s cubic-bezier(0.2, 0.6, 0.2, 1),
+    transform 0.32s cubic-bezier(0.2, 0.6, 0.2, 1);
+}
+
+.page-enter-from {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+.page-leave-to {
+  opacity: 0;
+  transform: translateY(-4px);
+}
+
+/* リスト stagger reveal — 子要素を順次フェード */
+@keyframes stagger-up {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.stagger-children > * {
+  animation: stagger-up 0.6s cubic-bezier(0.2, 0.6, 0.2, 1) backwards;
+}
+.stagger-children > *:nth-child(1) {
+  animation-delay: 0.05s;
+}
+.stagger-children > *:nth-child(2) {
+  animation-delay: 0.1s;
+}
+.stagger-children > *:nth-child(3) {
+  animation-delay: 0.15s;
+}
+.stagger-children > *:nth-child(4) {
+  animation-delay: 0.2s;
+}
+.stagger-children > *:nth-child(5) {
+  animation-delay: 0.25s;
+}
+.stagger-children > *:nth-child(6) {
+  animation-delay: 0.3s;
+}
+.stagger-children > *:nth-child(7) {
+  animation-delay: 0.35s;
+}
+.stagger-children > *:nth-child(8) {
+  animation-delay: 0.4s;
+}
+.stagger-children > *:nth-child(9) {
+  animation-delay: 0.45s;
+}
+.stagger-children > *:nth-child(10) {
+  animation-delay: 0.5s;
+}
+.stagger-children > *:nth-child(n + 11) {
+  animation-delay: 0.55s;
+}
+
+/* prefers-reduced-motion 対応 */
+@media (prefers-reduced-motion: reduce) {
+  .page-enter-active,
+  .page-leave-active,
+  .stagger-children > * {
+    animation: none !important;
+    transition: none !important;
+  }
+  .page-enter-from,
+  .page-leave-to {
+    transform: none;
+  }
 }
 </style>

--- a/app/assets/css/fonts.css
+++ b/app/assets/css/fonts.css
@@ -1,0 +1,10 @@
+/* ============================================================
+ * Editorial typography — Fraunces (display) / Inter Tight (body) / Cormorant Garamond (accent)
+ *
+ * Fraunces: 1900s old-style serif revival (Frere-Jones にインスパイア)
+ *           可変軸 SOFT/WONK でクラシック寄り～エキセントリックを切替可能
+ * Inter Tight: Inter のコンパクト版。情報密度の高い UI 用
+ * Cormorant Garamond: 19世紀 Garamond リバイバル。引用やキャプションの抒情性に
+ * ============================================================ */
+
+@import url("https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght,SOFT,WONK@9..144,300..900,0..100,0..1&family=Inter+Tight:wght@300..700&family=Cormorant+Garamond:ital,wght@0,400;0,500;0,600;1,400;1,500&display=swap");

--- a/app/assets/css/theme.css
+++ b/app/assets/css/theme.css
@@ -3,43 +3,73 @@
  * @nuxtjs/color-mode により <html> に "light" / "dark" クラスが付与される
  * ============================================================ */
 
+:root {
+  /* ── Typography tokens（エディトリアル用） ── */
+  --font-display:
+    "Fraunces", "Cormorant Garamond", "Times New Roman", "YuMincho", "Hiragino Mincho ProN", serif;
+  --font-serif:
+    "Cormorant Garamond", "Fraunces", "Times New Roman", "YuMincho", "Hiragino Mincho ProN", serif;
+  --font-sans:
+    "Inter Tight", -apple-system, "Helvetica Neue", "Hiragino Sans", "Yu Gothic UI", sans-serif;
+  --font-numeric: "Fraunces", "Times New Roman", serif;
+
+  /* タイポトラッキング */
+  --tracking-tight: -0.02em;
+  --tracking-base: 0;
+  --tracking-wide: 0.08em;
+  --tracking-wider: 0.18em;
+  --tracking-widest: 0.32em;
+}
+
 :root,
 :root.light {
   color-scheme: light;
 
   /* 背景 */
-  --color-bg-base: #f8f4ed;
-  --color-bg-surface: #fff;
-  --color-bg-elevated: #f5f0e8;
+  --color-bg-base: #f4ecdb;
+  --color-bg-surface: #fbf6e9;
+  --color-bg-elevated: #f0e6cf;
   --color-bg-input: #faf3e0;
-  --color-bg-subtle: #eaeef4;
+  --color-bg-subtle: #ebe1c8;
+  --color-bg-paper: #f8f1de;
+  --color-bg-ink: #0a1226;
 
   /* テキスト */
-  --color-text: #1e2d5a;
-  --color-text-secondary: #333;
-  --color-text-muted: #666;
-  --color-text-faint: #888;
-  --color-text-disabled: #999;
+  --color-text: #131c38;
+  --color-text-secondary: #2a3251;
+  --color-text-muted: #5a5544;
+  --color-text-faint: #837b62;
+  --color-text-disabled: #aaa294;
 
   /* プライマリ（ネイビー） */
-  --color-primary: #1e2d5a;
+  --color-primary: #131c38;
   --color-primary-hover: #2a3f7e;
-  --color-primary-active: #152040;
+  --color-primary-active: #0a1020;
   --color-primary-soft: #2d2d50;
-  --color-on-primary: #fff;
+  --color-on-primary: #fbf6e9;
+
+  /* アクセント（シャンパンゴールド／ボルドー） */
+  --color-accent: #b08a3e;
+  --color-accent-hover: #c9a55a;
+  --color-accent-soft: #d8b876;
+  --color-accent-bg: #f0e3c2;
+  --color-bordeaux: #6e1f2b;
+  --color-bordeaux-soft: #8c3540;
 
   /* セカンダリ（補助グレー） */
   --color-secondary: #9aa5b4;
   --color-secondary-hover: #6b7a99;
 
   /* ボーダー */
-  --color-border: #e0d8cc;
-  --color-border-strong: #d4d9e3;
-  --color-border-subtle: #eaeef4;
+  --color-border: #d8cdb0;
+  --color-border-strong: #b8a888;
+  --color-border-subtle: #ebe1c8;
+  --color-hairline: rgba(19, 28, 56, 0.2);
+  --color-hairline-strong: rgba(19, 28, 56, 0.45);
 
   /* リンク */
-  --color-link: #1e2d5a;
-  --color-link-hover: #2a3f7e;
+  --color-link: #131c38;
+  --color-link-hover: #b08a3e;
 
   /* ステータス: エラー / 危険 */
   --color-danger: #c0392b;
@@ -59,9 +89,9 @@
   --color-warning-soft: #6a5424;
 
   /* ヘッダー */
-  --color-header-bg: #1e2d5a;
-  --color-header-text: #fff;
-  --color-header-text-muted: #9aa5b4;
+  --color-header-bg: #0a1226;
+  --color-header-text: #fbf6e9;
+  --color-header-text-muted: #b8a888;
 
   /* バッジ: デフォルト */
   --color-badge-default-bg: #f0ebe0;
@@ -101,25 +131,35 @@
   color-scheme: dark;
 
   /* 背景: ネイビー寄りのダークパレット */
-  --color-bg-base: #0f1729;
-  --color-bg-surface: #1a2547;
-  --color-bg-elevated: #243160;
+  --color-bg-base: #0a1020;
+  --color-bg-surface: #131c38;
+  --color-bg-elevated: #1c2649;
   --color-bg-input: #1a2547;
-  --color-bg-subtle: #243160;
+  --color-bg-subtle: #1c2649;
+  --color-bg-paper: #131c38;
+  --color-bg-ink: #f4ecdb;
 
   /* テキスト */
-  --color-text: #e3e8f1;
-  --color-text-secondary: #c5cce0;
-  --color-text-muted: #8b95a8;
-  --color-text-faint: #6b7593;
+  --color-text: #f0e8d2;
+  --color-text-secondary: #d8cdb0;
+  --color-text-muted: #a39c84;
+  --color-text-faint: #7c7563;
   --color-text-disabled: #555f7a;
 
   /* プライマリ（明るめのネイビーブルー） */
-  --color-primary: #4a6ba8;
-  --color-primary-hover: #5d80c0;
-  --color-primary-active: #3a5790;
+  --color-primary: #d8cdb0;
+  --color-primary-hover: #f0e8d2;
+  --color-primary-active: #b8a888;
   --color-primary-soft: #2c3e6b;
-  --color-on-primary: #fff;
+  --color-on-primary: #0a1020;
+
+  /* アクセント（シャンパンゴールド／ボルドー） */
+  --color-accent: #d4ad5c;
+  --color-accent-hover: #e6c378;
+  --color-accent-soft: #c9a55a;
+  --color-accent-bg: #2a2516;
+  --color-bordeaux: #b85968;
+  --color-bordeaux-soft: #8c3540;
 
   /* セカンダリ */
   --color-secondary: #6b7593;
@@ -127,12 +167,14 @@
 
   /* ボーダー */
   --color-border: #2c3e6b;
-  --color-border-strong: #3d5285;
-  --color-border-subtle: #243160;
+  --color-border-strong: #4a5a85;
+  --color-border-subtle: #1c2649;
+  --color-hairline: rgba(240, 232, 210, 0.18);
+  --color-hairline-strong: rgba(240, 232, 210, 0.38);
 
   /* リンク */
-  --color-link: #7da0d9;
-  --color-link-hover: #a3bce6;
+  --color-link: #d4ad5c;
+  --color-link-hover: #e6c378;
 
   /* ステータス: エラー / 危険 */
   --color-danger: #e57373;
@@ -152,9 +194,9 @@
   --color-warning-soft: #d9b74a;
 
   /* ヘッダー */
-  --color-header-bg: #0a1020;
-  --color-header-text: #f0f3f9;
-  --color-header-text-muted: #8b95a8;
+  --color-header-bg: #060a18;
+  --color-header-text: #f0e8d2;
+  --color-header-text-muted: #a39c84;
 
   /* バッジ: デフォルト */
   --color-badge-default-bg: #2a2820;

--- a/app/components/atoms/ButtonDanger.vue
+++ b/app/components/atoms/ButtonDanger.vue
@@ -7,33 +7,41 @@ defineSlots<ButtonSlots>();
 
 <template>
   <button class="btn-danger" type="button" :disabled="disabled">
-    <slot />
+    <span class="btn-danger-label">
+      <slot />
+    </span>
   </button>
 </template>
 
 <style scoped>
 .btn-danger {
-  background: var(--color-danger-bg);
-  color: var(--color-danger);
-  border: 1px solid var(--color-danger-border);
-  padding: 0.4rem 0.8rem;
-  border-radius: 6px;
-  font-size: 0.85rem;
+  background: transparent;
+  color: var(--color-bordeaux);
+  border: 1px solid var(--color-bordeaux);
+  padding: 0.7rem 1.1rem;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background-color 0.2s;
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease;
 }
 
 .btn-danger:hover:not(:disabled) {
-  background: var(--color-danger-bg-strong);
+  background: var(--color-bordeaux);
+  color: var(--color-bg-paper);
 }
 
 .btn-danger:focus-visible {
-  outline: 2px solid var(--color-danger);
-  outline-offset: 2px;
+  outline: 1px solid var(--color-bordeaux);
+  outline-offset: 3px;
 }
 
 .btn-danger:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 </style>

--- a/app/components/atoms/ButtonPrimary.vue
+++ b/app/components/atoms/ButtonPrimary.vue
@@ -7,38 +7,59 @@ defineSlots<ButtonSlots>();
 
 <template>
   <button class="btn-primary" :type="type ?? 'button'" :disabled="disabled">
-    <slot />
+    <span class="btn-primary-label">
+      <slot />
+    </span>
   </button>
 </template>
 
 <style scoped>
 .btn-primary {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
-  padding: 0.6rem 1.4rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.95rem;
+  position: relative;
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
+  padding: 0.8rem 1.4rem;
+  border: 1px solid var(--color-bg-ink);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
   text-decoration: none;
-  transition: background-color 0.2s;
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease,
+    letter-spacing 0.25s ease;
+}
+
+.btn-primary-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .btn-primary:hover:not(:disabled) {
-  background: var(--color-primary-hover);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg-ink);
+  letter-spacing: calc(var(--tracking-widest) + 0.04em);
 }
 
 .btn-primary:active:not(:disabled) {
   background: var(--color-primary-active);
+  border-color: var(--color-primary-active);
+  color: var(--color-bg-paper);
 }
 
 .btn-primary:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: 1px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
 .btn-primary:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 </style>

--- a/app/components/atoms/ButtonSecondary.vue
+++ b/app/components/atoms/ButtonSecondary.vue
@@ -7,34 +7,44 @@ defineSlots<ButtonSlots>();
 
 <template>
   <button class="btn-secondary" type="button" :disabled="disabled">
-    <slot />
+    <span class="btn-secondary-label">
+      <slot />
+    </span>
   </button>
 </template>
 
 <style scoped>
 .btn-secondary {
-  background: var(--color-bg-subtle);
+  background: transparent;
   color: var(--color-text);
-  padding: 0.6rem 1.2rem;
-  border: none;
-  border-radius: 6px;
-  font-size: 0.95rem;
+  padding: 0.7rem 1.2rem;
+  border: 1px solid var(--color-hairline-strong);
+  font-family: var(--font-sans);
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
   text-decoration: none;
-  transition: background-color 0.2s;
+  transition:
+    background-color 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease;
 }
 
 .btn-secondary:hover:not(:disabled) {
-  background: var(--color-border-strong);
+  background: var(--color-bg-elevated);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .btn-secondary:focus-visible {
-  outline: 2px solid var(--color-primary);
-  outline-offset: 2px;
+  outline: 1px solid var(--color-accent);
+  outline-offset: 3px;
 }
 
 .btn-secondary:disabled {
   cursor: not-allowed;
-  opacity: 0.6;
+  opacity: 0.5;
 }
 </style>

--- a/app/components/atoms/CategoryBadge.test.ts
+++ b/app/components/atoms/CategoryBadge.test.ts
@@ -10,11 +10,11 @@ describe("CategoryBadge", () => {
       expect(wrapper.find(".category-badge").exists()).toBe(true);
     });
 
-    it("value のみが表示される", async () => {
+    it("value がテキストに含まれる", async () => {
       const wrapper = await mountSuspended(CategoryBadge, {
         props: { label: "ジャンル", value: "交響曲" },
       });
-      expect(wrapper.text()).toBe("交響曲");
+      expect(wrapper.find(".badge-value").text()).toBe("交響曲");
     });
 
     it("label と value は aria-label として連結される", async () => {

--- a/app/components/atoms/CategoryBadge.vue
+++ b/app/components/atoms/CategoryBadge.vue
@@ -14,46 +14,84 @@ const ariaLabel = computed(() => `${props.label}: ${props.value}`);
 </script>
 
 <template>
-  <span class="category-badge" :class="kindClass" :aria-label="ariaLabel">{{ value }}</span>
+  <span class="category-badge" :class="kindClass" :aria-label="ariaLabel">
+    <span class="badge-mark" aria-hidden="true">&middot;</span>
+    <span class="badge-value">{{ value }}</span>
+  </span>
 </template>
 
 <style scoped>
 .category-badge {
-  display: inline-block;
-  border-radius: 4px;
-  padding: 0.15rem 0.55rem;
-  font-size: 0.8rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.25rem 0.65rem;
+  font-family: var(--font-sans);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
   line-height: 1.4;
-  border: 1px solid transparent;
+  border: 1px solid;
+  background: transparent;
+}
+
+.badge-mark {
+  font-size: 0.85rem;
+  line-height: 1;
+  letter-spacing: 0;
+}
+
+.badge-value {
+  font-size: 0.68rem;
 }
 
 .kind-default {
-  background: var(--color-badge-default-bg);
-  border-color: var(--color-badge-default-border);
-  color: var(--color-badge-default-text);
+  border-color: var(--color-hairline-strong);
+  color: var(--color-text-muted);
+}
+
+.kind-default .badge-mark {
+  color: var(--color-text-faint);
 }
 
 .kind-genre {
-  background: var(--color-badge-genre-bg);
-  border-color: var(--color-badge-genre-border);
-  color: var(--color-badge-genre-text);
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+:root.dark .kind-genre {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+.kind-genre .badge-mark {
+  color: var(--color-accent);
 }
 
 .kind-era {
-  background: var(--color-badge-era-bg);
-  border-color: var(--color-badge-era-border);
-  color: var(--color-badge-era-text);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+}
+.kind-era .badge-mark {
+  color: var(--color-accent-soft);
 }
 
 .kind-formation {
-  background: var(--color-badge-formation-bg);
-  border-color: var(--color-badge-formation-border);
-  color: var(--color-badge-formation-text);
+  border-color: var(--color-bordeaux);
+  color: var(--color-bordeaux);
+}
+:root.dark .kind-formation {
+  border-color: var(--color-bordeaux);
+  color: var(--color-bordeaux);
+}
+.kind-formation .badge-mark {
+  color: var(--color-bordeaux-soft);
 }
 
 .kind-region {
-  background: var(--color-badge-region-bg);
-  border-color: var(--color-badge-region-border);
-  color: var(--color-badge-region-text);
+  border-color: var(--color-text-muted);
+  color: var(--color-text-secondary);
+}
+.kind-region .badge-mark {
+  color: var(--color-text-faint);
 }
 </style>

--- a/app/components/atoms/EmptyState.test.ts
+++ b/app/components/atoms/EmptyState.test.ts
@@ -6,7 +6,7 @@ describe("EmptyState", () => {
     const wrapper = await mountSuspended(EmptyState, {
       slots: { default: "まだ記録がありません。" },
     });
-    expect(wrapper.text()).toBe("まだ記録がありません。");
+    expect(wrapper.find(".empty-text").text()).toBe("まだ記録がありません。");
   });
 
   it("empty-state クラスが存在する", async () => {

--- a/app/components/atoms/EmptyState.vue
+++ b/app/components/atoms/EmptyState.vue
@@ -1,13 +1,36 @@
 <template>
   <div class="empty-state">
-    <p><slot /></p>
+    <span class="empty-mark" aria-hidden="true">&mdash;</span>
+    <p class="empty-text"><slot /></p>
   </div>
 </template>
 
 <style scoped>
 .empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 4.5rem 2rem;
   text-align: center;
-  padding: 4rem;
-  color: var(--color-text-faint);
+  border: 1px dashed var(--color-hairline);
+  background: transparent;
+}
+
+.empty-mark {
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  color: var(--color-accent);
+  font-style: italic;
+}
+
+.empty-text {
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--color-text-muted);
+  letter-spacing: 0.04em;
+  max-width: 32em;
+  line-height: 1.5;
 }
 </style>

--- a/app/components/atoms/ErrorMessage.vue
+++ b/app/components/atoms/ErrorMessage.vue
@@ -12,24 +12,44 @@ defineProps<{
     class="error-message"
     :class="{ block: variant === 'block', center }"
   >
+    <span v-if="variant === 'block'" class="error-mark smallcaps" aria-hidden="true">
+      Error &mdash;
+    </span>
     {{ message }}
   </component>
 </template>
 
 <style scoped>
 .error-message {
-  color: var(--color-danger);
-  font-size: 0.875rem;
+  color: var(--color-bordeaux);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.9rem;
   margin: 0;
+}
+:root.dark .error-message {
+  color: var(--color-bordeaux);
+  filter: brightness(1.15);
 }
 
 .error-message.block {
-  background: var(--color-danger-bg);
-  border: 1px solid var(--color-danger-border);
-  padding: 0.8rem 1rem;
-  border-radius: 6px;
+  background: transparent;
+  border: 1px solid var(--color-bordeaux);
+  border-left: 3px solid var(--color-bordeaux);
+  padding: 0.9rem 1.1rem;
+  border-radius: 0;
   margin-bottom: 1rem;
-  font-size: 0.9rem;
+  font-size: 0.95rem;
+  display: flex;
+  align-items: baseline;
+  gap: 0.6rem;
+}
+
+.error-mark {
+  color: var(--color-bordeaux);
+  font-style: normal;
+  font-weight: 700;
+  flex-shrink: 0;
 }
 
 .center {

--- a/app/components/atoms/FormGroup.vue
+++ b/app/components/atoms/FormGroup.vue
@@ -10,8 +10,8 @@ defineProps<{
 <template>
   <div class="form-group">
     <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-    <label :for="inputId">
-      {{ label }}
+    <label class="form-label" :for="inputId">
+      <span class="form-label-text">{{ label }}</span>
       <RequiredMark v-if="required" />
     </label>
     <slot />
@@ -23,11 +23,22 @@ defineProps<{
 .form-group {
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0.45rem;
 }
 
-label {
-  font-weight: 500;
-  color: var(--color-text-secondary);
+.form-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.form-label-text {
+  display: inline-block;
 }
 </style>

--- a/app/components/atoms/PageTitle.test.ts
+++ b/app/components/atoms/PageTitle.test.ts
@@ -16,10 +16,10 @@ describe("PageTitle", () => {
     expect(wrapper.find(".page-title").exists()).toBe(true);
   });
 
-  it("h1 要素として描画される", async () => {
+  it("h1 要素を含む", async () => {
     const wrapper = await mountSuspended(PageTitle, {
       slots: { default: "タイトル" },
     });
-    expect(wrapper.element.tagName.toLowerCase()).toBe("h1");
+    expect(wrapper.find("h1.page-title").exists()).toBe(true);
   });
 });

--- a/app/components/atoms/PageTitle.vue
+++ b/app/components/atoms/PageTitle.vue
@@ -1,11 +1,70 @@
+<script setup lang="ts">
+defineProps<{
+  eyebrow?: string;
+  meta?: string;
+}>();
+</script>
+
 <template>
-  <h1 class="page-title"><slot /></h1>
+  <header class="page-title-block">
+    <div v-if="eyebrow || meta" class="page-title-meta">
+      <span v-if="eyebrow" class="page-title-eyebrow smallcaps">{{ eyebrow }}</span>
+      <span class="page-title-rule" aria-hidden="true" />
+      <span v-if="meta" class="page-title-meta-text smallcaps">{{ meta }}</span>
+    </div>
+    <h1 class="page-title">
+      <span class="page-title-text"><slot /></span>
+    </h1>
+  </header>
 </template>
 
 <style scoped>
+.page-title-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-bottom: 1.8rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.page-title-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.page-title-eyebrow {
+  color: var(--color-bordeaux);
+}
+:root.dark .page-title-eyebrow {
+  color: var(--color-accent);
+}
+
+.page-title-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.page-title-meta-text {
+  color: var(--color-text-muted);
+}
+
 .page-title {
-  font-size: 1.6rem;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
-  margin-bottom: 1.5rem;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
+}
+
+.page-title-text {
+  display: inline-block;
+  line-height: 1.1;
 }
 </style>

--- a/app/components/atoms/RequiredMark.test.ts
+++ b/app/components/atoms/RequiredMark.test.ts
@@ -2,9 +2,9 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 import RequiredMark from "./RequiredMark.vue";
 
 describe("RequiredMark", () => {
-  it("「必須」テキストが表示される", async () => {
+  it("「required」テキストが表示される", async () => {
     const wrapper = await mountSuspended(RequiredMark);
-    expect(wrapper.text()).toBe("必須");
+    expect(wrapper.text()).toBe("required");
   });
 
   it("required クラスが存在する", async () => {

--- a/app/components/atoms/RequiredMark.vue
+++ b/app/components/atoms/RequiredMark.vue
@@ -1,19 +1,41 @@
 <template>
-  <span class="required" aria-label="必須">必須</span>
+  <span class="required" aria-label="必須">required</span>
 </template>
 
 <style scoped>
 .required {
   display: inline-block;
   margin-left: 0.4rem;
-  padding: 0.1rem 0.45rem;
-  border-radius: 999px;
-  background-color: var(--color-danger);
-  color: var(--color-on-primary);
-  font-size: 0.7rem;
-  font-weight: 600;
-  line-height: 1.3;
-  letter-spacing: 0.05em;
+  padding: 0;
+  background: none;
+  color: var(--color-bordeaux);
+  font-family: var(--font-sans);
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  line-height: 1;
   vertical-align: middle;
+  position: relative;
+  padding-left: 0.6rem;
+}
+
+.required::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 0.35rem;
+  height: 1px;
+  background: var(--color-bordeaux);
+}
+
+:root.dark .required {
+  color: var(--color-bordeaux);
+  filter: brightness(1.2);
+}
+:root.dark .required::before {
+  background: currentColor;
 }
 </style>

--- a/app/components/atoms/SelectInput.vue
+++ b/app/components/atoms/SelectInput.vue
@@ -14,37 +14,68 @@ defineEmits<{
 </script>
 
 <template>
-  <select
-    :id="id"
-    class="select-input"
-    :value="modelValue"
-    :required="required"
-    :disabled="disabled"
-    @change="$emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
-  >
-    <option value="">{{ placeholder ?? "---" }}</option>
-    <option v-for="option in options" :key="option.value" :value="option.value">
-      {{ option.label }}
-    </option>
-  </select>
+  <div class="select-wrap">
+    <select
+      :id="id"
+      class="select-input"
+      :value="modelValue"
+      :required="required"
+      :disabled="disabled"
+      @change="$emit('update:modelValue', ($event.target as HTMLSelectElement).value)"
+    >
+      <option value="">{{ placeholder ?? "---" }}</option>
+      <option v-for="option in options" :key="option.value" :value="option.value">
+        {{ option.label }}
+      </option>
+    </select>
+    <span class="select-caret" aria-hidden="true">&#x25BE;</span>
+  </div>
 </template>
 
 <style scoped>
+.select-wrap {
+  position: relative;
+  width: 100%;
+}
+
 .select-input {
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.6rem 0.8rem;
+  appearance: none;
+  -webkit-appearance: none;
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.55rem 1.6rem 0.55rem 0.1rem;
   font-size: 0.95rem;
-  background: var(--color-bg-input);
+  background: transparent;
   color: var(--color-text);
-  transition: border-color 0.2s;
+  transition: border-color 0.25s ease;
   width: 100%;
   box-sizing: border-box;
-  font-family: inherit;
+  font-family: var(--font-sans);
+  cursor: pointer;
+}
+
+.select-input:hover:not(:disabled) {
+  border-bottom-color: var(--color-text-muted);
 }
 
 .select-input:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
+}
+
+.select-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.select-caret {
+  position: absolute;
+  right: 0.3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--color-accent);
+  font-size: 0.85rem;
 }
 </style>

--- a/app/components/atoms/TextInput.vue
+++ b/app/components/atoms/TextInput.vue
@@ -28,20 +28,44 @@ defineEmits<{
 
 <style scoped>
 .text-input {
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.6rem 0.8rem;
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.55rem 0.1rem;
   font-size: 0.95rem;
-  background: var(--color-bg-input);
+  background: transparent;
   color: var(--color-text);
-  transition: border-color 0.2s;
+  transition:
+    border-color 0.25s ease,
+    background 0.25s ease;
   width: 100%;
   box-sizing: border-box;
-  font-family: inherit;
+  font-family: var(--font-sans);
+}
+
+.text-input::placeholder {
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
+.text-input:hover:not(:disabled) {
+  border-bottom-color: var(--color-text-muted);
 }
 
 .text-input:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 92%,
+    var(--color-accent-bg) 92%,
+    var(--color-accent-bg) 100%
+  );
+}
+
+.text-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 </style>

--- a/app/components/molecules/AuthFormContainer.vue
+++ b/app/components/molecules/AuthFormContainer.vue
@@ -6,25 +6,89 @@ defineProps<{
 
 <template>
   <div class="auth-form-container">
-    <h1>{{ title }}</h1>
+    <header class="auth-head">
+      <span class="head-tag smallcaps">Sign in</span>
+      <span class="head-rule" aria-hidden="true" />
+    </header>
+    <h1 class="auth-title">
+      <span class="auth-title-text">{{ title }}</span>
+    </h1>
     <slot />
   </div>
 </template>
 
 <style scoped>
 .auth-form-container {
-  background: var(--color-bg-subtle);
-  padding: 2rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(61, 36, 9, 0.15);
+  background: var(--color-bg-paper);
+  padding: 2.5rem 2.4rem 2.4rem;
+  border-radius: 0;
+  border: 1px solid var(--color-hairline-strong);
   width: 100%;
-  max-width: 400px;
-  border: 1px solid var(--color-secondary);
+  max-width: 440px;
+  position: relative;
 }
 
-h1 {
-  text-align: center;
-  margin-bottom: 1.5rem;
+/* ゴールドの 4 隅マーク */
+.auth-form-container::before,
+.auth-form-container::after {
+  content: "";
+  position: absolute;
+  width: 16px;
+  height: 16px;
+  border: 1px solid var(--color-accent);
+  pointer-events: none;
+}
+.auth-form-container::before {
+  top: -1px;
+  left: -1px;
+  border-right: none;
+  border-bottom: none;
+}
+.auth-form-container::after {
+  bottom: -1px;
+  right: -1px;
+  border-left: none;
+  border-top: none;
+}
+
+.auth-head {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.8rem;
+}
+
+.head-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .head-tag {
+  color: var(--color-accent);
+}
+
+.head-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.auth-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(2rem, 5vw, 2.8rem);
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  margin-bottom: 1.8rem;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60,
+    "WONK" 1;
+  line-height: 1.05;
+}
+
+@media (max-width: 600px) {
+  .auth-form-container {
+    padding: 2rem 1.6rem;
+  }
 }
 </style>

--- a/app/components/molecules/ComposerItem.test.ts
+++ b/app/components/molecules/ComposerItem.test.ts
@@ -77,14 +77,14 @@ describe("ComposerItem", () => {
       const wrapper = await mountSuspended(ComposerItem, {
         props: { composer: sampleComposerWithCategories },
       });
-      expect(wrapper.find(".kind-era").text()).toBe("古典派");
+      expect(wrapper.find(".kind-era .badge-value").text()).toBe("古典派");
     });
 
     it("region が設定されている場合、地域バッジが表示される", async () => {
       const wrapper = await mountSuspended(ComposerItem, {
         props: { composer: sampleComposerWithCategories },
       });
-      expect(wrapper.find(".kind-region").text()).toBe("ドイツ・オーストリア");
+      expect(wrapper.find(".kind-region .badge-value").text()).toBe("ドイツ・オーストリア");
     });
 
     it("全カテゴリが未設定の場合、バッジが一切表示されない", async () => {

--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -13,102 +13,167 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="composer-item">
-    <img
-      v-if="composer.imageUrl"
-      :src="composer.imageUrl"
-      :alt="composer.name"
-      class="composer-thumb"
-      loading="lazy"
-      referrerpolicy="no-referrer"
-    />
+  <article class="composer-item">
+    <div class="composer-portrait">
+      <img
+        v-if="composer.imageUrl"
+        :src="composer.imageUrl"
+        :alt="composer.name"
+        class="composer-thumb"
+        loading="lazy"
+        referrerpolicy="no-referrer"
+      />
+      <span v-else class="composer-thumb composer-thumb--empty" aria-hidden="true">
+        {{ composer.name.slice(0, 1) }}
+      </span>
+    </div>
+
     <div class="composer-main">
-      <div class="composer-name">{{ composer.name }}</div>
+      <h2 class="composer-name">{{ composer.name }}</h2>
       <div class="composer-category-wrapper">
         <ComposerCategoryList :composer="composer" />
       </div>
     </div>
+
     <div class="composer-actions">
-      <button type="button" class="btn-detail" @click="emit('detail')">詳細</button>
-      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
-      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
+      <button type="button" class="btn-detail" @click="emit('detail')">
+        <span>Read</span>
+        <span aria-hidden="true">&rarr;</span>
+      </button>
+      <ButtonSecondary @click="emit('edit')">Edit</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">Delete</ButtonDanger>
     </div>
-  </div>
+  </article>
 </template>
 
 <style scoped>
 .composer-item {
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  padding: 1.2rem 1.5rem;
-  display: flex;
-  justify-content: space-between;
+  position: relative;
+  background: var(--color-bg-paper);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 1.5rem 0.5rem 1.5rem 0;
+  display: grid;
+  grid-template-columns: 80px 1fr auto;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
+  transition: background 0.25s ease;
+}
+
+.composer-item:hover {
+  background: var(--color-bg-elevated);
+}
+
+.composer-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%) scaleY(0);
+  height: 60%;
+  width: 2px;
+  background: var(--color-accent);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.composer-item:hover::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+.composer-portrait {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .composer-thumb {
-  width: 56px;
-  height: 56px;
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
   object-fit: cover;
   background: var(--color-bg-elevated);
   flex-shrink: 0;
+  border: 1px solid var(--color-hairline-strong);
+}
+
+.composer-thumb--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.7rem;
+  color: var(--color-accent);
+  background: var(--color-bg-paper);
 }
 
 .composer-main {
   flex: 1;
   min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
 }
 
 .composer-name {
-  font-size: 1.1rem;
-  font-weight: bold;
-  margin-bottom: 0.3rem;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.3rem, 2.4vw, 1.7rem);
+  line-height: 1.15;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
 .composer-category-wrapper {
-  margin-top: 0.4rem;
+  margin-top: 0.3rem;
 }
 
 .composer-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
   flex-shrink: 0;
+  align-items: center;
 }
 
 .btn-detail {
-  background: var(--color-bg-elevated);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
   color: var(--color-text);
-  padding: 0.6rem 1.2rem;
-  border: 1px solid #c2a878;
-  border-radius: 6px;
-  font-size: 0.95rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--color-bg-ink);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.2s;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease;
 }
 
 .btn-detail:hover {
-  background: var(--color-border);
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
 }
 
-:global(.dark .btn-detail) {
-  border-color: #6e5a3d;
+:root.dark .btn-detail {
+  border-color: var(--color-text);
+  color: var(--color-text);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 720px) {
   .composer-item {
-    flex-direction: column;
-    align-items: flex-start;
-  }
-
-  .composer-main {
-    width: 100%;
+    grid-template-columns: 64px 1fr;
   }
 
   .composer-actions {
+    grid-column: 1 / -1;
     width: 100%;
     justify-content: flex-end;
   }

--- a/app/components/molecules/ConcertLogItem.vue
+++ b/app/components/molecules/ConcertLogItem.vue
@@ -12,68 +12,131 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="log-item">
+  <article class="log-item">
     <div class="log-main">
-      <div class="log-title">
-        {{ concertLog.title }}
-      </div>
-      <div class="log-venue">{{ concertLog.venue }}</div>
       <div class="log-meta">
-        <span class="date">{{ formatDate(concertLog.concertDate) }}</span>
+        <time class="log-date smallcaps numeric">{{ formatDate(concertLog.concertDate) }}</time>
+        <span class="log-rule" aria-hidden="true" />
+        <span class="log-venue smallcaps">{{ concertLog.venue }}</span>
       </div>
-      <div v-if="concertLog.conductor" class="log-sub conductor">
-        指揮: {{ concertLog.conductor }}
-      </div>
-      <div v-if="concertLog.orchestra" class="log-sub">
-        {{ concertLog.orchestra }}
-      </div>
-      <div v-if="concertLog.soloist" class="log-sub">ソリスト: {{ concertLog.soloist }}</div>
+
+      <h2 class="log-title">{{ concertLog.title }}</h2>
+
+      <dl class="log-credits">
+        <template v-if="concertLog.conductor">
+          <dt class="smallcaps">Conductor</dt>
+          <dd>{{ concertLog.conductor }}</dd>
+        </template>
+        <template v-if="concertLog.orchestra">
+          <dt class="smallcaps">Orchestra</dt>
+          <dd>{{ concertLog.orchestra }}</dd>
+        </template>
+        <template v-if="concertLog.soloist">
+          <dt class="smallcaps">Soloist</dt>
+          <dd>{{ concertLog.soloist }}</dd>
+        </template>
+      </dl>
     </div>
+
     <div class="log-actions">
-      <ButtonSecondary @click="emit('detail')">詳細</ButtonSecondary>
+      <ButtonSecondary @click="emit('detail')">Read</ButtonSecondary>
     </div>
-  </div>
+  </article>
 </template>
 
 <style scoped>
 .log-item {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 10px;
-  padding: 1.2rem 1.5rem;
+  position: relative;
+  background: var(--color-bg-paper);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 1.6rem 0.5rem 1.6rem 0;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.5rem;
+  transition: background 0.25s ease;
+}
+
+.log-item:hover {
+  background: var(--color-bg-elevated);
+}
+
+.log-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%) scaleY(0);
+  height: 60%;
+  width: 2px;
+  background: var(--color-accent);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.log-item:hover::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+.log-main {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
-}
-
-.log-title {
-  font-size: 1.1rem;
-  font-weight: bold;
-  color: var(--color-text);
-  margin-bottom: 0.3rem;
-}
-
-.log-venue {
-  font-size: 0.95rem;
-  color: var(--color-text-secondary);
-  margin-bottom: 0.2rem;
+  flex-direction: column;
+  gap: 0.6rem;
+  min-width: 0;
 }
 
 .log-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.log-date {
+  color: var(--color-bordeaux);
+}
+:root.dark .log-date {
+  color: var(--color-accent);
+}
+
+.log-rule {
+  width: 1.5rem;
+  height: 1px;
+  background: var(--color-hairline-strong);
+}
+
+.log-venue {
   color: var(--color-text-muted);
-  font-size: 0.9rem;
-  margin-bottom: 0.3rem;
 }
 
-.date {
-  color: var(--color-text-disabled);
+.log-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.4rem, 2.6vw, 1.85rem);
+  line-height: 1.18;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
-.log-sub {
-  font-size: 0.9rem;
+.log-credits {
+  display: grid;
+  grid-template-columns: minmax(80px, auto) 1fr;
+  gap: 0.3rem 1rem;
+  margin-top: 0.4rem;
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
   color: var(--color-text-secondary);
-  margin-top: 0.2rem;
+}
+
+.log-credits dt {
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+}
+
+.log-credits dd {
+  font-style: italic;
 }
 
 .log-actions {
@@ -81,5 +144,16 @@ const emit = defineEmits<{
   flex-direction: column;
   gap: 0.5rem;
   flex-shrink: 0;
+  align-items: flex-end;
+}
+
+@media (max-width: 720px) {
+  .log-item {
+    grid-template-columns: 1fr;
+  }
+  .log-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
 }
 </style>

--- a/app/components/molecules/FormActions.test.ts
+++ b/app/components/molecules/FormActions.test.ts
@@ -10,7 +10,7 @@ describe("FormActions", () => {
     it("キャンセルボタンが表示される", async () => {
       const wrapper = await mountSuspended(FormActions, globalComponents);
       const buttons = wrapper.findAll("button");
-      const cancelButton = buttons.find((b) => b.text() === "キャンセル");
+      const cancelButton = buttons.find((b) => b.text() === "Cancel");
       expect(cancelButton).toBeDefined();
     });
 
@@ -55,7 +55,7 @@ describe("FormActions", () => {
     it("キャンセルボタンクリックで cancel イベントが emit される", async () => {
       const wrapper = await mountSuspended(FormActions, globalComponents);
       const buttons = wrapper.findAll("button");
-      const cancelButton = buttons.find((b) => b.text() === "キャンセル");
+      const cancelButton = buttons.find((b) => b.text() === "Cancel");
       await cancelButton?.trigger("click");
       expect(wrapper.emitted("cancel")).toBeDefined();
     });

--- a/app/components/molecules/FormActions.vue
+++ b/app/components/molecules/FormActions.vue
@@ -11,18 +11,33 @@ const emit = defineEmits<{
 
 <template>
   <div class="form-actions">
-    <ButtonSecondary @click="emit('cancel')">キャンセル</ButtonSecondary>
-    <ButtonPrimary type="submit" :disabled="isSubmitting">
-      {{ submitLabel ?? "保存する" }}
-    </ButtonPrimary>
+    <span class="form-actions-rule" aria-hidden="true" />
+    <div class="form-actions-buttons">
+      <ButtonSecondary @click="emit('cancel')">Cancel</ButtonSecondary>
+      <ButtonPrimary type="submit" :disabled="isSubmitting">
+        {{ submitLabel ?? "保存する" }}
+      </ButtonPrimary>
+    </div>
   </div>
 </template>
 
 <style scoped>
 .form-actions {
   display: flex;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 1.4rem;
+  margin-top: 1.5rem;
+}
+
+.form-actions-rule {
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.form-actions-buttons {
+  display: flex;
+  gap: 0.8rem;
   justify-content: flex-end;
-  margin-top: 1rem;
+  flex-wrap: wrap;
 }
 </style>

--- a/app/components/molecules/ListeningLogFilter.test.ts
+++ b/app/components/molecules/ListeningLogFilter.test.ts
@@ -16,25 +16,25 @@ describe("ListeningLogFilter", () => {
       const wrapper = await mountSuspended(ListeningLogFilter, {
         props: { modelValue: { ...initialState }, isActive: false },
       });
-      expect(wrapper.text()).toContain("キーワード");
-      expect(wrapper.text()).toContain("評価");
-      expect(wrapper.text()).toContain("お気に入りのみ");
-      expect(wrapper.text()).toContain("期間（開始）");
-      expect(wrapper.text()).toContain("期間（終了）");
+      expect(wrapper.text()).toContain("Keyword");
+      expect(wrapper.text()).toContain("Rating");
+      expect(wrapper.text()).toContain("Favorites only");
+      expect(wrapper.text()).toContain("From");
+      expect(wrapper.text()).toContain("To");
     });
 
     it("isActive が false のとき条件クリアボタンを表示しない", async () => {
       const wrapper = await mountSuspended(ListeningLogFilter, {
         props: { modelValue: { ...initialState }, isActive: false },
       });
-      expect(wrapper.text()).not.toContain("条件をクリア");
+      expect(wrapper.text()).not.toContain("Clear filter");
     });
 
     it("isActive が true のとき条件クリアボタンを表示する", async () => {
       const wrapper = await mountSuspended(ListeningLogFilter, {
         props: { modelValue: { ...initialState, keyword: "X" }, isActive: true },
       });
-      expect(wrapper.text()).toContain("条件をクリア");
+      expect(wrapper.text()).toContain("Clear filter");
     });
   });
 

--- a/app/components/molecules/ListeningLogFilter.vue
+++ b/app/components/molecules/ListeningLogFilter.vue
@@ -12,11 +12,11 @@ const emit = defineEmits<{
 }>();
 
 const ratingOptions = [
-  { value: "5", label: "★5" },
-  { value: "4", label: "★4" },
-  { value: "3", label: "★3" },
-  { value: "2", label: "★2" },
-  { value: "1", label: "★1" },
+  { value: "5", label: "★ 5" },
+  { value: "4", label: "★ 4" },
+  { value: "3", label: "★ 3" },
+  { value: "2", label: "★ 2" },
+  { value: "1", label: "★ 1" },
 ];
 
 function update<K extends keyof ListeningLogFilterState>(
@@ -29,21 +29,25 @@ function update<K extends keyof ListeningLogFilterState>(
 </script>
 
 <template>
-  <div class="filter">
+  <section class="filter">
+    <header class="filter-head">
+      <span class="filter-tag smallcaps">Filter</span>
+      <span class="filter-rule" aria-hidden="true" />
+    </header>
     <div class="filter-row">
       <div class="filter-field filter-field-keyword">
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-        <label for="filter-keyword" class="filter-label">キーワード</label>
+        <label for="filter-keyword" class="filter-label smallcaps">Keyword</label>
         <TextInput
           id="filter-keyword"
           :model-value="modelValue.keyword"
-          placeholder="作曲家・曲名・メモを検索"
+          placeholder="作曲家・曲名・メモを検索…"
           @update:model-value="(v) => update(modelValue, 'keyword', v)"
         />
       </div>
       <div class="filter-field">
         <!-- eslint-disable-next-line vuejs-accessibility/label-has-for -->
-        <label for="filter-rating" class="filter-label">評価</label>
+        <label for="filter-rating" class="filter-label smallcaps">Rating</label>
         <SelectInput
           id="filter-rating"
           :model-value="modelValue.rating"
@@ -55,7 +59,7 @@ function update<K extends keyof ListeningLogFilterState>(
         />
       </div>
       <div class="filter-field filter-field-date">
-        <label for="filter-from" class="filter-label">期間（開始）</label>
+        <label for="filter-from" class="filter-label smallcaps">From</label>
         <input
           id="filter-from"
           class="filter-date"
@@ -65,7 +69,7 @@ function update<K extends keyof ListeningLogFilterState>(
         />
       </div>
       <div class="filter-field filter-field-date">
-        <label for="filter-to" class="filter-label">期間（終了）</label>
+        <label for="filter-to" class="filter-label smallcaps">To</label>
         <input
           id="filter-to"
           class="filter-date"
@@ -82,43 +86,64 @@ function update<K extends keyof ListeningLogFilterState>(
           :checked="modelValue.favoriteOnly"
           @change="update(modelValue, 'favoriteOnly', ($event.target as HTMLInputElement).checked)"
         />
-        <span>お気に入りのみ</span>
+        <span class="checkbox-text smallcaps">Favorites only</span>
       </label>
       <ButtonSecondary v-if="isActive" class="filter-reset" @click="emit('reset')">
-        条件をクリア
+        Clear filter
       </ButtonSecondary>
     </div>
-  </div>
+  </section>
 </template>
 
 <style scoped>
 .filter {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 8px;
-  padding: 1rem 1.25rem;
-  margin-bottom: 1.5rem;
+  background: transparent;
+  border: 1px solid var(--color-hairline);
+  border-left: 3px solid var(--color-accent);
+  padding: 1.25rem 1.5rem 1.4rem;
+  margin-bottom: 2rem;
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
+  gap: 1rem;
+}
+
+.filter-head {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-bottom: 0.2rem;
+}
+
+.filter-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .filter-tag {
+  color: var(--color-accent);
+}
+
+.filter-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
 }
 
 .filter-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.75rem;
+  gap: 1.25rem;
   align-items: flex-end;
 }
 
 .filter-row-bottom {
   justify-content: space-between;
   align-items: center;
+  margin-top: 0.4rem;
 }
 
 .filter-field {
   display: flex;
   flex-direction: column;
-  gap: 0.25rem;
+  gap: 0.4rem;
   flex: 1 1 160px;
   min-width: 160px;
 }
@@ -132,34 +157,45 @@ function update<K extends keyof ListeningLogFilterState>(
 }
 
 .filter-label {
-  font-size: 0.8rem;
   color: var(--color-text-muted);
 }
 
 .filter-date {
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.55rem 0.7rem;
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.55rem 0.1rem;
   font-size: 0.95rem;
-  background: var(--color-bg-input);
+  background: transparent;
   color: var(--color-text);
   width: 100%;
   box-sizing: border-box;
-  font-family: inherit;
+  font-family: var(--font-sans);
+  font-variant-numeric: tabular-nums;
+  transition: border-color 0.25s ease;
 }
 
 .filter-date:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
 }
 
 .filter-checkbox {
   display: inline-flex;
   align-items: center;
-  gap: 0.4rem;
-  font-size: 0.9rem;
+  gap: 0.55rem;
   color: var(--color-text);
   cursor: pointer;
+}
+
+.filter-checkbox input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.checkbox-text {
+  color: var(--color-text-muted);
 }
 
 .filter-reset {

--- a/app/components/molecules/ListeningLogItem.vue
+++ b/app/components/molecules/ListeningLogItem.vue
@@ -13,81 +13,145 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div class="log-item">
+  <article class="log-item">
     <div class="log-main">
-      <div class="log-title">
+      <div class="log-meta">
         <FavoriteIndicator :is-favorite="listeningLog.isFavorite" />
+        <span class="log-composer smallcaps">{{ listeningLog.composer }}</span>
+        <span class="log-rule" aria-hidden="true" />
+        <time class="log-date smallcaps numeric">{{ formatDate(listeningLog.listenedAt) }}</time>
+      </div>
+
+      <h2 class="log-title">
         <NuxtLink :to="`/listening-logs/${listeningLog.id}`">
           {{ listeningLog.piece }}
         </NuxtLink>
-      </div>
-      <div class="log-meta">
-        <span>{{ listeningLog.composer }}</span>
-      </div>
-      <div class="log-sub">
+      </h2>
+
+      <div class="log-rating">
         <RatingDisplay :rating="listeningLog.rating" />
-        <span class="date">{{ formatDate(listeningLog.listenedAt) }}</span>
       </div>
-      <p v-if="listeningLog.memo" class="log-memo">{{ listeningLog.memo }}</p>
+
+      <p v-if="listeningLog.memo" class="log-memo">
+        <span class="memo-quote" aria-hidden="true">&ldquo;</span>
+        {{ listeningLog.memo }}
+        <span class="memo-quote" aria-hidden="true">&rdquo;</span>
+      </p>
     </div>
+
     <div class="log-actions">
-      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
-      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
+      <ButtonSecondary @click="emit('edit')">Edit</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">Delete</ButtonDanger>
     </div>
-  </div>
+  </article>
 </template>
 
 <style scoped>
 .log-item {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 10px;
-  padding: 1.2rem 1.5rem;
+  position: relative;
+  background: var(--color-bg-paper);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 1.6rem 0.5rem 1.6rem 0;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 1.5rem;
+  transition: background 0.25s ease;
+}
+
+.log-item:hover {
+  background: var(--color-bg-elevated);
+}
+
+.log-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%) scaleY(0);
+  height: 60%;
+  width: 2px;
+  background: var(--color-accent);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.log-item:hover::before {
+  transform: translateY(-50%) scaleY(1);
+}
+
+.log-main {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 1rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.log-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+}
+
+.log-composer {
+  color: var(--color-bordeaux);
+}
+:root.dark .log-composer {
+  color: var(--color-accent);
+}
+
+.log-rule {
+  width: 1.5rem;
+  height: 1px;
+  background: var(--color-hairline-strong);
+}
+
+.log-date {
+  color: var(--color-text-muted);
 }
 
 .log-title {
-  font-size: 1.1rem;
-  font-weight: bold;
-  margin-bottom: 0.3rem;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.3rem, 2.4vw, 1.65rem);
+  line-height: 1.2;
+  letter-spacing: var(--tracking-tight);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
 .log-title a {
   color: var(--color-text);
   text-decoration: none;
+  transition: color 0.25s ease;
 }
 
 .log-title a:hover {
-  text-decoration: underline;
+  color: var(--color-accent);
 }
 
-.log-meta {
-  color: var(--color-text-muted);
-  font-size: 0.9rem;
-  display: flex;
-  gap: 1rem;
-  margin-bottom: 0.3rem;
-}
-
-.log-sub {
-  display: flex;
-  gap: 1rem;
-  font-size: 0.9rem;
-  margin-bottom: 0.3rem;
-}
-
-.date {
-  color: var(--color-text-disabled);
+.log-rating {
+  margin-top: 0.1rem;
 }
 
 .log-memo {
-  font-size: 0.9rem;
-  color: var(--color-text-secondary);
-  margin-top: 0.5rem;
+  font-family: var(--font-serif);
   font-style: italic;
+  color: var(--color-text-secondary);
+  font-size: 1rem;
+  line-height: 1.55;
+  padding-left: 1rem;
+  border-left: 1px solid var(--color-hairline-strong);
+  max-width: 50em;
+  margin-top: 0.25rem;
+}
+
+.memo-quote {
+  font-family: var(--font-display);
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 1.2em;
 }
 
 .log-actions {
@@ -95,5 +159,16 @@ const emit = defineEmits<{
   flex-direction: column;
   gap: 0.5rem;
   flex-shrink: 0;
+  align-items: flex-end;
+}
+
+@media (max-width: 720px) {
+  .log-item {
+    grid-template-columns: 1fr;
+  }
+  .log-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+  }
 }
 </style>

--- a/app/components/molecules/PageHeader.vue
+++ b/app/components/molecules/PageHeader.vue
@@ -8,22 +8,66 @@ const router = useRouter();
 </script>
 
 <template>
-  <div class="page-header">
-    <h1>{{ title }}</h1>
-    <ButtonPrimary v-if="newPagePath" @click="router.push(newPagePath!)"><slot /></ButtonPrimary>
-  </div>
+  <header class="page-header">
+    <div class="page-header-inner">
+      <span class="page-header-rule" aria-hidden="true" />
+      <h1 class="page-header-title">{{ title }}</h1>
+      <ButtonPrimary v-if="newPagePath" @click="router.push(newPagePath!)">
+        <slot />
+      </ButtonPrimary>
+    </div>
+    <span class="page-header-trail" aria-hidden="true" />
+  </header>
 </template>
 
 <style scoped>
 .page-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2rem;
+  flex-direction: column;
+  gap: 1rem;
+  margin-bottom: 2.4rem;
 }
 
-.page-header h1 {
-  font-size: 1.8rem;
+.page-header-inner {
+  display: flex;
+  align-items: baseline;
+  gap: 1.4rem;
+}
+
+.page-header-rule {
+  flex: 0 0 3rem;
+  height: 1px;
+  align-self: center;
+  background: var(--color-accent);
+  opacity: 0.7;
+}
+
+.page-header-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.8rem, 4vw, 2.6rem);
+  line-height: 1.05;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
+  flex: 1;
+}
+
+.page-header-trail {
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+@media (max-width: 600px) {
+  .page-header-inner {
+    flex-wrap: wrap;
+    gap: 0.8rem;
+  }
+  .page-header-rule {
+    flex: 0 0 1.8rem;
+  }
 }
 </style>

--- a/app/components/molecules/PieceItem.test.ts
+++ b/app/components/molecules/PieceItem.test.ts
@@ -120,7 +120,7 @@ describe("PieceItem", () => {
       const wrapper = await mountSuspended(PieceItem, {
         props: { piece: samplePieceWithCategories, composerName: "ベートーヴェン" },
       });
-      expect(wrapper.find(".kind-genre").text()).toBe("交響曲");
+      expect(wrapper.find(".kind-genre .badge-value").text()).toBe("交響曲");
     });
 
     it("genre が未設定の場合、ジャンルバッジが表示されない", async () => {
@@ -134,7 +134,7 @@ describe("PieceItem", () => {
       const wrapper = await mountSuspended(PieceItem, {
         props: { piece: samplePieceWithCategories, composerName: "ベートーヴェン" },
       });
-      expect(wrapper.find(".kind-era").text()).toBe("ロマン派");
+      expect(wrapper.find(".kind-era .badge-value").text()).toBe("ロマン派");
     });
 
     it("era が未設定の場合、時代バッジが表示されない", async () => {
@@ -148,10 +148,10 @@ describe("PieceItem", () => {
       const wrapper = await mountSuspended(PieceItem, {
         props: { piece: samplePieceWithCategories, composerName: "ベートーヴェン" },
       });
-      expect(wrapper.find(".kind-genre").text()).toBe("交響曲");
-      expect(wrapper.find(".kind-era").text()).toBe("ロマン派");
-      expect(wrapper.find(".kind-formation").text()).toBe("管弦楽");
-      expect(wrapper.find(".kind-region").text()).toBe("ドイツ・オーストリア");
+      expect(wrapper.find(".kind-genre .badge-value").text()).toBe("交響曲");
+      expect(wrapper.find(".kind-era .badge-value").text()).toBe("ロマン派");
+      expect(wrapper.find(".kind-formation .badge-value").text()).toBe("管弦楽");
+      expect(wrapper.find(".kind-region .badge-value").text()).toBe("ドイツ・オーストリア");
     });
 
     it("全カテゴリが未設定の場合、バッジが一切表示されない", async () => {

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -22,7 +22,7 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
 </script>
 
 <template>
-  <div class="piece-item">
+  <article class="piece-item">
     <button
       v-if="hasYouTubeThumbnail"
       type="button"
@@ -31,73 +31,136 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
       @click="emit('play')"
     >
       <YouTubeThumbnail :video-url="piece.videoUrl" :alt="thumbnailAlt" />
+      <span class="thumb-play" aria-hidden="true">&#9658;</span>
     </button>
+
     <div class="piece-main">
-      <div class="piece-title">{{ piece.title }}</div>
-      <div class="piece-composer">{{ composerName }}</div>
+      <p class="piece-composer smallcaps">{{ composerName }}</p>
+      <h2 class="piece-title">{{ piece.title }}</h2>
       <div class="piece-category-wrapper">
         <PieceCategoryList :piece="piece" />
       </div>
     </div>
+
     <div class="piece-actions">
-      <button type="button" class="btn-detail" @click="emit('detail')">詳細</button>
-      <ButtonSecondary @click="emit('edit')">編集</ButtonSecondary>
-      <ButtonDanger @click="emit('delete')">削除</ButtonDanger>
+      <button type="button" class="btn-detail" @click="emit('detail')">
+        <span>Read</span>
+        <span aria-hidden="true">&rarr;</span>
+      </button>
+      <ButtonSecondary @click="emit('edit')">Edit</ButtonSecondary>
+      <ButtonDanger @click="emit('delete')">Delete</ButtonDanger>
     </div>
-  </div>
+  </article>
 </template>
 
 <style scoped>
 .piece-item {
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border);
-  border-radius: 10px;
-  padding: 1.2rem 1.5rem;
-  display: flex;
-  justify-content: space-between;
+  position: relative;
+  background: var(--color-bg-paper);
+  border: none;
+  border-bottom: 1px solid var(--color-hairline);
+  padding: 1.6rem 0.5rem 1.6rem 0;
+  display: grid;
+  grid-template-columns: 160px 1fr auto;
   align-items: center;
-  gap: 1rem;
+  gap: 1.5rem;
+  transition: background 0.25s ease;
+}
+
+.piece-item:hover {
+  background: var(--color-bg-elevated);
+}
+
+.piece-item::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%) scaleY(0);
+  height: 60%;
+  width: 2px;
+  background: var(--color-accent);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.piece-item:hover::before {
+  transform: translateY(-50%) scaleY(1);
 }
 
 .piece-thumbnail {
+  position: relative;
   flex-shrink: 0;
   padding: 0;
   margin: 0;
-  border: none;
+  border: 1px solid var(--color-hairline);
   background: transparent;
   cursor: pointer;
-  border-radius: 6px;
-  transition: opacity 0.2s;
+  transition:
+    transform 0.3s ease,
+    border-color 0.3s ease;
+  overflow: hidden;
+  width: 160px;
+  aspect-ratio: 16 / 9;
 }
 
 .piece-thumbnail:hover {
-  opacity: 0.85;
+  border-color: var(--color-accent);
 }
 
 .piece-thumbnail:focus-visible {
-  outline: 2px solid #c2a878;
+  outline: 1px solid var(--color-accent);
   outline-offset: 2px;
+}
+
+.thumb-play {
+  position: absolute;
+  inset: 0;
+  margin: auto;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
+  border: 1px solid var(--color-accent);
+  font-size: 0.85rem;
+  padding-left: 3px;
+  opacity: 0;
+  transition: opacity 0.25s ease;
+  pointer-events: none;
+}
+
+.piece-thumbnail:hover .thumb-play {
+  opacity: 1;
 }
 
 .piece-main {
   flex: 1;
   min-width: 0;
-  min-height: 90px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
-}
-
-.piece-title {
-  font-size: 1.1rem;
-  font-weight: bold;
-  margin-bottom: 0.3rem;
-  color: var(--color-text);
+  gap: 0.45rem;
 }
 
 .piece-composer {
-  font-size: 0.9rem;
-  color: var(--color-text-muted);
+  color: var(--color-bordeaux);
+}
+:root.dark .piece-composer {
+  color: var(--color-accent);
+}
+
+.piece-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.3rem, 2.4vw, 1.65rem);
+  line-height: 1.15;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
 .piece-category-wrapper {
@@ -106,54 +169,54 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
 
 .piece-actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
   flex-shrink: 0;
+  align-items: center;
 }
 
 .btn-detail {
-  background: var(--color-bg-elevated);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: transparent;
   color: var(--color-text);
-  padding: 0.6rem 1.2rem;
-  border: 1px solid #c2a878;
-  border-radius: 6px;
-  font-size: 0.95rem;
+  padding: 0.7rem 1rem;
+  border: 1px solid var(--color-bg-ink);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background 0.2s;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease,
+    border-color 0.25s ease;
 }
 
 .btn-detail:hover {
-  background: var(--color-border);
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
 }
 
-:global(.dark .piece-thumbnail:focus-visible) {
-  outline-color: #6e5a3d;
+:root.dark .btn-detail {
+  border-color: var(--color-text);
+  color: var(--color-text);
 }
 
-:global(.dark .btn-detail) {
-  border-color: #6e5a3d;
-}
-
-@media (max-width: 600px) {
+@media (max-width: 720px) {
   .piece-item {
-    flex-direction: column;
-    align-items: flex-start;
+    grid-template-columns: 1fr;
+    padding: 1.5rem 0;
   }
 
   .piece-thumbnail {
-    order: 1;
     width: 100%;
-    max-width: 240px;
+    max-width: 280px;
     align-self: center;
   }
 
-  .piece-main {
-    order: 2;
-    width: 100%;
-    min-height: 0;
-  }
-
   .piece-actions {
-    order: 3;
     width: 100%;
     justify-content: flex-end;
   }

--- a/app/components/organisms/ComposerList.vue
+++ b/app/components/organisms/ComposerList.vue
@@ -24,7 +24,7 @@ const emit = defineEmits<{
       >作曲家が登録されていません。最初の作曲家を追加しましょう。</EmptyState
     >
 
-    <ul v-else class="composer-list">
+    <ul v-else class="composer-list stagger-children">
       <li v-for="composer in composers" :key="composer.id">
         <ComposerItem
           :composer="composer"
@@ -40,14 +40,9 @@ const emit = defineEmits<{
 <style scoped>
 .composer-list {
   list-style: none;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-@media (min-width: 1024px) {
-  .composer-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
 }
 </style>

--- a/app/components/organisms/ConcertLogDetail.test.ts
+++ b/app/components/organisms/ConcertLogDetail.test.ts
@@ -47,7 +47,6 @@ describe("ConcertLogDetail", () => {
         props: { log: sampleLog, pieces: [], composerNameById },
       });
       expect(wrapper.find("h1").text()).toBe("定期演奏会 第100回");
-      expect(wrapper.text()).toContain("会場");
       expect(wrapper.text()).toContain("サントリーホール");
     });
 
@@ -87,9 +86,9 @@ describe("ConcertLogDetail", () => {
           composerNameById,
         },
       });
-      expect(wrapper.text()).not.toContain("指揮者");
-      expect(wrapper.text()).not.toContain("オーケストラ");
-      expect(wrapper.text()).not.toContain("ソリスト");
+      expect(wrapper.text()).not.toContain("Conductor");
+      expect(wrapper.text()).not.toContain("Orchestra");
+      expect(wrapper.text()).not.toContain("Soloist");
     });
   });
 
@@ -115,14 +114,14 @@ describe("ConcertLogDetail", () => {
           composerNameById,
         },
       });
-      expect(wrapper.text()).toContain("プログラムなし");
+      expect(wrapper.text()).toContain("プログラムは記録されていません");
     });
 
     it("pieceIds が未設定の場合もプログラムなしメッセージが表示される", async () => {
       const wrapper = await mountSuspended(ConcertLogDetail, {
         props: { log: sampleLog, pieces: samplePieces, composerNameById },
       });
-      expect(wrapper.text()).toContain("プログラムなし");
+      expect(wrapper.text()).toContain("プログラムは記録されていません");
     });
   });
 });

--- a/app/components/organisms/ConcertLogDetail.vue
+++ b/app/components/organisms/ConcertLogDetail.vue
@@ -16,91 +16,220 @@ const programPieces = computed(() => {
     .map((id) => props.pieces.find((p) => p.id === id))
     .filter((p): p is Piece => p !== undefined);
 });
+
+const shortId = computed(() => props.log.id.slice(0, 6).toUpperCase());
 </script>
 
 <template>
   <article class="log-detail">
-    <header>
-      <h1>{{ log.title }}</h1>
+    <header class="log-detail-head">
+      <div class="log-meta">
+        <span class="meta-tag smallcaps">IV / Concert</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-id smallcaps numeric">N&deg; {{ shortId }}</span>
+      </div>
+
+      <p class="log-venue smallcaps">{{ log.venue }}</p>
+
+      <h1 class="log-title">{{ log.title }}</h1>
+
+      <time class="log-date smallcaps numeric">{{ formatDatetime(log.concertDate) }}</time>
     </header>
 
-    <dl class="detail-list">
-      <dt>会場</dt>
-      <dd>{{ log.venue }}</dd>
+    <section class="credits-section">
+      <span class="section-tag smallcaps">Credits</span>
+      <dl class="credits-list">
+        <template v-if="log.conductor">
+          <dt class="smallcaps">Conductor</dt>
+          <dd>{{ log.conductor }}</dd>
+        </template>
 
-      <dt>開催日時</dt>
-      <dd>{{ formatDatetime(log.concertDate) }}</dd>
+        <template v-if="log.orchestra">
+          <dt class="smallcaps">Orchestra</dt>
+          <dd>{{ log.orchestra }}</dd>
+        </template>
 
-      <template v-if="log.conductor">
-        <dt>指揮者</dt>
-        <dd>{{ log.conductor }}</dd>
-      </template>
+        <template v-if="log.soloist">
+          <dt class="smallcaps">Soloist</dt>
+          <dd>{{ log.soloist }}</dd>
+        </template>
+      </dl>
+    </section>
 
-      <template v-if="log.orchestra">
-        <dt>オーケストラ / アンサンブル</dt>
-        <dd>{{ log.orchestra }}</dd>
-      </template>
-
-      <template v-if="log.soloist">
-        <dt>ソリスト</dt>
-        <dd>{{ log.soloist }}</dd>
-      </template>
-
-      <dt>プログラム</dt>
-      <dd>
-        <ol v-if="programPieces.length > 0" class="program-list">
-          <li v-for="piece in programPieces" :key="piece.id">
-            {{ piece.title }} / {{ props.composerNameById[piece.composerId] ?? "(不明)" }}
-          </li>
-        </ol>
-        <span v-else class="no-program">プログラムなし</span>
-      </dd>
-    </dl>
+    <section class="program-section">
+      <span class="section-tag smallcaps">Program</span>
+      <ol v-if="programPieces.length > 0" class="program-list">
+        <li v-for="(piece, idx) in programPieces" :key="piece.id" class="program-row">
+          <span class="program-num numeric">{{ String(idx + 1).padStart(2, "0") }}</span>
+          <div class="program-piece">
+            <span class="program-composer smallcaps">
+              {{ composerNameById[piece.composerId] ?? "(不明)" }}
+            </span>
+            <span class="program-title">{{ piece.title }}</span>
+          </div>
+        </li>
+      </ol>
+      <p v-else class="no-program">
+        <em>&mdash;&mdash; プログラムは記録されていません</em>
+      </p>
+    </section>
   </article>
 </template>
 
 <style scoped>
 .log-detail {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 12px;
-  padding: 2rem;
-  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
 }
 
-.log-detail header {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--color-secondary);
+.log-detail-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
 }
 
-.log-detail h1 {
-  font-size: 1.8rem;
+.log-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-id {
+  color: var(--color-text-muted);
+}
+
+.log-venue {
+  color: var(--color-bordeaux);
+  margin-top: 0.2rem;
+}
+:root.dark .log-venue {
+  color: var(--color-accent);
+}
+
+.log-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60,
+    "WONK" 1;
 }
 
-.detail-list {
+.log-date {
+  color: var(--color-text-muted);
+  margin-top: 0.4rem;
+}
+
+/* ── Credits ── */
+.credits-section,
+.program-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.section-tag {
+  color: var(--color-bordeaux);
+  display: block;
+  padding-bottom: 0.6rem;
+  border-bottom: 1px solid var(--color-hairline);
+}
+:root.dark .section-tag {
+  color: var(--color-accent);
+}
+
+.credits-list {
   display: grid;
-  grid-template-columns: 14rem 1fr;
-  gap: 0.6rem 1rem;
+  grid-template-columns: minmax(120px, auto) 1fr;
+  gap: 0.5rem 2rem;
+  font-family: var(--font-serif);
 }
 
-dt {
-  font-weight: bold;
-  color: var(--color-text-faint);
-  font-size: 0.9rem;
+.credits-list dt {
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
 }
 
+.credits-list dd {
+  font-style: italic;
+  color: var(--color-text);
+  font-size: 1.1rem;
+}
+
+/* ── Program ── */
 .program-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  padding: 0;
   margin: 0;
-  padding-left: 1.5rem;
 }
 
-.program-list li {
-  margin-bottom: 0.3rem;
+.program-row {
+  display: grid;
+  grid-template-columns: 60px 1fr;
+  align-items: baseline;
+  gap: 1.2rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.program-row:last-child {
+  border-bottom: none;
+}
+
+.program-num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.4rem;
+  color: var(--color-accent);
+  font-weight: 300;
+}
+
+.program-piece {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.program-composer {
+  color: var(--color-text-muted);
+}
+
+.program-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.2rem;
+  color: var(--color-text);
+  letter-spacing: var(--tracking-tight);
 }
 
 .no-program {
+  font-family: var(--font-serif);
   color: var(--color-text-muted);
+  font-style: italic;
+  padding: 1rem 0;
 }
 </style>

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -102,17 +102,30 @@ function handleSubmit() {
       />
     </FormGroup>
 
-    <FormGroup label="開催日時" input-id="concert-date" required>
-      <input id="concert-date" v-model="form.concertDate" type="datetime-local" required />
-    </FormGroup>
+    <div class="form-row">
+      <FormGroup label="開催日時" input-id="concert-date" required>
+        <input
+          id="concert-date"
+          v-model="form.concertDate"
+          type="datetime-local"
+          class="native-input"
+          required
+        />
+      </FormGroup>
 
-    <FormGroup label="会場" input-id="venue" required>
-      <TextInput id="venue" v-model="form.venue" placeholder="例: サントリーホール" required />
-    </FormGroup>
+      <FormGroup label="会場" input-id="venue" required>
+        <TextInput id="venue" v-model="form.venue" placeholder="例: サントリーホール" required />
+      </FormGroup>
+    </div>
 
-    <FormGroup label="指揮者" input-id="conductor">
-      <TextInput id="conductor" v-model="form.conductor" placeholder="例: カラヤン" />
-    </FormGroup>
+    <div class="form-row">
+      <FormGroup label="指揮者" input-id="conductor">
+        <TextInput id="conductor" v-model="form.conductor" placeholder="例: カラヤン" />
+      </FormGroup>
+      <FormGroup label="ソリスト" input-id="soloist">
+        <TextInput id="soloist" v-model="form.soloist" placeholder="例: アルゲリッチ" />
+      </FormGroup>
+    </div>
 
     <FormGroup label="オーケストラ / アンサンブル" input-id="orchestra">
       <TextInput
@@ -122,24 +135,24 @@ function handleSubmit() {
       />
     </FormGroup>
 
-    <FormGroup label="ソリスト" input-id="soloist">
-      <TextInput id="soloist" v-model="form.soloist" placeholder="例: アルゲリッチ" />
-    </FormGroup>
-
     <FormGroup label="プログラム" input-id="piece-select">
       <div class="piece-selector">
-        <select
-          data-testid="piece-select"
-          :disabled="piecesPending"
-          @change="selectedPieceId = ($event.target as HTMLSelectElement).value"
-        >
-          <option value="">{{ piecesPending ? "読み込み中..." : "楽曲を選択" }}</option>
-          <option v-for="piece in pieces" :key="piece.id" :value="piece.id">
-            {{ piece.title }} / {{ composerNameById[piece.composerId] ?? "(不明)" }}
-          </option>
-        </select>
+        <div class="select-wrap">
+          <select
+            data-testid="piece-select"
+            class="native-select"
+            :disabled="piecesPending"
+            @change="selectedPieceId = ($event.target as HTMLSelectElement).value"
+          >
+            <option value="">{{ piecesPending ? "読み込み中…" : "楽曲を選択" }}</option>
+            <option v-for="piece in pieces" :key="piece.id" :value="piece.id">
+              {{ piece.title }} / {{ composerNameById[piece.composerId] ?? "(不明)" }}
+            </option>
+          </select>
+          <span class="select-caret" aria-hidden="true">&#x25BE;</span>
+        </div>
         <button type="button" data-testid="add-piece" class="btn-add-piece" @click="addPiece">
-          追加
+          <span class="smallcaps">Add</span>
         </button>
       </div>
 
@@ -153,9 +166,20 @@ function handleSubmit() {
         <template #item="{ element, index }">
           <li data-testid="program-item" class="program-item">
             <!-- NOSONAR: draggableがolラッパーを生成するためliの親はolになる -->
-            <span class="drag-handle" aria-label="ドラッグして並べ替え">☰</span>
+            <span class="program-num numeric">{{ String(index + 1).padStart(2, "0") }}</span>
+            <button
+              type="button"
+              class="drag-handle"
+              :aria-label="`${element.title} をドラッグして並べ替え`"
+              tabindex="-1"
+            >
+              &#10741;
+            </button>
             <span class="piece-info">
-              {{ element.title }} / {{ composerNameById[element.composerId] ?? "(不明)" }}
+              <span class="piece-info-composer smallcaps">
+                {{ composerNameById[element.composerId] ?? "(不明)" }}
+              </span>
+              <span class="piece-info-title">{{ element.title }}</span>
             </span>
             <button
               type="button"
@@ -163,7 +187,7 @@ function handleSubmit() {
               class="btn-remove-piece"
               @click="removePiece(index)"
             >
-              削除
+              &times;
             </button>
           </li>
         </template>
@@ -181,82 +205,186 @@ function handleSubmit() {
 .log-form {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1.6rem;
+  max-width: 720px;
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.2rem;
+}
+
+@media (max-width: 600px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.native-input,
+.native-select {
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.55rem 0.1rem;
+  font-size: 0.95rem;
+  font-family: var(--font-sans);
+  background: transparent;
+  color: var(--color-text);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.25s ease;
+  font-variant-numeric: tabular-nums;
+}
+
+.native-input:focus,
+.native-select:focus {
+  outline: none;
+  border-bottom-color: var(--color-accent);
+}
+
+.select-wrap {
+  position: relative;
+  width: 100%;
+}
+
+.native-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 1.6rem;
+  cursor: pointer;
+}
+
+.select-caret {
+  position: absolute;
+  right: 0.3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--color-accent);
+  font-size: 0.85rem;
 }
 
 .piece-selector {
   display: flex;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.piece-selector select {
-  flex: 1;
+  gap: 0.8rem;
+  align-items: flex-end;
 }
 
 .btn-add-piece {
-  padding: 0.4rem 1rem;
-  background: #4a6fa5;
-  color: var(--color-on-primary);
-  border: none;
-  border-radius: 6px;
+  flex-shrink: 0;
+  padding: 0.7rem 1.2rem;
+  background: transparent;
+  color: var(--color-text);
+  border: 1px solid var(--color-bg-ink);
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
+  transition:
+    background 0.25s ease,
+    color 0.25s ease;
 }
 
 .btn-add-piece:hover {
-  background: #3a5f95;
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
+}
+
+:root.dark .btn-add-piece {
+  border-color: var(--color-text);
 }
 
 .program-list {
   list-style: none;
   padding: 0;
-  margin: 0.5rem 0 0;
+  margin: 0.8rem 0 0;
   display: flex;
   flex-direction: column;
-  gap: 0.4rem;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
 }
 
 .program-item {
-  display: flex;
+  display: grid;
+  grid-template-columns: 40px 24px 1fr auto;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.5rem 0.75rem;
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-border);
-  border-radius: 6px;
+  gap: 0.8rem;
+  padding: 0.85rem 0.5rem;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.program-num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.2rem;
+  color: var(--color-accent);
+  font-weight: 300;
 }
 
 .drag-handle {
   cursor: grab;
   user-select: none;
   color: var(--color-text-muted);
+  background: none;
+  border: none;
+  padding: 0.2rem;
+  font-size: 1rem;
+  line-height: 1;
+  transition: color 0.2s ease;
+}
+
+.drag-handle:hover {
+  color: var(--color-accent);
+}
+
+.drag-handle:active {
+  cursor: grabbing;
 }
 
 .piece-info {
-  flex: 1;
-  font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  min-width: 0;
+}
+
+.piece-info-composer {
+  color: var(--color-text-muted);
+  font-size: 0.65rem;
+}
+
+.piece-info-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.05rem;
+  color: var(--color-text);
 }
 
 .btn-remove-piece {
-  padding: 0.2rem 0.6rem;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   background: none;
-  color: var(--color-danger);
-  border: 1px solid var(--color-danger);
-  border-radius: 4px;
+  color: var(--color-text-faint);
+  border: 1px solid var(--color-hairline);
+  border-radius: 0;
   cursor: pointer;
-  font-size: 0.85rem;
+  font-size: 1.1rem;
+  line-height: 1;
+  transition:
+    color 0.25s ease,
+    border-color 0.25s ease;
 }
 
 .btn-remove-piece:hover {
-  background: var(--color-danger);
-  color: var(--color-on-primary);
-}
-
-:global(.dark .btn-add-piece) {
-  background: #6a8fc5;
-}
-
-:global(.dark .btn-add-piece:hover) {
-  background: #7a9fd5;
+  color: var(--color-bordeaux);
+  border-color: var(--color-bordeaux);
 }
 </style>

--- a/app/components/organisms/ConcertLogList.vue
+++ b/app/components/organisms/ConcertLogList.vue
@@ -14,7 +14,7 @@ const router = useRouter();
       >まだ記録がありません。最初のコンサート記録を追加しましょう。</EmptyState
     >
 
-    <ul v-else class="log-list">
+    <ul v-else class="log-list stagger-children">
       <li v-for="log in logs" :key="log.id">
         <ConcertLogItem :concert-log="log" @detail="router.push(`/concert-logs/${log.id}`)" />
       </li>
@@ -27,6 +27,7 @@ const router = useRouter();
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
 }
 </style>

--- a/app/components/organisms/FeaturedPiece.vue
+++ b/app/components/organisms/FeaturedPiece.vue
@@ -41,10 +41,12 @@ const shuffle = () => {
 
 <template>
   <div class="featured">
-    <div class="featured-header">
-      <h2 class="featured-heading">今日の一曲</h2>
+    <div class="featured-meta">
+      <span class="meta-tag smallcaps">Now playing</span>
+      <span class="meta-rule" aria-hidden="true" />
       <button v-if="canShuffle && !loading" class="shuffle-btn" type="button" @click="shuffle">
-        ↺ 別の曲を見る
+        <span aria-hidden="true">&#x2934;</span>
+        <span>Shuffle</span>
       </button>
     </div>
 
@@ -52,15 +54,21 @@ const shuffle = () => {
       <div class="loading-pulse" />
     </div>
 
-    <div v-else-if="!featured" class="featured-empty">動画付きの楽曲がまだ登録されていません</div>
+    <div v-else-if="!featured" class="featured-empty">
+      <p class="empty-quote">&ldquo;A song unsung is silence.&rdquo;</p>
+      <p class="empty-help">動画付きの楽曲がまだ登録されていません</p>
+    </div>
 
     <div v-else class="featured-content">
-      <VideoPlayer :key="featured.id" :video-url="featured.videoUrl!" />
+      <div class="featured-video">
+        <VideoPlayer :key="featured.id" :video-url="featured.videoUrl!" />
+      </div>
       <div class="piece-info">
-        <p class="piece-title">《{{ featured.title }}》</p>
         <p class="piece-composer">
           {{ (props.composerNameById ?? {})[featured.composerId] ?? "(不明な作曲家)" }}
         </p>
+        <p class="piece-title">{{ featured.title }}</p>
+        <p class="piece-attr smallcaps">a piece selected for you tonight</p>
       </div>
     </div>
   </div>
@@ -68,42 +76,54 @@ const shuffle = () => {
 
 <style scoped>
 .featured {
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 16px;
-  padding: 1.75rem;
-}
-
-.featured-header {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 1.25rem;
+  flex-direction: column;
+  gap: 1.4rem;
 }
 
-.featured-heading {
-  font-size: 1.1rem;
-  color: var(--color-text);
-  font-weight: 600;
-  letter-spacing: 0.04em;
+.featured-meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+  font-weight: 700;
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
 }
 
 .shuffle-btn {
-  background: none;
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.4rem 0.9rem;
-  font-size: 0.85rem;
-  color: var(--color-secondary-hover);
+  background: transparent;
+  border: 1px solid var(--color-hairline-strong);
+  color: var(--color-text-muted);
+  padding: 0.45rem 0.95rem;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   transition:
-    border-color 0.2s,
-    color 0.2s;
+    border-color 0.25s ease,
+    color 0.25s ease,
+    background 0.25s ease;
 }
 
 .shuffle-btn:hover {
-  border-color: var(--color-text);
-  color: var(--color-text);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .featured-loading {
@@ -112,15 +132,14 @@ const shuffle = () => {
 
 .loading-pulse {
   width: 100%;
-  height: 200px;
+  aspect-ratio: 16 / 9;
   background: linear-gradient(
     90deg,
     var(--color-bg-subtle) 25%,
-    var(--color-border-strong) 50%,
+    var(--color-border) 50%,
     var(--color-bg-subtle) 75%
   );
   background-size: 200% 100%;
-  border-radius: 8px;
   animation: pulse 1.5s infinite;
 }
 
@@ -134,33 +153,88 @@ const shuffle = () => {
 }
 
 .featured-empty {
-  padding: 3rem;
-  text-align: center;
-  color: var(--color-text-faint);
-  font-size: 0.95rem;
-}
-
-.featured-content {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.piece-info {
+  padding: 3rem 1rem;
   text-align: center;
 }
 
-.piece-title {
-  font-size: 1.15rem;
-  font-weight: 600;
-  color: var(--color-text);
+.empty-quote {
+  font-family: var(--font-display);
   font-style: italic;
+  font-size: 1.6rem;
+  color: var(--color-text);
+  line-height: 1.3;
+  margin-bottom: 0.4rem;
+  font-variation-settings: "opsz" 144;
+}
+
+.empty-help {
+  font-family: var(--font-sans);
+  font-size: 0.85rem;
+  color: var(--color-text-faint);
   letter-spacing: 0.04em;
 }
 
+.featured-content {
+  display: grid;
+  grid-template-columns: 1.4fr 1fr;
+  gap: 1.8rem;
+  align-items: center;
+}
+
+.featured-video {
+  width: 100%;
+}
+
+.piece-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 1rem;
+  border-left: 1px solid var(--color-hairline);
+}
+
 .piece-composer {
-  font-size: 0.9rem;
-  color: var(--color-secondary-hover);
-  margin-top: 0.25rem;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+}
+
+.piece-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.6rem, 2.5vw, 2.1rem);
+  color: var(--color-text);
+  line-height: 1.15;
+  letter-spacing: var(--tracking-tight);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60;
+}
+
+.piece-attr {
+  margin-top: 0.6rem;
+  color: var(--color-text-faint);
+  font-family: var(--font-serif);
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+@media (max-width: 760px) {
+  .featured-content {
+    grid-template-columns: 1fr;
+    gap: 1.2rem;
+  }
+  .piece-info {
+    border-left: none;
+    border-top: 1px solid var(--color-hairline);
+    padding: 1.2rem 0 0;
+  }
 }
 </style>

--- a/app/components/organisms/ListeningLogDetail.vue
+++ b/app/components/organisms/ListeningLogDetail.vue
@@ -2,79 +2,152 @@
 import { formatDatetime } from "~/utils/date";
 import type { ListeningLog } from "~/types";
 
-defineProps<{
+const props = defineProps<{
   log: ListeningLog;
 }>();
+
+const shortId = computed(() => props.log.id.slice(0, 6).toUpperCase());
 </script>
 
 <template>
   <article class="log-detail">
-    <header>
-      <h1>
+    <header class="log-detail-head">
+      <div class="log-meta">
+        <span class="meta-tag smallcaps">I / Recording</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-id smallcaps numeric">N&deg; {{ shortId }}</span>
+      </div>
+
+      <p class="log-composer smallcaps">
         <FavoriteIndicator :is-favorite="log.isFavorite" />
-        {{ log.piece }}
-      </h1>
+        {{ log.composer }}
+      </p>
+
+      <h1 class="log-title">{{ log.piece }}</h1>
+
+      <div class="log-rating-row">
+        <RatingDisplay :rating="log.rating" />
+        <span class="meta-rule" aria-hidden="true" />
+        <time class="smallcaps numeric">{{ formatDatetime(log.listenedAt) }}</time>
+      </div>
     </header>
 
-    <dl class="detail-list">
-      <dt>作曲家</dt>
-      <dd>{{ log.composer }}</dd>
-
-      <dt>鑑賞日時</dt>
-      <dd>{{ formatDatetime(log.listenedAt) }}</dd>
-
-      <dt>評価</dt>
-      <dd><RatingDisplay :rating="log.rating" /></dd>
-    </dl>
-
     <section v-if="log.memo" class="memo">
-      <h2>感想・メモ</h2>
-      <p>{{ log.memo }}</p>
+      <span class="memo-tag smallcaps">Notes</span>
+      <p class="memo-body">{{ log.memo }}</p>
     </section>
   </article>
 </template>
 
 <style scoped>
 .log-detail {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 12px;
-  padding: 2rem;
-  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: 2.4rem;
 }
 
-.log-detail header {
-  margin-bottom: 1.5rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid var(--color-secondary);
+.log-detail-head {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+  padding-bottom: 2rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
 }
 
-.log-detail h1 {
-  font-size: 1.8rem;
+.log-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-id {
+  color: var(--color-text-muted);
+}
+
+.log-composer {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: var(--color-bordeaux);
+  margin-top: 0.4rem;
+}
+:root.dark .log-composer {
+  color: var(--color-accent);
+}
+
+.log-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1.05;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60,
+    "WONK" 1;
 }
 
-.detail-list {
-  display: grid;
-  grid-template-columns: 8rem 1fr;
-  gap: 0.6rem 1rem;
-  margin-bottom: 1.5rem;
+.log-rating-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-top: 0.4rem;
 }
 
-dt {
-  font-weight: bold;
-  color: var(--color-text-faint);
-  font-size: 0.9rem;
+.log-rating-row time {
+  color: var(--color-text-muted);
 }
 
-.memo h2 {
-  font-size: 1rem;
-  color: var(--color-text-faint);
-  margin-bottom: 0.5rem;
+.memo {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  max-width: 38em;
 }
 
-.memo p {
-  line-height: 1.7;
-  color: var(--color-text-secondary);
+.memo-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .memo-tag {
+  color: var(--color-accent);
+}
+
+.memo-body {
+  font-family: var(--font-serif);
+  font-size: 1.15rem;
+  line-height: 1.75;
+  color: var(--color-text);
+  font-style: italic;
+  padding-left: 1.4rem;
+  border-left: 1px solid var(--color-accent);
+  position: relative;
+}
+
+.memo-body::before {
+  content: "\201C";
+  position: absolute;
+  left: -0.4em;
+  top: -0.6em;
+  font-family: var(--font-display);
+  font-size: 3.5rem;
+  color: var(--color-accent);
+  opacity: 0.5;
+  font-style: italic;
+  line-height: 1;
 }
 </style>

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -240,25 +240,25 @@ describe("ListeningLogForm", () => {
   describe("楽曲選択", () => {
     it("楽曲選択セレクトボックスが表示される", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      expect(wrapper.find("select.piece-select").exists()).toBe(true);
+      expect(wrapper.find("select#piece-select").exists()).toBe(true);
     });
 
     it("「選択しない」オプションが含まれる", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const options = wrapper.findAll("select.piece-select option");
+      const options = wrapper.findAll("select#piece-select option");
       expect(options[0].text()).toBe("選択しない");
     });
 
     it("楽曲一覧がオプションに表示される", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const options = wrapper.findAll("select.piece-select option");
+      const options = wrapper.findAll("select#piece-select option");
       expect(options[1].text()).toBe("交響曲第9番 / ベートーヴェン");
       expect(options[2].text()).toBe("魔笛 / モーツァルト");
     });
 
     it("楽曲を選択すると曲名・作曲家が自動入力される", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
       await select.setValue("piece-1");
 
       const composerInput = wrapper.find('input[placeholder="例: ベートーヴェン"]');
@@ -269,7 +269,7 @@ describe("ListeningLogForm", () => {
 
     it("「選択しない」を選ぶと曲名・作曲家がクリアされる", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
 
       await select.setValue("piece-1");
       await select.setValue("");
@@ -289,28 +289,28 @@ describe("ListeningLogForm", () => {
 
     it("videoUrl ありの曲を選択すると動画プレイヤーが表示される", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
       await select.setValue("piece-3");
       expect(wrapper.find(".video-player").exists()).toBe(true);
     });
 
     it("表示された動画は選択した曲の URL を使用する", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
       await select.setValue("piece-3");
       expect(wrapper.find("iframe").attributes("src")).toContain("video123");
     });
 
     it("videoUrl なしの曲を選択しても動画プレイヤーは表示されない", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
       await select.setValue("piece-1");
       expect(wrapper.find(".video-player").exists()).toBe(false);
     });
 
     it("別の曲（videoUrl あり）に選択を変えると動画が切り替わる", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
 
       await select.setValue("piece-3");
       expect(wrapper.find("iframe").attributes("src")).toContain("video123");
@@ -321,7 +321,7 @@ describe("ListeningLogForm", () => {
 
     it("「選択しない」にすると動画が非表示になる", async () => {
       const wrapper = await mountSuspended(ListeningLogForm);
-      const select = wrapper.find("select.piece-select");
+      const select = wrapper.find("select#piece-select");
 
       await select.setValue("piece-3");
       expect(wrapper.find(".video-player").exists()).toBe(true);

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -55,21 +55,30 @@ function handleSubmit() {
 <template>
   <form class="log-form" @submit.prevent="handleSubmit">
     <FormGroup label="鑑賞日時" input-id="listened-at" required>
-      <input id="listened-at" v-model="form.listenedAt" type="datetime-local" required />
+      <input
+        id="listened-at"
+        v-model="form.listenedAt"
+        type="datetime-local"
+        class="native-input"
+        required
+      />
     </FormGroup>
 
     <FormGroup label="楽曲マスタから選択" input-id="piece-select">
-      <select
-        id="piece-select"
-        class="piece-select"
-        :disabled="piecesPending"
-        @change="handlePieceSelect"
-      >
-        <option value="">{{ piecesPending ? "読み込み中..." : "選択しない" }}</option>
-        <option v-for="piece in pieces" :key="piece.id" :value="piece.id">
-          {{ piece.title }} / {{ composerNameById[piece.composerId] ?? "(不明)" }}
-        </option>
-      </select>
+      <div class="select-wrap">
+        <select
+          id="piece-select"
+          class="native-select"
+          :disabled="piecesPending"
+          @change="handlePieceSelect"
+        >
+          <option value="">{{ piecesPending ? "読み込み中…" : "選択しない" }}</option>
+          <option v-for="piece in pieces" :key="piece.id" :value="piece.id">
+            {{ piece.title }} / {{ composerNameById[piece.composerId] ?? "(不明)" }}
+          </option>
+        </select>
+        <span class="select-caret" aria-hidden="true">&#x25BE;</span>
+      </div>
     </FormGroup>
 
     <VideoPlayer v-if="selectedVideoUrl" :video-url="selectedVideoUrl" />
@@ -95,7 +104,7 @@ function handleSubmit() {
     <div class="form-group">
       <label class="checkbox-label" for="is-favorite">
         <input id="is-favorite" v-model="form.isFavorite" type="checkbox" />
-        お気に入り
+        <span class="checkbox-text smallcaps">Mark as favorite</span>
       </label>
     </div>
 
@@ -104,7 +113,8 @@ function handleSubmit() {
         id="memo"
         v-model="form.memo"
         rows="4"
-        placeholder="自由に感想を書いてください..."
+        class="native-textarea"
+        placeholder="自由に感想を書いてください…"
       />
     </FormGroup>
 
@@ -114,20 +124,25 @@ function handleSubmit() {
 
 <style scoped>
 .log-form {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 12px;
-  padding: 2rem;
+  background: transparent;
+  border: none;
+  padding: 0;
   max-width: 720px;
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.6rem;
 }
 
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: 1rem;
+  gap: 1.2rem;
+}
+
+@media (max-width: 600px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
 }
 
 .form-group {
@@ -136,29 +151,79 @@ function handleSubmit() {
   gap: 0.4rem;
 }
 
-input[type="datetime-local"],
-textarea,
-select {
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.6rem 0.8rem;
+/* native input/select/textarea — エディトリアル罫線スタイル */
+.native-input,
+.native-textarea,
+.native-select {
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.55rem 0.1rem;
   font-size: 0.95rem;
-  font-family: inherit;
-  background: var(--color-bg-input);
-  transition: border-color 0.2s;
+  font-family: var(--font-sans);
+  background: transparent;
+  color: var(--color-text);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color 0.25s ease;
+  font-variant-numeric: tabular-nums;
 }
 
-input:focus,
-textarea:focus {
+.native-textarea {
+  font-family: var(--font-serif);
+  resize: vertical;
+}
+
+.native-textarea::placeholder,
+.native-input::placeholder {
+  color: var(--color-text-faint);
+  font-style: italic;
+}
+
+.native-input:focus,
+.native-textarea:focus,
+.native-select:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
+}
+
+.select-wrap {
+  position: relative;
+  width: 100%;
+}
+
+.native-select {
+  appearance: none;
+  -webkit-appearance: none;
+  padding-right: 1.6rem;
+  cursor: pointer;
+}
+
+.select-caret {
+  position: absolute;
+  right: 0.3rem;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
+  color: var(--color-accent);
+  font-size: 0.85rem;
 }
 
 .checkbox-label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: normal;
+  gap: 0.6rem;
   cursor: pointer;
+  font-family: var(--font-sans);
+}
+
+.checkbox-label input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.checkbox-text {
+  color: var(--color-text-muted);
 }
 </style>

--- a/app/components/organisms/ListeningLogList.vue
+++ b/app/components/organisms/ListeningLogList.vue
@@ -18,7 +18,7 @@ const router = useRouter();
       >まだ記録がありません。最初の鑑賞記録を追加しましょう。</EmptyState
     >
 
-    <ul v-else class="log-list">
+    <ul v-else class="log-list stagger-children">
       <li v-for="log in logs" :key="log.id">
         <ListeningLogItem
           :listening-log="log"
@@ -35,6 +35,7 @@ const router = useRouter();
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 1rem;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
 }
 </style>

--- a/app/components/organisms/ListeningLogStatistics.test.ts
+++ b/app/components/organisms/ListeningLogStatistics.test.ts
@@ -32,11 +32,11 @@ describe("ListeningLogStatistics", () => {
       const wrapper = await mountSuspended(ListeningLogStatistics, {
         props: { statistics: populatedStats },
       });
-      expect(wrapper.text()).toContain("総鑑賞数");
+      expect(wrapper.text()).toContain("Total entries");
       expect(wrapper.text()).toContain("10");
-      expect(wrapper.text()).toContain("お気に入り");
+      expect(wrapper.text()).toContain("Favorites");
       expect(wrapper.text()).toContain("4");
-      expect(wrapper.text()).toContain("平均評価");
+      expect(wrapper.text()).toContain("Average rating");
       expect(wrapper.text()).toContain("4.20");
     });
 
@@ -65,11 +65,11 @@ describe("ListeningLogStatistics", () => {
       expect(wrapper.text()).toContain("まだ鑑賞記録がありません");
     });
 
-    it("total が 0 のとき平均評価は - 表示", async () => {
+    it("total が 0 のとき平均評価は — 表示", async () => {
       const wrapper = await mountSuspended(ListeningLogStatistics, {
         props: { statistics: emptyStats },
       });
-      expect(wrapper.text()).toContain("-");
+      expect(wrapper.text()).toContain("—");
     });
   });
 });

--- a/app/components/organisms/ListeningLogStatistics.vue
+++ b/app/components/organisms/ListeningLogStatistics.vue
@@ -23,7 +23,7 @@ const monthlyMax = computed(() =>
 );
 
 const averageDisplay = computed(() =>
-  props.statistics.total === 0 ? "-" : props.statistics.averageRating.toFixed(2),
+  props.statistics.total === 0 ? "—" : props.statistics.averageRating.toFixed(2),
 );
 
 const formatMonthLabel = (month: string): string => {
@@ -34,19 +34,25 @@ const formatMonthLabel = (month: string): string => {
 
 <template>
   <div class="stats">
-    <section class="summary">
-      <div class="summary-card">
-        <span class="summary-label">総鑑賞数</span>
-        <span class="summary-value">{{ statistics.total }}</span>
-      </div>
-      <div class="summary-card">
-        <span class="summary-label">お気に入り</span>
-        <span class="summary-value">{{ statistics.favoriteCount }}</span>
-      </div>
-      <div class="summary-card">
-        <span class="summary-label">平均評価</span>
-        <span class="summary-value">{{ averageDisplay }}</span>
-      </div>
+    <section class="summary stagger-children">
+      <article class="summary-card">
+        <span class="summary-num smallcaps">N&deg; 01</span>
+        <span class="summary-label smallcaps">Total entries</span>
+        <span class="summary-value numeric">{{ statistics.total }}</span>
+        <span class="summary-meta">記録された鑑賞</span>
+      </article>
+      <article class="summary-card summary-card--accent">
+        <span class="summary-num smallcaps">N&deg; 02</span>
+        <span class="summary-label smallcaps">Favorites</span>
+        <span class="summary-value numeric">{{ statistics.favoriteCount }}</span>
+        <span class="summary-meta">心に残った演奏</span>
+      </article>
+      <article class="summary-card">
+        <span class="summary-num smallcaps">N&deg; 03</span>
+        <span class="summary-label smallcaps">Average rating</span>
+        <span class="summary-value numeric">{{ averageDisplay }}</span>
+        <span class="summary-meta">5 段階評価の平均</span>
+      </article>
     </section>
 
     <EmptyState v-if="statistics.total === 0">
@@ -55,10 +61,14 @@ const formatMonthLabel = (month: string): string => {
 
     <template v-else>
       <section class="panel">
-        <h2 class="panel-title">評価分布</h2>
+        <header class="panel-head">
+          <span class="panel-num">I</span>
+          <h2 class="panel-title">Distribution of ratings</h2>
+          <span class="smallcaps panel-meta">評価分布</span>
+        </header>
         <ul class="bar-list">
           <li v-for="row in ratingRows" :key="row.rating" class="bar-row">
-            <span class="bar-label">★{{ row.rating }}</span>
+            <span class="bar-label numeric">★ {{ row.rating }}</span>
             <div class="bar-track">
               <div
                 class="bar-fill"
@@ -66,33 +76,47 @@ const formatMonthLabel = (month: string): string => {
                 :data-empty="row.count === 0"
               />
             </div>
-            <span class="bar-count">{{ row.count }}</span>
+            <span class="bar-count numeric">{{ row.count }}</span>
           </li>
         </ul>
       </section>
 
       <section class="panel">
-        <h2 class="panel-title">よく聴く作曲家</h2>
+        <header class="panel-head">
+          <span class="panel-num">II</span>
+          <h2 class="panel-title">Most listened composers</h2>
+          <span class="smallcaps panel-meta">よく聴く作曲家</span>
+        </header>
         <ul class="bar-list">
           <li v-for="row in statistics.topComposers" :key="row.composer" class="bar-row">
             <span class="bar-label bar-label-name">{{ row.composer }}</span>
             <div class="bar-track">
-              <div class="bar-fill" :style="{ width: `${(row.count / composerMax) * 100}%` }" />
+              <div
+                class="bar-fill bar-fill--accent"
+                :style="{ width: `${(row.count / composerMax) * 100}%` }"
+              />
             </div>
-            <span class="bar-count">{{ row.count }}</span>
+            <span class="bar-count numeric">{{ row.count }}</span>
           </li>
         </ul>
       </section>
 
       <section class="panel">
-        <h2 class="panel-title">月別の鑑賞数（直近 12 ヶ月）</h2>
+        <header class="panel-head">
+          <span class="panel-num">III</span>
+          <h2 class="panel-title">Monthly trend</h2>
+          <span class="smallcaps panel-meta">直近 12 ヶ月の鑑賞数</span>
+        </header>
         <ul class="bar-list">
           <li v-for="row in statistics.monthlyTrend" :key="row.month" class="bar-row">
-            <span class="bar-label">{{ formatMonthLabel(row.month) }}</span>
+            <span class="bar-label numeric">{{ formatMonthLabel(row.month) }}</span>
             <div class="bar-track">
-              <div class="bar-fill" :style="{ width: `${(row.count / monthlyMax) * 100}%` }" />
+              <div
+                class="bar-fill bar-fill--bordeaux"
+                :style="{ width: `${(row.count / monthlyMax) * 100}%` }"
+              />
             </div>
-            <span class="bar-count">{{ row.count }}</span>
+            <span class="bar-count numeric">{{ row.count }}</span>
           </li>
         </ul>
       </section>
@@ -104,73 +128,137 @@ const formatMonthLabel = (month: string): string => {
 .stats {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 3rem;
 }
 
+/* ── Summary cards ── */
 .summary {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1rem;
+  gap: 0;
+  border: 1px solid var(--color-hairline-strong);
+  background: var(--color-hairline);
 }
 
-@media (max-width: 600px) {
+@media (max-width: 760px) {
   .summary {
     grid-template-columns: 1fr;
   }
 }
 
 .summary-card {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 10px;
-  padding: 1rem 1.25rem;
+  background: var(--color-bg-paper);
+  padding: 1.8rem 1.5rem 1.6rem;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
+  gap: 0.4rem;
+  position: relative;
+}
+
+.summary-card--accent {
+  background: var(--color-bg-elevated);
+}
+
+.summary-num {
+  color: var(--color-bordeaux);
+  font-weight: 700;
+}
+:root.dark .summary-num {
+  color: var(--color-accent);
 }
 
 .summary-label {
-  font-size: 0.85rem;
   color: var(--color-text-muted);
 }
 
 .summary-value {
-  font-size: 1.8rem;
-  font-weight: bold;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(3rem, 8vw, 5rem);
+  line-height: 0.95;
   color: var(--color-text);
+  margin: 0.4rem 0 0;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30,
+    "WONK" 1;
 }
 
+.summary-card--accent .summary-value {
+  color: var(--color-accent);
+}
+
+.summary-meta {
+  font-family: var(--font-serif);
+  font-style: italic;
+  color: var(--color-text-faint);
+  font-size: 0.85rem;
+  margin-top: 0.2rem;
+}
+
+/* ── Panel ── */
 .panel {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 10px;
-  padding: 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.panel-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+}
+
+.panel-num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.4rem;
+  color: var(--color-accent);
 }
 
 .panel-title {
-  font-size: 1.1rem;
-  margin-bottom: 1rem;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
+  flex: 1;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
+.panel-meta {
+  color: var(--color-text-muted);
+}
+
+/* ── Bar charts ── */
 .bar-list {
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: 0.6rem;
+  gap: 0.85rem;
+  padding: 0;
+  margin: 0;
 }
 
 .bar-row {
   display: grid;
-  grid-template-columns: 80px 1fr 40px;
+  grid-template-columns: 110px 1fr 50px;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
   font-size: 0.9rem;
 }
 
 .bar-label {
   color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
 }
 
 .bar-label-name {
@@ -178,28 +266,69 @@ const formatMonthLabel = (month: string): string => {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1rem;
+  text-transform: none;
+  letter-spacing: 0;
 }
 
 .bar-track {
-  background: var(--color-bg-input);
-  border-radius: 4px;
-  height: 14px;
+  height: 4px;
+  background: var(--color-hairline);
+  position: relative;
   overflow: hidden;
 }
 
 .bar-fill {
-  background: var(--color-primary);
+  background: var(--color-bg-ink);
   height: 100%;
-  transition: width 0.3s ease;
+  transition: width 0.6s cubic-bezier(0.2, 0.6, 0.2, 1);
+  position: relative;
+}
+
+.bar-fill::after {
+  content: "";
+  position: absolute;
+  right: -3px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 6px;
+  height: 6px;
+  background: var(--color-accent);
+  border-radius: 50%;
+}
+
+.bar-fill--accent {
+  background: var(--color-accent);
+}
+.bar-fill--accent::after {
+  background: var(--color-bg-ink);
+}
+:root.dark .bar-fill--accent::after {
+  background: var(--color-text);
+}
+
+.bar-fill--bordeaux {
+  background: var(--color-bordeaux);
+}
+.bar-fill--bordeaux::after {
+  background: var(--color-accent);
 }
 
 .bar-fill[data-empty="true"] {
   background: transparent;
 }
+.bar-fill[data-empty="true"]::after {
+  display: none;
+}
 
 .bar-count {
   text-align: right;
   color: var(--color-text);
-  font-variant-numeric: tabular-nums;
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: 1.1rem;
 }
 </style>

--- a/app/components/organisms/LoginForm.test.ts
+++ b/app/components/organisms/LoginForm.test.ts
@@ -33,11 +33,11 @@ describe("LoginForm", () => {
       expect(wrapper.find("button[type='submit']").text()).toBe("ログイン");
     });
 
-    it("isLoading=true のとき「ログイン中...」ボタンが表示される", async () => {
+    it("isLoading=true のとき「Signing in…」ボタンが表示される", async () => {
       const wrapper = await mountSuspended(LoginForm, {
         props: { isLoading: true, errors: defaultErrors },
       });
-      expect(wrapper.find("button[type='submit']").text()).toBe("ログイン中...");
+      expect(wrapper.find("button[type='submit']").text()).toBe("Signing in…");
     });
 
     it("isLoading=true のとき送信ボタンが disabled になる", async () => {

--- a/app/components/organisms/LoginForm.vue
+++ b/app/components/organisms/LoginForm.vue
@@ -54,22 +54,23 @@ function handleSubmit() {
       <ErrorMessage v-if="props.errors.general" :message="props.errors.general" :center="true" />
 
       <ButtonPrimary type="submit" :disabled="props.isLoading">
-        {{ props.isLoading ? "ログイン中..." : "ログイン" }}
+        {{ props.isLoading ? "Signing in…" : "ログイン" }}
       </ButtonPrimary>
     </form>
 
     <div class="divider">
-      <span>または</span>
+      <span class="smallcaps">Or</span>
     </div>
 
     <button type="button" class="btn-google-login" @click="emit('googleLogin')">
-      Google でログイン
+      <span class="g-mark" aria-hidden="true">G</span>
+      <span class="g-label">Google でログイン</span>
     </button>
 
     <div class="register-link">
       <p>
         アカウントをお持ちでない方は
-        <NuxtLink to="/auth/user-register">新規登録</NuxtLink>
+        <NuxtLink to="/auth/user-register">新規登録 &rarr;</NuxtLink>
       </p>
     </div>
   </AuthFormContainer>
@@ -82,10 +83,73 @@ form {
   gap: 1.5rem;
 }
 
+.divider {
+  display: flex;
+  align-items: center;
+  text-align: center;
+  color: var(--color-text-muted);
+  gap: 0.8rem;
+  margin: 1.5rem 0 1.2rem;
+}
+
+.divider::before,
+.divider::after {
+  content: "";
+  flex: 1;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.btn-google-login {
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.7rem;
+  padding: 0.8rem 1rem;
+  border: 1px solid var(--color-hairline-strong);
+  background-color: transparent;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background-color 0.25s ease,
+    border-color 0.25s ease;
+}
+
+.btn-google-login:hover {
+  background-color: var(--color-bg-elevated);
+  border-color: var(--color-accent);
+}
+
+.g-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--color-accent);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--color-accent);
+  letter-spacing: 0;
+}
+
+.g-label {
+  font-weight: 600;
+}
+
 .register-link {
   text-align: center;
-  margin-top: 1rem;
-  color: #7a5c38;
+  margin-top: 1.4rem;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
 }
 
 .register-link p {
@@ -96,67 +160,15 @@ form {
 
 .register-link a {
   display: inline-block;
-  color: var(--color-primary-soft);
+  color: var(--color-accent);
   text-decoration: none;
   white-space: nowrap;
+  font-weight: 500;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.25s ease;
 }
 
 .register-link a:hover {
-  text-decoration: underline;
-}
-
-.divider {
-  display: flex;
-  align-items: center;
-  text-align: center;
-  color: #7a5c38;
-  gap: 0.75rem;
-  margin: 1.25rem 0;
-  font-size: 0.85rem;
-}
-
-.divider::before,
-.divider::after {
-  content: "";
-  flex: 1;
-  border-bottom: 1px solid #d4c5b0;
-}
-
-.btn-google-login {
-  width: 100%;
-  padding: 0.75rem 1rem;
-  border: 1px solid #d4c5b0;
-  border-radius: 4px;
-  background-color: var(--color-bg-surface);
-  color: var(--color-primary-soft);
-  font-size: 1rem;
-  cursor: pointer;
-  transition: background-color 0.2s;
-}
-
-.btn-google-login:hover {
-  background-color: var(--color-bg-elevated);
-}
-
-:global(.dark .register-link) {
-  color: var(--color-text-secondary);
-}
-
-:global(.dark .register-link a) {
-  color: var(--color-link);
-}
-
-:global(.dark .divider) {
-  color: var(--color-text-muted);
-}
-
-:global(.dark .divider::before),
-:global(.dark .divider::after) {
-  border-bottom-color: var(--color-border-strong);
-}
-
-:global(.dark .btn-google-login) {
-  border-color: var(--color-border-strong);
-  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
 }
 </style>

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -25,7 +25,7 @@ const router = useRouter();
       >楽曲が登録されていません。最初の楽曲を追加しましょう。</EmptyState
     >
 
-    <ul v-else class="piece-list">
+    <ul v-else class="piece-list stagger-children">
       <li v-for="piece in pieces" :key="piece.id">
         <PieceItem
           :piece="piece"
@@ -43,14 +43,9 @@ const router = useRouter();
 <style scoped>
 .piece-list {
   list-style: none;
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 1rem;
-}
-
-@media (min-width: 1024px) {
-  .piece-list {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline);
 }
 </style>

--- a/app/components/organisms/QuickLogForm.vue
+++ b/app/components/organisms/QuickLogForm.vue
@@ -29,63 +29,88 @@ function handleSubmit() {
 
 <template>
   <form class="quick-log-form" @submit.prevent="handleSubmit">
-    <div class="piece-info">
-      <span class="piece-info-label">作曲家</span>
-      <span class="piece-info-value">{{ composer }}</span>
-    </div>
-    <div class="piece-info">
-      <span class="piece-info-label">曲名</span>
-      <span class="piece-info-value">{{ piece }}</span>
-    </div>
+    <dl class="piece-info-grid">
+      <div class="piece-info-row">
+        <dt class="smallcaps">Composer</dt>
+        <dd class="piece-info-value">{{ composer }}</dd>
+      </div>
+      <div class="piece-info-row">
+        <dt class="smallcaps">Piece</dt>
+        <dd class="piece-info-value">{{ piece }}</dd>
+      </div>
+    </dl>
 
-    <FormGroup label="評価">
+    <FormGroup label="Rating">
       <RatingSelector v-model="rating" />
     </FormGroup>
 
     <div class="form-group">
       <label class="checkbox-label" for="is-favorite">
         <input id="is-favorite" v-model="isFavorite" type="checkbox" />
-        お気に入り
+        <span class="checkbox-text">Mark as favorite</span>
       </label>
     </div>
 
-    <FormGroup label="感想・メモ" input-id="memo">
-      <textarea id="memo" v-model="memo" rows="4" placeholder="自由に感想を書いてください..." />
+    <FormGroup label="Notes" input-id="memo">
+      <textarea id="memo" v-model="memo" rows="4" placeholder="自由に感想を書いてください…" />
     </FormGroup>
 
-    <div v-if="saved" class="success-message">保存しました！</div>
+    <div v-if="saved" class="success-message">
+      <span aria-hidden="true">&check;</span> 保存しました
+    </div>
 
-    <ButtonPrimary type="submit">記録する</ButtonPrimary>
+    <div class="form-action">
+      <ButtonPrimary type="submit">記録する</ButtonPrimary>
+    </div>
   </form>
 </template>
 
 <style scoped>
 .quick-log-form {
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 12px;
-  padding: 2rem;
+  background: var(--color-bg-paper);
+  border: 1px solid var(--color-hairline);
+  padding: clamp(1.5rem, 3vw, 2.4rem);
   display: flex;
   flex-direction: column;
-  gap: 1.2rem;
+  gap: 1.4rem;
+  position: relative;
 }
 
-.piece-info {
+.quick-log-form::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 4px;
+  height: 100%;
+  background: var(--color-accent);
+  opacity: 0.6;
+}
+
+.piece-info-grid {
   display: flex;
-  gap: 0.8rem;
-  align-items: baseline;
+  flex-direction: column;
+  gap: 0.6rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-hairline);
 }
 
-.piece-info-label {
-  font-size: 0.85rem;
+.piece-info-row {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.piece-info-row dt {
+  min-width: 6rem;
   color: var(--color-text-muted);
-  min-width: 4rem;
 }
 
 .piece-info-value {
-  font-size: 1rem;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.05rem;
   color: var(--color-text);
-  font-weight: bold;
 }
 
 .form-group {
@@ -95,31 +120,63 @@ function handleSubmit() {
 }
 
 .checkbox-label {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  font-weight: normal;
+  gap: 0.6rem;
+  font-family: var(--font-sans);
+  font-size: 0.9rem;
+  color: var(--color-text);
   cursor: pointer;
 }
 
+.checkbox-label input[type="checkbox"] {
+  accent-color: var(--color-accent);
+  width: 1.05rem;
+  height: 1.05rem;
+}
+
+.checkbox-text {
+  letter-spacing: 0.02em;
+}
+
 textarea {
-  border: 1px solid var(--color-secondary);
-  border-radius: 6px;
-  padding: 0.6rem 0.8rem;
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.6rem 0.1rem;
   font-size: 0.95rem;
-  font-family: inherit;
-  background: var(--color-bg-input);
-  transition: border-color 0.2s;
+  font-family: var(--font-serif);
+  background: transparent;
+  color: var(--color-text);
+  transition: border-color 0.25s ease;
+  resize: vertical;
+}
+
+textarea::placeholder {
+  font-style: italic;
+  color: var(--color-text-faint);
 }
 
 textarea:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
 }
 
 .success-message {
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-wide);
+  text-transform: uppercase;
   color: var(--color-success);
-  font-size: 0.95rem;
-  font-weight: bold;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.form-action {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 0.5rem;
 }
 </style>

--- a/app/components/organisms/UserRegisterForm.test.ts
+++ b/app/components/organisms/UserRegisterForm.test.ts
@@ -33,11 +33,11 @@ describe("UserRegisterForm", () => {
       expect(wrapper.find("button[type='submit']").text()).toBe("登録");
     });
 
-    it("isLoading=true のとき「登録中...」ボタンが表示される", async () => {
+    it("isLoading=true のとき「Registering…」ボタンが表示される", async () => {
       const wrapper = await mountSuspended(UserRegisterForm, {
         props: { isLoading: true, errors: defaultErrors, successMessage: "" },
       });
-      expect(wrapper.find("button[type='submit']").text()).toBe("登録中...");
+      expect(wrapper.find("button[type='submit']").text()).toBe("Registering…");
     });
 
     it("successMessage が設定されているとき表示される", async () => {

--- a/app/components/organisms/UserRegisterForm.vue
+++ b/app/components/organisms/UserRegisterForm.vue
@@ -50,24 +50,25 @@ function handleSubmit() {
           required
         />
         <p class="password-requirements">
-          パスワードは8文字以上で、大文字・小文字・数字を含む必要があります
+          <em>—</em>
+          パスワードは 8 文字以上で、大文字・小文字・数字を含む必要があります
         </p>
       </FormGroup>
 
       <ButtonPrimary type="submit" :disabled="props.isLoading">
-        {{ props.isLoading ? "登録中..." : "登録" }}
+        {{ props.isLoading ? "Registering…" : "登録" }}
       </ButtonPrimary>
     </form>
 
     <div v-if="props.successMessage" class="success-message">
       <p>{{ props.successMessage }}</p>
-      <NuxtLink to="/auth/login">ログイン画面へ</NuxtLink>
+      <NuxtLink to="/auth/login">ログイン画面へ &rarr;</NuxtLink>
     </div>
 
     <div class="login-link">
       <p>
         既にアカウントをお持ちですか？
-        <NuxtLink to="/auth/login">ログイン</NuxtLink>
+        <NuxtLink to="/auth/login">ログイン &rarr;</NuxtLink>
       </p>
     </div>
   </AuthFormContainer>
@@ -81,30 +82,62 @@ form {
 }
 
 .password-requirements {
-  color: #7a5c38;
-  font-size: 0.875rem;
-  margin: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.85rem;
+  margin: 0.25rem 0 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+}
+
+.password-requirements em {
+  color: var(--color-accent);
+  font-style: italic;
+  font-family: var(--font-display);
 }
 
 .success-message {
-  background-color: #d8e8c0;
-  color: #2a5218;
-  padding: 1rem;
-  border-radius: 4px;
-  text-align: center;
+  background: transparent;
+  border: 1px solid var(--color-accent);
+  border-left: 3px solid var(--color-accent);
+  color: var(--color-text);
+  padding: 1rem 1.2rem;
+  text-align: left;
+  font-family: var(--font-serif);
+  margin-top: 1rem;
+}
+
+.success-message p {
+  font-style: italic;
+  margin: 0 0 0.4rem;
 }
 
 .success-message a {
   display: inline-block;
-  margin-top: 0.5rem;
-  color: #2a5218;
-  text-decoration: underline;
+  color: var(--color-accent);
+  text-decoration: none;
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.25s ease;
+}
+
+.success-message a:hover {
+  border-bottom-color: var(--color-accent);
 }
 
 .login-link {
   text-align: center;
-  margin-top: 1rem;
-  color: #7a5c38;
+  margin-top: 1.4rem;
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
 }
 
 .login-link p {
@@ -115,33 +148,15 @@ form {
 
 .login-link a {
   display: inline-block;
-  color: var(--color-primary-soft);
+  color: var(--color-accent);
   text-decoration: none;
   white-space: nowrap;
+  font-weight: 500;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.25s ease;
 }
 
 .login-link a:hover {
-  text-decoration: underline;
-}
-
-:global(.dark .password-requirements) {
-  color: #c8a878;
-}
-
-:global(.dark .success-message) {
-  background-color: #2a5218;
-  color: #d8e8c0;
-}
-
-:global(.dark .success-message a) {
-  color: #d8e8c0;
-}
-
-:global(.dark .login-link) {
-  color: var(--color-text-secondary);
-}
-
-:global(.dark .login-link a) {
-  color: var(--color-link);
+  border-bottom-color: var(--color-accent);
 }
 </style>

--- a/app/components/organisms/VerifyEmailForm.test.ts
+++ b/app/components/organisms/VerifyEmailForm.test.ts
@@ -33,7 +33,7 @@ describe("VerifyEmailForm", () => {
     it("「再送信」ボタンが表示される", async () => {
       const wrapper = await mountSuspended(VerifyEmailForm, { props: defaultProps });
       const buttons = wrapper.findAll("button");
-      const resendButton = buttons.find((b) => b.text() === "再送信");
+      const resendButton = buttons.find((b) => b.text() === "Resend code");
       expect(resendButton).toBeDefined();
     });
 
@@ -78,7 +78,7 @@ describe("VerifyEmailForm", () => {
     it("「再送信」ボタンを押すと resend イベントが発火する", async () => {
       const wrapper = await mountSuspended(VerifyEmailForm, { props: defaultProps });
       const buttons = wrapper.findAll("button");
-      const resendButton = buttons.find((b) => b.text() === "再送信");
+      const resendButton = buttons.find((b) => b.text() === "Resend code");
       await resendButton?.trigger("click");
       expect(wrapper.emitted("resend")).toBeDefined();
     });

--- a/app/components/organisms/VerifyEmailForm.vue
+++ b/app/components/organisms/VerifyEmailForm.vue
@@ -31,34 +31,39 @@ function handleResend() {
 <template>
   <AuthFormContainer title="メールアドレス確認">
     <p class="description">
-      <strong>{{ props.email }}</strong> に送信された認証コードを入力してください。
+      <strong class="description-email">{{ props.email }}</strong>
+      <br />
+      に送信された認証コードを入力してください。
     </p>
 
     <form @submit.prevent="handleSubmit">
-      <div class="form-group">
-        <label for="code">認証コード</label>
+      <FormGroup label="認証コード" input-id="code" required>
         <input
           id="code"
           v-model="code"
           type="text"
-          placeholder="例: 123456"
+          class="code-input"
+          placeholder="123456"
           autocomplete="one-time-code"
           required
         />
         <ErrorMessage v-if="props.error" :message="props.error" data-testid="error-message" />
-      </div>
+      </FormGroup>
 
-      <p v-if="props.infoMessage" class="info-message">{{ props.infoMessage }}</p>
+      <p v-if="props.infoMessage" class="info-message">
+        <span class="info-mark smallcaps">Sent</span>
+        {{ props.infoMessage }}
+      </p>
 
       <ButtonPrimary type="submit" :disabled="props.isLoading">
-        {{ props.isLoading ? "確認中..." : "確認する" }}
+        {{ props.isLoading ? "Verifying…" : "確認する" }}
       </ButtonPrimary>
     </form>
 
     <div class="resend-section">
       <p>コードが届きませんか？</p>
       <button type="button" class="resend-button" :disabled="props.isLoading" @click="handleResend">
-        再送信
+        <span class="smallcaps">Resend code</span>
       </button>
     </div>
   </AuthFormContainer>
@@ -67,9 +72,20 @@ function handleResend() {
 <style scoped>
 .description {
   text-align: center;
-  color: #7a5c38;
+  color: var(--color-text-muted);
   margin-bottom: 1.5rem;
+  font-family: var(--font-serif);
+  font-style: italic;
   font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.description-email {
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--color-accent);
+  font-size: 1.05rem;
+  font-weight: 500;
 }
 
 form {
@@ -78,85 +94,81 @@ form {
   gap: 1.5rem;
 }
 
-.form-group {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-}
-
-label {
-  font-weight: 500;
+.code-input {
+  border: none;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  border-radius: 0;
+  padding: 0.7rem 0.1rem;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.6rem;
+  letter-spacing: 0.4em;
+  background: transparent;
   color: var(--color-text);
+  width: 100%;
+  box-sizing: border-box;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+  transition: border-color 0.25s ease;
 }
 
-input[type="text"] {
-  padding: 0.75rem;
-  border: 1px solid var(--color-secondary);
-  border-radius: 4px;
-  font-size: 1rem;
-  background: var(--color-bg-input);
-  transition: border-color 0.2s;
+.code-input::placeholder {
+  color: var(--color-text-faint);
+  font-style: italic;
 }
 
-input[type="text"]:focus {
+.code-input:focus {
   outline: none;
-  border-color: var(--color-primary);
+  border-bottom-color: var(--color-accent);
 }
 
 .info-message {
-  color: #2a5218;
-  background-color: #d8e8c0;
-  padding: 0.75rem;
-  border-radius: 4px;
+  border-left: 3px solid var(--color-accent);
+  padding: 0.6rem 0.8rem;
+  font-family: var(--font-serif);
+  font-style: italic;
   font-size: 0.9rem;
+  color: var(--color-text-secondary);
   margin: 0;
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+.info-mark {
+  color: var(--color-accent);
+  font-style: normal;
 }
 
 .resend-section {
   text-align: center;
-  margin-top: 1.5rem;
-  color: #7a5c38;
+  margin-top: 1.4rem;
+  color: var(--color-text-muted);
 }
 
 .resend-section p {
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.6rem;
+  font-family: var(--font-serif);
+  font-style: italic;
   font-size: 0.9rem;
 }
 
 .resend-button {
   background: none;
   border: none;
-  color: var(--color-primary-soft);
-  font-size: 0.9rem;
-  text-decoration: underline;
+  color: var(--color-accent);
   cursor: pointer;
-  padding: 0;
+  padding: 0.3rem 0;
+  border-bottom: 1px solid transparent;
+  transition: border-color 0.25s ease;
 }
 
 .resend-button:hover:not(:disabled) {
-  color: var(--color-text);
+  border-bottom-color: var(--color-accent);
 }
 
 .resend-button:disabled {
-  color: #a89070;
+  color: var(--color-text-disabled);
   cursor: not-allowed;
-  text-decoration: none;
-}
-
-:global(.dark .description) {
-  color: #c8a878;
-}
-
-:global(.dark .info-message) {
-  color: #d8e8c0;
-  background-color: #2a5218;
-}
-
-:global(.dark .resend-section) {
-  color: #c8a878;
-}
-
-:global(.dark .resend-button:disabled) {
-  color: #6e5435;
 }
 </style>

--- a/app/components/templates/ComposerDetailTemplate.test.ts
+++ b/app/components/templates/ComposerDetailTemplate.test.ts
@@ -23,23 +23,23 @@ describe("ComposerDetailTemplate", () => {
     const wrapper = await mountSuspended(ComposerDetailTemplate, {
       props: { composer: sample, error: null, isAdmin: true },
     });
-    expect(wrapper.find(".btn-secondary").exists()).toBe(true);
-    expect(wrapper.find(".btn-danger").exists()).toBe(true);
+    expect(wrapper.find("a.admin-link").exists()).toBe(true);
+    expect(wrapper.find(".admin-link--danger").exists()).toBe(true);
   });
 
   it("非管理者の場合、編集・削除ボタンが表示されない", async () => {
     const wrapper = await mountSuspended(ComposerDetailTemplate, {
       props: { composer: sample, error: null, isAdmin: false },
     });
-    expect(wrapper.find(".btn-secondary").exists()).toBe(false);
-    expect(wrapper.find(".btn-danger").exists()).toBe(false);
+    expect(wrapper.find("a.admin-link").exists()).toBe(false);
+    expect(wrapper.find(".admin-link--danger").exists()).toBe(false);
   });
 
   it("削除ボタンクリックで delete イベントが emit される", async () => {
     const wrapper = await mountSuspended(ComposerDetailTemplate, {
       props: { composer: sample, error: null, isAdmin: true },
     });
-    await wrapper.find(".btn-danger").trigger("click");
+    await wrapper.find(".admin-link--danger").trigger("click");
     expect(wrapper.emitted("delete")).toBeDefined();
   });
 

--- a/app/components/templates/ComposerDetailTemplate.vue
+++ b/app/components/templates/ComposerDetailTemplate.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Composer } from "~/types";
 
-defineProps<{
+const props = defineProps<{
   composer: Composer | null;
   error: Error | null;
   isAdmin: boolean;
@@ -10,11 +10,19 @@ defineProps<{
 const emit = defineEmits<{
   delete: [composer: Composer];
 }>();
+
+const shortId = computed(() => {
+  if (props.composer === null) return "";
+  return props.composer.id.slice(0, 6).toUpperCase();
+});
 </script>
 
 <template>
-  <div>
-    <NuxtLink to="/composers" class="back-link">← 作曲家一覧</NuxtLink>
+  <article class="composer-detail">
+    <NuxtLink to="/composers" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to composers</span>
+    </NuxtLink>
 
     <ErrorMessage
       v-if="error"
@@ -23,108 +31,223 @@ const emit = defineEmits<{
     />
 
     <template v-else-if="composer">
-      <div class="composer-header">
-        <img
-          v-if="composer.imageUrl"
-          :src="composer.imageUrl"
-          :alt="composer.name"
-          class="composer-image"
-          loading="lazy"
-          referrerpolicy="no-referrer"
-        />
-        <div class="composer-name">{{ composer.name }}</div>
-        <div class="composer-category-wrapper">
-          <ComposerCategoryList :composer="composer" />
-        </div>
-        <div v-if="isAdmin" class="admin-actions">
-          <NuxtLink :to="`/composers/${composer.id}/edit`" class="btn-secondary">編集</NuxtLink>
-          <button class="btn-danger" @click="emit('delete', composer)">削除</button>
-        </div>
+      <div class="composer-grid">
+        <aside v-if="composer.imageUrl" class="composer-portrait">
+          <figure class="portrait-frame">
+            <img
+              :src="composer.imageUrl"
+              :alt="composer.name"
+              class="composer-image"
+              loading="lazy"
+              referrerpolicy="no-referrer"
+            />
+            <figcaption class="portrait-caption smallcaps">Portrait</figcaption>
+          </figure>
+        </aside>
+
+        <header class="composer-masthead">
+          <div class="composer-meta">
+            <span class="meta-tag smallcaps">III / Composers</span>
+            <span class="meta-rule" aria-hidden="true" />
+            <span class="meta-id smallcaps numeric">N&deg; {{ shortId }}</span>
+          </div>
+
+          <h1 class="composer-name">{{ composer.name }}</h1>
+
+          <div class="composer-category-wrapper">
+            <ComposerCategoryList :composer="composer" />
+          </div>
+
+          <div v-if="isAdmin" class="admin-actions">
+            <NuxtLink :to="`/composers/${composer.id}/edit`" class="admin-link">
+              <span class="smallcaps">Edit</span>
+            </NuxtLink>
+            <span class="admin-sep" aria-hidden="true">/</span>
+            <button class="admin-link admin-link--danger" @click="emit('delete', composer)">
+              <span class="smallcaps">Delete</span>
+            </button>
+          </div>
+        </header>
       </div>
     </template>
-  </div>
+  </article>
 </template>
 
 <style scoped>
+.composer-detail {
+  margin-bottom: 4rem;
+}
+
 .back-link {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.9rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .back-link:hover {
-  color: var(--color-text-secondary);
+  color: var(--color-accent);
+  gap: 0.65rem;
 }
 
-.composer-header {
-  margin-bottom: 1.5rem;
+.composer-grid {
+  display: grid;
+  grid-template-columns: minmax(220px, 280px) 1fr;
+  gap: 3rem;
+  align-items: start;
+}
+
+.composer-grid:has(.composer-masthead:only-child) {
+  grid-template-columns: 1fr;
+}
+
+.composer-portrait {
+  position: sticky;
+  top: 2rem;
+}
+
+.portrait-frame {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
 }
 
 .composer-image {
-  max-width: 240px;
-  max-height: 320px;
-  width: auto;
-  height: auto;
-  object-fit: contain;
-  border-radius: 6px;
-  margin-bottom: 1rem;
+  width: 100%;
+  max-height: 380px;
+  object-fit: cover;
+  border: 1px solid var(--color-hairline-strong);
   background: var(--color-bg-elevated);
+  filter: grayscale(0.15) sepia(0.05);
+  transition: filter 0.5s ease;
+}
+
+.composer-image:hover {
+  filter: none;
+}
+
+.portrait-caption {
+  color: var(--color-text-faint);
+  text-align: center;
+}
+
+.composer-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+}
+
+.composer-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-id {
+  color: var(--color-text-muted);
 }
 
 .composer-name {
-  font-size: 1.5rem;
-  font-weight: bold;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(2.4rem, 6vw, 4.6rem);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
-  margin-bottom: 0.3rem;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60,
+    "WONK" 1;
 }
 
 .composer-category-wrapper {
-  margin-top: 0.5rem;
+  margin-top: 0.4rem;
 }
 
 .admin-actions {
   display: flex;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 0.9rem;
   margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--color-hairline);
 }
 
-.btn-secondary {
-  display: inline-block;
-  padding: 0.4rem 1rem;
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-primary);
-  color: var(--color-primary);
-  border-radius: 4px;
-  font-size: 0.9rem;
+.admin-link {
+  background: transparent;
+  border: none;
+  padding: 0.3rem 0;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  position: relative;
   text-decoration: none;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+  transition: color 0.25s ease;
 }
 
-.btn-secondary:hover {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
+.admin-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 1px;
+  background: currentColor;
+  transition: width 0.3s ease;
 }
 
-.btn-danger {
-  padding: 0.4rem 1rem;
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-danger);
-  color: var(--color-danger);
-  border-radius: 4px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+.admin-link:hover {
+  color: var(--color-accent);
 }
 
-.btn-danger:hover {
-  background: var(--color-danger);
-  color: var(--color-on-primary);
+.admin-link:hover::after {
+  width: 100%;
+}
+
+.admin-link--danger:hover {
+  color: var(--color-bordeaux);
+}
+:root.dark .admin-link--danger:hover {
+  color: var(--color-bordeaux);
+}
+
+.admin-sep {
+  color: var(--color-text-faint);
+  font-family: var(--font-display);
+  font-style: italic;
+}
+
+@media (max-width: 760px) {
+  .composer-grid {
+    grid-template-columns: 1fr;
+    gap: 2rem;
+  }
+
+  .composer-portrait {
+    position: relative;
+    top: 0;
+    max-width: 240px;
+  }
 }
 </style>

--- a/app/components/templates/ComposerEditTemplate.vue
+++ b/app/components/templates/ComposerEditTemplate.vue
@@ -13,8 +13,13 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>作曲家を編集</PageTitle>
+  <div class="form-page">
+    <NuxtLink to="/composers" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to composers</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="III / Composers" meta="Edit">作曲家を編集</PageTitle>
 
     <ErrorMessage v-if="fetchError" message="作曲家の取得に失敗しました。" variant="block" />
 
@@ -33,3 +38,26 @@ const emit = defineEmits<{
     </template>
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ComposerNewTemplate.vue
+++ b/app/components/templates/ComposerNewTemplate.vue
@@ -11,11 +11,39 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>作曲家を追加</PageTitle>
+  <div class="form-page">
+    <NuxtLink to="/composers" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to composers</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="III / Composers" meta="New entry">作曲家を追加</PageTitle>
 
     <ErrorMessage v-if="error" :message="error" variant="block" />
 
     <ComposerForm submit-label="登録する" @submit="emit('submit', $event)" />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ComposersTemplate.test.ts
+++ b/app/components/templates/ComposersTemplate.test.ts
@@ -16,10 +16,10 @@ describe("ComposersTemplate", () => {
     expect(wrapper.find("a[href='/composers/new']").exists()).toBe(false);
   });
 
-  it("タイトルが '作曲家マスタ' と表示される", async () => {
+  it("タイトルが '作曲家' と表示される", async () => {
     const wrapper = await mountSuspended(ComposersTemplate, {
       props: { composers: [], error: null, pending: false, hasMore: false, isAdmin: true },
     });
-    expect(wrapper.text()).toContain("作曲家マスタ");
+    expect(wrapper.find("h1.masthead-title").text()).toContain("作曲家");
   });
 });

--- a/app/components/templates/ComposersTemplate.vue
+++ b/app/components/templates/ComposersTemplate.vue
@@ -16,13 +16,36 @@ const emit = defineEmits<{
   loadMore: [];
   retry: [];
 }>();
+
+const composerCount = computed(() => props.composers.length);
 </script>
 
 <template>
-  <div>
-    <PageHeader title="作曲家マスタ" :new-page-path="props.isAdmin ? '/composers/new' : undefined"
-      >+ 新しい作曲家</PageHeader
-    >
+  <div class="composers-page">
+    <header class="composers-masthead">
+      <div class="masthead-meta">
+        <span class="meta-tag smallcaps">III / Composers</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-count smallcaps numeric">
+          {{ composerCount.toString().padStart(3, "0") }}
+          {{ composerCount === 1 ? "name on file" : "names on file" }}
+        </span>
+      </div>
+
+      <h1 class="masthead-title">
+        <span class="title-jp">作曲家</span>
+        <span class="title-en"><em>Composers</em></span>
+      </h1>
+
+      <p class="masthead-lede">
+        <em>Lives written in sound.</em> &mdash; 作曲家を時代と地域で巡る索引。
+      </p>
+
+      <div v-if="props.isAdmin" class="masthead-actions">
+        <ButtonPrimary @click="$router.push('/composers/new')"> + 新しい作曲家 </ButtonPrimary>
+      </div>
+    </header>
+
     <ComposerListInfinite
       :composers="props.composers"
       :error="props.error"
@@ -36,3 +59,93 @@ const emit = defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+.composers-page {
+  margin-bottom: 4rem;
+}
+
+.composers-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.2rem 0 2.6rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2rem;
+}
+
+.masthead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-count {
+  color: var(--color-text-muted);
+}
+
+.masthead-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.masthead-lede {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 38em;
+}
+
+.masthead-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  margin-right: 0.25em;
+}
+:root.dark .masthead-lede em {
+  color: var(--color-accent);
+}
+
+.masthead-actions {
+  margin-top: 0.4rem;
+}
+</style>

--- a/app/components/templates/ConcertLogDetailTemplate.vue
+++ b/app/components/templates/ConcertLogDetailTemplate.vue
@@ -31,41 +31,56 @@ const handleDelete = async () => {
 </script>
 
 <template>
-  <div>
-    <div class="page-header">
-      <NuxtLink to="/concert-logs" class="back-link">← コンサート記録一覧</NuxtLink>
+  <article class="concert-detail">
+    <header class="concert-detail-head">
+      <NuxtLink to="/concert-logs" class="back-link">
+        <span aria-hidden="true">&larr;</span>
+        <span class="smallcaps">Back to concerts</span>
+      </NuxtLink>
       <div class="actions">
         <ButtonSecondary @click="router.push(`/concert-logs/${props.log.id}/edit`)">
-          編集
+          Edit
         </ButtonSecondary>
-        <ButtonDanger @click="handleDelete">削除</ButtonDanger>
+        <ButtonDanger @click="handleDelete">Delete</ButtonDanger>
       </div>
-    </div>
+    </header>
 
     <ConcertLogDetail :log="log" :pieces="pieces ?? []" :composer-name-by-id="composerNameById" />
-  </div>
+  </article>
 </template>
 
 <style scoped>
-.page-header {
+.concert-detail {
+  margin-bottom: 4rem;
+}
+
+.concert-detail-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 .back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.9rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .back-link:hover {
-  color: var(--color-text-secondary);
+  color: var(--color-accent);
+  gap: 0.65rem;
 }
 
 .actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 </style>

--- a/app/components/templates/ConcertLogEditTemplate.vue
+++ b/app/components/templates/ConcertLogEditTemplate.vue
@@ -12,9 +12,15 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>コンサート記録を編集</PageTitle>
-    <ErrorMessage v-if="error" :message="error" />
+  <div class="form-page">
+    <NuxtLink to="/concert-logs" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to concerts</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="IV / Halls" meta="Edit">コンサート記録を編集</PageTitle>
+
+    <ErrorMessage v-if="error" :message="error" variant="block" />
     <ConcertLogForm
       :initial-values="log"
       submit-label="更新する"
@@ -22,3 +28,26 @@ const emit = defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ConcertLogNewTemplate.vue
+++ b/app/components/templates/ConcertLogNewTemplate.vue
@@ -11,9 +11,38 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>コンサート記録を追加</PageTitle>
-    <ErrorMessage v-if="error" :message="error" />
+  <div class="form-page">
+    <NuxtLink to="/concert-logs" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to concerts</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="IV / Halls" meta="New entry">コンサート記録を追加</PageTitle>
+
+    <ErrorMessage v-if="error" :message="error" variant="block" />
     <ConcertLogForm submit-label="記録する" @submit="emit('submit', $event)" />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ConcertLogsTemplate.vue
+++ b/app/components/templates/ConcertLogsTemplate.vue
@@ -1,14 +1,130 @@
 <script setup lang="ts">
 import type { ConcertLog } from "~/types";
 
-defineProps<{
+const props = defineProps<{
   logs: ConcertLog[];
 }>();
+
+const concertCount = computed(() => props.logs.length);
 </script>
 
 <template>
-  <div>
-    <PageHeader title="コンサート記録" new-page-path="/concert-logs/new">+ 新しい記録</PageHeader>
+  <div class="concerts-page">
+    <header class="concerts-masthead">
+      <div class="masthead-meta">
+        <span class="meta-tag smallcaps">IV / Halls</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-count smallcaps numeric">
+          {{ concertCount.toString().padStart(3, "0") }}
+          {{ concertCount === 1 ? "concert remembered" : "concerts remembered" }}
+        </span>
+      </div>
+
+      <h1 class="masthead-title">
+        <span class="title-jp">演奏会</span>
+        <span class="title-en"><em>Concerts</em></span>
+      </h1>
+
+      <p class="masthead-lede">
+        <em>Halls remembered.</em> &mdash; 会場で聴いた音は、いずれ記憶から薄れる。<br />
+        消える前に、書き留める。
+      </p>
+
+      <div class="masthead-actions">
+        <ButtonPrimary @click="$router.push('/concert-logs/new')"> + 新しい記録 </ButtonPrimary>
+      </div>
+    </header>
+
     <ConcertLogList :logs="logs" />
   </div>
 </template>
+
+<style scoped>
+.concerts-page {
+  margin-bottom: 4rem;
+}
+
+.concerts-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.2rem 0 2.6rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2rem;
+}
+
+.masthead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-count {
+  color: var(--color-text-muted);
+}
+
+.masthead-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.masthead-lede {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 38em;
+}
+
+.masthead-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  margin-right: 0.25em;
+}
+:root.dark .masthead-lede em {
+  color: var(--color-accent);
+}
+
+.masthead-actions {
+  margin-top: 0.4rem;
+}
+</style>

--- a/app/components/templates/HomeTemplate.test.ts
+++ b/app/components/templates/HomeTemplate.test.ts
@@ -34,7 +34,7 @@ describe("HomeTemplate", () => {
         props: { pieces: [], loading: false, isAdmin: true },
         global: { stubs },
       });
-      expect(wrapper.find(".admin-section").exists()).toBe(true);
+      expect(wrapper.find(".editorial-desk").exists()).toBe(true);
       expect(wrapper.find('a[href="/pieces/new"]').exists()).toBe(true);
     });
 
@@ -43,7 +43,7 @@ describe("HomeTemplate", () => {
         props: { pieces: [], loading: false, isAdmin: false },
         global: { stubs },
       });
-      expect(wrapper.find(".admin-section").exists()).toBe(false);
+      expect(wrapper.find(".editorial-desk").exists()).toBe(false);
     });
   });
 });

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -12,7 +12,52 @@ defineProps<{
 
 <template>
   <div class="home">
+    <!-- ============================================================
+         I. Editorial — Manifest hero
+         ============================================================ -->
     <section class="hero">
+      <div class="hero-rail" aria-hidden="true">
+        <span class="rail-mark">
+          <span class="rail-no">N&deg;</span>
+          <span class="rail-num">01</span>
+        </span>
+        <span class="rail-line" />
+        <span class="rail-foot">&mdash;</span>
+      </div>
+
+      <div class="hero-grid">
+        <div class="hero-eyebrow">
+          <span class="smallcaps eyebrow-tag">Editorial</span>
+          <span class="eyebrow-rule" aria-hidden="true" />
+          <span class="smallcaps eyebrow-meta">A Field Guide to Listening</span>
+        </div>
+
+        <h1 class="hero-title">
+          <span class="hero-line-1">The art of</span>
+          <span class="hero-line-2">listening,</span>
+          <span class="hero-line-3"><em>kept.</em></span>
+        </h1>
+
+        <p class="hero-lede">
+          一夜の演奏は、再現できない。<br />
+          だからこそ、<em>聴いた瞬間</em>を書き留めておきたい。&mdash;&mdash;
+          <span class="lede-quiet"
+            >Nocturne は、CD・配信・コンサートで出会った音楽を静かに記録するための場所です。</span
+          >
+        </p>
+
+        <div class="hero-cta">
+          <NuxtLink to="/listening-logs" class="cta-primary">
+            <span class="cta-label">鑑賞記録を残す</span>
+            <span class="cta-arrow" aria-hidden="true">&rarr;</span>
+          </NuxtLink>
+          <NuxtLink to="/pieces" class="cta-ghost">
+            <span class="cta-label">楽曲を探す</span>
+          </NuxtLink>
+        </div>
+      </div>
+
+      <!-- 五線譜 + ゴールド音符 -->
       <svg
         class="hero-deco"
         viewBox="0 0 600 320"
@@ -20,21 +65,15 @@ defineProps<{
         aria-hidden="true"
         preserveAspectRatio="xMidYMid slice"
       >
-        <!--
-          五線譜（トレブル譜表）
-          各線の音: 第1線=E4, 第2線=G4, 第3線=B4, 第4線=D5, 第5線=F5
-          各間の音: 第1間=F4, 第2間=A4, 第3間=C5, 第4間=E5
-          1段 = 10px (半音1つ分)
+        <defs>
+          <linearGradient id="goldGrad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stop-color="var(--color-accent)" stop-opacity="0" />
+            <stop offset="50%" stop-color="var(--color-accent)" stop-opacity="0.85" />
+            <stop offset="100%" stop-color="var(--color-accent)" stop-opacity="0" />
+          </linearGradient>
+        </defs>
 
-          ロ短調スケール上行: B4 → C#5 → D5 → E5 → F#5 → G5
-            B4  第3線    y=160
-            C#5 第3間    y=150  (♯)
-            D5  第4線    y=140  } ♫ ビーム付き八分音符
-            E5  第4間    y=130  }
-            F#5 第5線    y=120  (♯)
-            G5  第5線の上 y=110
-        -->
-        <g class="staff-lines" stroke="rgba(255,255,255,0.12)" stroke-width="1.5" fill="none">
+        <g class="staff-lines" stroke="var(--staff-color)" stroke-width="0.8" fill="none">
           <line x1="0" y1="120" x2="600" y2="120" />
           <line x1="0" y1="140" x2="600" y2="140" />
           <line x1="0" y1="160" x2="600" y2="160" />
@@ -42,15 +81,13 @@ defineProps<{
           <line x1="0" y1="200" x2="600" y2="200" />
         </g>
 
-        <!-- note-1: B4（第3線 / 主音）四分音符 符幹↑ -->
-        <g class="note note-1" fill="rgba(255,255,255,0.20)">
+        <!-- 主旋律: B4 → C#5 → D5,E5 → F#5 → G5（ロ短調 上行） -->
+        <g class="note note-1" fill="var(--note-color-strong)">
           <ellipse cx="58" cy="160" rx="13" ry="9" transform="rotate(-20 58 160)" />
           <rect x="70" y="106" width="2.5" height="54" />
         </g>
-
-        <!-- note-2: C#5（第3間）四分音符+♯ 符幹↓ -->
-        <g class="note note-2" fill="rgba(255,255,255,0.24)">
-          <g stroke="rgba(255,255,255,0.24)" stroke-width="1.5" stroke-linecap="round" fill="none">
+        <g class="note note-2" fill="var(--note-color)">
+          <g stroke="var(--note-color)" stroke-width="1.2" stroke-linecap="round" fill="none">
             <line x1="139" y1="143" x2="137" y2="157" />
             <line x1="145" y1="143" x2="143" y2="157" />
             <line x1="135" y1="147" x2="149" y2="145" />
@@ -59,22 +96,20 @@ defineProps<{
           <ellipse cx="163" cy="150" rx="13" ry="9" transform="rotate(-20 163 150)" />
           <rect x="150" y="150" width="2.5" height="62" />
         </g>
-
-        <!-- note-3: D5+E5 ビーム付き八分音符（♫）符幹↓ -->
-        <g class="note note-3" fill="rgba(255,255,255,0.18)">
-          <!-- D5（第4線） -->
+        <g class="note note-3" fill="var(--note-color-soft)">
           <ellipse cx="252" cy="140" rx="13" ry="9" transform="rotate(-20 252 140)" />
           <rect x="239" y="140" width="2.5" height="62" />
-          <!-- E5（第4間） -->
           <ellipse cx="308" cy="130" rx="13" ry="9" transform="rotate(-20 308 130)" />
           <rect x="295" y="130" width="2.5" height="62" />
-          <!-- ビーム: 符幹下端を右上がりで繋ぐ -->
           <path d="M239,202 L297.5,192 L297.5,186 L239,196 Z" />
         </g>
-
-        <!-- note-4: F#5（第5線）四分音符+♯ 符幹↓ -->
-        <g class="note note-4" fill="rgba(255,255,255,0.21)">
-          <g stroke="rgba(255,255,255,0.21)" stroke-width="1.5" stroke-linecap="round" fill="none">
+        <g class="note note-4" fill="var(--note-color-strong)">
+          <g
+            stroke="var(--note-color-strong)"
+            stroke-width="1.2"
+            stroke-linecap="round"
+            fill="none"
+          >
             <line x1="390" y1="113" x2="388" y2="127" />
             <line x1="396" y1="113" x2="394" y2="127" />
             <line x1="386" y1="117" x2="400" y2="115" />
@@ -83,56 +118,101 @@ defineProps<{
           <ellipse cx="414" cy="120" rx="13" ry="9" transform="rotate(-20 414 120)" />
           <rect x="401" y="120" width="2.5" height="62" />
         </g>
-
-        <!-- note-5: G5（第5線の上の間）四分音符 符幹↓ -->
-        <g class="note note-5" fill="rgba(255,255,255,0.14)">
+        <g class="note note-5" fill="var(--note-color-soft)">
           <ellipse cx="508" cy="110" rx="13" ry="9" transform="rotate(-20 508 110)" />
           <rect x="495" y="110" width="2.5" height="62" />
         </g>
       </svg>
 
-      <div class="hero-content">
-        <h1 class="hero-title">Nocturne</h1>
-        <p class="hero-sub">鑑賞した音楽を、静かに記録する。</p>
-        <div class="hero-cta">
-          <NuxtLink to="/listening-logs" class="cta-primary">鑑賞記録を残す</NuxtLink>
-          <NuxtLink to="/pieces" class="cta-ghost">楽曲を探す →</NuxtLink>
-        </div>
+      <!-- 装飾的な数字: 大きな I -->
+      <span class="hero-bignum" aria-hidden="true">I</span>
+    </section>
+
+    <!-- ============================================================
+         II. Featured — Today's piece
+         ============================================================ -->
+    <section class="featured-section">
+      <header class="section-head">
+        <span class="section-num">II</span>
+        <span class="section-rule" aria-hidden="true" />
+        <h2 class="section-title">Tonight&rsquo;s Selection</h2>
+        <span class="section-meta smallcaps">今日の一曲</span>
+      </header>
+
+      <div class="featured-stage">
+        <FeaturedPiece
+          :pieces="pieces"
+          :loading="loading"
+          :composer-name-by-id="composerNameById"
+        />
       </div>
     </section>
 
-    <section class="featured-section">
-      <FeaturedPiece :pieces="pieces" :loading="loading" :composer-name-by-id="composerNameById" />
-    </section>
+    <!-- ============================================================
+         III. Departments — three columns
+         ============================================================ -->
+    <section class="departments">
+      <header class="section-head">
+        <span class="section-num">III</span>
+        <span class="section-rule" aria-hidden="true" />
+        <h2 class="section-title">Departments</h2>
+        <span class="section-meta smallcaps">部門</span>
+      </header>
 
-    <section class="menu-cards">
-      <NuxtLink to="/listening-logs" class="card">
-        <span class="card-icon">🎼</span>
-        <h2>鑑賞記録</h2>
-        <p>CD・配信・YouTubeなどで聴いた演奏を記録する</p>
-      </NuxtLink>
-      <NuxtLink to="/pieces" class="card">
-        <span class="card-icon">🎵</span>
-        <h2>楽曲を探す</h2>
-        <p>登録された楽曲一覧を探索する</p>
-      </NuxtLink>
-      <NuxtLink to="/concert-logs" class="card">
-        <span class="card-icon">🎹</span>
-        <h2>コンサート記録</h2>
-        <p>実際に聴いたコンサートの記録を残す</p>
-      </NuxtLink>
-    </section>
-
-    <section v-if="isAdmin" class="admin-section">
-      <h2 class="admin-section-title">管理者メニュー</h2>
-      <div class="admin-cards">
-        <NuxtLink to="/pieces/new" class="admin-card">
-          <h3>楽曲マスタ追加</h3>
-          <p>新しい楽曲を登録する</p>
+      <div class="dept-grid stagger-children">
+        <NuxtLink to="/listening-logs" class="dept-card">
+          <span class="dept-num smallcaps">01 / Logs</span>
+          <h3 class="dept-title">鑑賞記録</h3>
+          <p class="dept-lead">
+            <em>Recordings</em> — CD・配信・YouTube などで聴いた演奏の所感を、<br class="dept-br" />
+            手稿のように書き留める。
+          </p>
+          <span class="dept-cta smallcaps">Enter &nbsp;&rarr;</span>
         </NuxtLink>
-        <NuxtLink to="/composers/new" class="admin-card">
-          <h3>作曲家マスタ追加</h3>
-          <p>新しい作曲家を登録する</p>
+
+        <NuxtLink to="/pieces" class="dept-card dept-card--feature">
+          <span class="dept-num smallcaps">02 / Pieces</span>
+          <h3 class="dept-title">楽曲</h3>
+          <p class="dept-lead">
+            <em>Repertoire</em> — 交響曲、協奏曲、室内楽。<br class="dept-br" />
+            登録された楽曲群を時代と編成で巡る。
+          </p>
+          <span class="dept-cta smallcaps">Enter &nbsp;&rarr;</span>
+        </NuxtLink>
+
+        <NuxtLink to="/concert-logs" class="dept-card">
+          <span class="dept-num smallcaps">03 / Halls</span>
+          <h3 class="dept-title">演奏会</h3>
+          <p class="dept-lead">
+            <em>Concerts</em> — 会場で聴いた音は、いずれ記憶から薄れる。<br class="dept-br" />
+            消える前に、書き留める。
+          </p>
+          <span class="dept-cta smallcaps">Enter &nbsp;&rarr;</span>
+        </NuxtLink>
+      </div>
+    </section>
+
+    <!-- ============================================================
+         IV. Editorial desk (Admin)
+         ============================================================ -->
+    <section v-if="isAdmin" class="editorial-desk">
+      <header class="section-head">
+        <span class="section-num">IV</span>
+        <span class="section-rule" aria-hidden="true" />
+        <h2 class="section-title">Editorial Desk</h2>
+        <span class="section-meta smallcaps">編集部・管理者専用</span>
+      </header>
+
+      <div class="desk-grid">
+        <NuxtLink to="/pieces/new" class="desk-card">
+          <span class="desk-tag smallcaps">New entry</span>
+          <h3 class="desk-title">楽曲を登録する</h3>
+          <p class="desk-lead">レパートリーへ新しい一曲を加える。</p>
+        </NuxtLink>
+        <NuxtLink to="/composers/new" class="desk-card">
+          <span class="desk-tag smallcaps">New entry</span>
+          <h3 class="desk-title">作曲家を登録する</h3>
+          <p class="desk-lead">マスタへ作曲家を追加する。</p>
         </NuxtLink>
       </div>
     </section>
@@ -140,33 +220,36 @@ defineProps<{
 </template>
 
 <style scoped>
+/* ============================================================
+ * Color helpers (五線譜SVGで使用)
+ * ============================================================ */
 .home {
-  margin: -2rem -2rem 0;
+  --staff-color: rgba(176, 138, 62, 0.28);
+  --note-color: rgba(176, 138, 62, 0.55);
+  --note-color-strong: rgba(176, 138, 62, 0.75);
+  --note-color-soft: rgba(176, 138, 62, 0.4);
+
+  margin: -2.5rem -2.5rem 0;
   padding-bottom: 4rem;
   overflow-x: hidden;
 }
-
-/* ── Hero ── */
-.hero {
-  position: relative;
-  background: linear-gradient(135deg, #0a1628 0%, #1e2d5a 60%, #152040 100%);
-  min-height: 380px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  overflow: hidden;
-  padding: 3rem 2rem;
-  margin: 0;
+:root.dark .home {
+  --staff-color: rgba(212, 173, 92, 0.32);
+  --note-color: rgba(212, 173, 92, 0.6);
+  --note-color-strong: rgba(212, 173, 92, 0.8);
+  --note-color-soft: rgba(212, 173, 92, 0.45);
 }
 
-/* ── アニメーション ── */
+/* ============================================================
+ * Animations
+ * ============================================================ */
 @keyframes float {
   0%,
   100% {
     transform: translateY(0);
   }
   50% {
-    transform: translateY(-14px);
+    transform: translateY(-12px);
   }
 }
 
@@ -176,14 +259,14 @@ defineProps<{
     opacity: 0.7;
   }
   50% {
-    opacity: 1.3;
+    opacity: 1.1;
   }
 }
 
 @keyframes fadeUp {
   from {
     opacity: 0;
-    transform: translateY(28px);
+    transform: translateY(24px);
   }
   to {
     opacity: 1;
@@ -191,10 +274,324 @@ defineProps<{
   }
 }
 
+@keyframes inkSpread {
+  from {
+    opacity: 0;
+    letter-spacing: 0.1em;
+  }
+  to {
+    opacity: 1;
+    letter-spacing: var(--tracking-tight);
+  }
+}
+
+/* ============================================================
+ * I. Hero
+ * ============================================================ */
+.hero {
+  position: relative;
+  background-color: var(--color-bg-paper);
+  border-bottom: 1px solid var(--color-hairline);
+  padding: clamp(3rem, 7vw, 6rem) clamp(1.5rem, 5vw, 6rem) clamp(4rem, 9vw, 7rem);
+  overflow: hidden;
+  isolation: isolate;
+}
+
+/* 紙の生成り感のレイヤー */
+.hero::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 25% 30%, rgba(176, 138, 62, 0.08) 0%, transparent 60%),
+    radial-gradient(ellipse at 90% 80%, rgba(110, 31, 43, 0.05) 0%, transparent 50%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+:root.dark .hero {
+  background: linear-gradient(180deg, #060a18 0%, #0a1226 60%, #060a18 100%);
+}
+:root.dark .hero::before {
+  background:
+    radial-gradient(ellipse at 25% 30%, rgba(212, 173, 92, 0.12) 0%, transparent 60%),
+    radial-gradient(ellipse at 90% 80%, rgba(184, 89, 104, 0.08) 0%, transparent 50%);
+}
+
+/* 左の縦ライン (rail) — 雑誌の余白の表情 */
+.hero-rail {
+  position: absolute;
+  left: clamp(1.5rem, 4vw, 4rem);
+  top: 0;
+  bottom: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 1.5rem 0;
+  z-index: 2;
+  font-family: var(--font-sans);
+}
+
+.rail-mark {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+  font-family: var(--font-display);
+  font-style: italic;
+  color: var(--color-accent);
+  letter-spacing: 0;
+}
+
+.rail-no {
+  font-size: 0.7rem;
+  font-weight: 400;
+  letter-spacing: 0.05em;
+  opacity: 0.85;
+}
+
+.rail-num {
+  font-size: 1rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  font-variation-settings:
+    "opsz" 144,
+    "WONK" 1;
+}
+
+.rail-line {
+  flex: 1;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    var(--color-hairline-strong) 30%,
+    var(--color-hairline-strong) 70%,
+    transparent 100%
+  );
+}
+
+.rail-foot {
+  color: var(--color-accent);
+  font-family: var(--font-display);
+  font-size: 1rem;
+}
+
+/* 大きな装飾的ローマ数字 */
+.hero-bignum {
+  position: absolute;
+  right: clamp(1.5rem, 5vw, 5rem);
+  bottom: clamp(-3rem, -3vw, -1.5rem);
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: clamp(14rem, 32vw, 30rem);
+  line-height: 0.82;
+  color: var(--color-accent);
+  opacity: 0.18;
+  z-index: 1;
+  pointer-events: none;
+  font-variation-settings:
+    "opsz" 144,
+    "WONK" 1;
+  user-select: none;
+}
+:root.dark .hero-bignum {
+  opacity: 0.22;
+}
+
+.hero-grid {
+  position: relative;
+  z-index: 3;
+  max-width: 980px;
+  margin: 0 auto 0 max(4rem, 9vw);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  animation: fadeUp 0.9s cubic-bezier(0.2, 0.6, 0.2, 1) forwards;
+}
+
+/* Eyebrow — Editorial / 罫線 / Field Guide */
+.hero-eyebrow {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.eyebrow-tag {
+  color: var(--color-bordeaux);
+  font-weight: 700;
+}
+:root.dark .eyebrow-tag {
+  color: var(--color-bordeaux);
+  filter: brightness(1.4);
+}
+
+.eyebrow-rule {
+  width: 3.5rem;
+  height: 1px;
+  background: var(--color-hairline-strong);
+}
+
+.eyebrow-meta {
+  font-family: var(--font-serif);
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+  font-weight: 400;
+}
+
+/* Hero Title */
+.hero-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(3rem, 9vw, 7.5rem);
+  line-height: 0.92;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+:root.dark .hero-title {
+  color: var(--color-header-text);
+}
+
+.hero-line-1,
+.hero-line-2,
+.hero-line-3 {
+  display: block;
+  animation: fadeUp 1s cubic-bezier(0.2, 0.6, 0.2, 1) backwards;
+}
+.hero-line-1 {
+  font-style: italic;
+  color: var(--color-text-muted);
+  font-size: 0.55em;
+  margin-left: 0.2em;
+  animation-delay: 0.05s;
+}
+.hero-line-2 {
+  margin-left: 0;
+  animation-delay: 0.15s;
+}
+.hero-line-3 {
+  margin-left: 1.4em;
+  color: var(--color-accent);
+  animation-delay: 0.3s;
+}
+.hero-line-3 em {
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.hero-lede {
+  font-family: var(--font-serif);
+  font-size: clamp(1.05rem, 1.6vw, 1.25rem);
+  line-height: 1.65;
+  color: var(--color-text-secondary);
+  max-width: 36em;
+  margin-top: 0.5rem;
+  font-weight: 400;
+}
+
+.hero-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+}
+:root.dark .hero-lede em {
+  color: var(--color-accent);
+}
+
+.lede-quiet {
+  color: var(--color-text-muted);
+  font-size: 0.9em;
+}
+
+.hero-cta {
+  display: flex;
+  align-items: center;
+  gap: 2rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.cta-primary,
+.cta-ghost {
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.95rem 1.6rem;
+  transition:
+    background 0.3s ease,
+    color 0.3s ease,
+    border-color 0.3s ease,
+    transform 0.3s ease;
+}
+
+.cta-primary {
+  background: var(--color-bg-ink);
+  color: var(--color-bg-paper);
+  border: 1px solid var(--color-bg-ink);
+}
+
+.cta-primary:hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: var(--color-bg-ink);
+}
+
+.cta-primary .cta-arrow {
+  transition: transform 0.3s ease;
+}
+
+.cta-primary:hover .cta-arrow {
+  transform: translateX(4px);
+}
+
+.cta-ghost {
+  color: var(--color-text);
+  border-bottom: 1px solid var(--color-hairline-strong);
+  padding: 0.6rem 0;
+  letter-spacing: var(--tracking-wide);
+}
+
+.cta-ghost:hover {
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+}
+
+:root.dark .cta-ghost {
+  color: var(--color-header-text);
+}
+
+/* 五線譜SVG */
+.hero-deco {
+  position: absolute;
+  right: -8%;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 75%;
+  height: 70%;
+  pointer-events: none;
+  opacity: 0.7;
+  z-index: 1;
+}
+
 .staff-lines {
   animation: shimmer 5s ease-in-out infinite;
 }
-
 .note {
   transform-box: fill-box;
   transform-origin: bottom center;
@@ -221,204 +618,307 @@ defineProps<{
   animation-delay: -0.8s;
 }
 
-.hero-deco {
+/* ============================================================
+ * Section head — 雑誌の章タイトル
+ * ============================================================ */
+.section-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1.4rem;
+  margin-bottom: 2.2rem;
+  padding-top: 0.5rem;
+}
+
+.section-num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 1.4rem;
+  color: var(--color-accent);
+  letter-spacing: 0.05em;
+}
+
+.section-rule {
+  flex: 0 0 4rem;
+  height: 1px;
+  align-self: center;
+  background: var(--color-hairline-strong);
+}
+
+.section-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings: "opsz" 80;
+}
+
+.section-meta {
+  margin-left: auto;
+  color: var(--color-text-faint);
+}
+
+/* ============================================================
+ * II. Featured stage
+ * ============================================================ */
+.featured-section {
+  max-width: 1080px;
+  margin: clamp(3rem, 6vw, 5rem) auto 0;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+.featured-stage {
+  border: 1px solid var(--color-hairline);
+  background: var(--color-bg-surface);
+  padding: clamp(1.25rem, 3vw, 2.25rem);
+  position: relative;
+}
+
+/* 4隅の装飾的なゴールドコーナー */
+.featured-stage::before,
+.featured-stage::after {
+  content: "";
   position: absolute;
-  inset: 0;
-  width: 100%;
-  height: 100%;
+  width: 18px;
+  height: 18px;
+  border: 1px solid var(--color-accent);
   pointer-events: none;
 }
-
-.hero-content {
-  position: relative;
-  z-index: 1;
-  text-align: center;
-  animation: fadeUp 0.9s ease-out forwards;
+.featured-stage::before {
+  top: -1px;
+  left: -1px;
+  border-right: none;
+  border-bottom: none;
+}
+.featured-stage::after {
+  bottom: -1px;
+  right: -1px;
+  border-left: none;
+  border-top: none;
 }
 
-.hero-title {
-  font-size: clamp(2.5rem, 8vw, 4.5rem);
-  color: #fff;
-  font-style: italic;
-  letter-spacing: 0.12em;
-  margin-bottom: 1rem;
-  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.4);
+/* ============================================================
+ * III. Departments
+ * ============================================================ */
+.departments {
+  max-width: 1280px;
+  margin: clamp(4rem, 7vw, 6rem) auto 0;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
 }
 
-.hero-sub {
-  font-size: 1.05rem;
-  color: rgba(255, 255, 255, 0.7);
-  letter-spacing: 0.06em;
-  margin-bottom: 2.5rem;
-}
-
-.hero-cta {
-  display: flex;
-  gap: 1rem;
-  justify-content: center;
-  flex-wrap: wrap;
-}
-
-.cta-primary {
-  display: inline-block;
-  padding: 0.75rem 2rem;
-  background: #fff;
-  color: var(--color-primary);
-  border-radius: 6px;
-  text-decoration: none;
-  font-weight: 600;
-  font-size: 0.95rem;
-  transition: opacity 0.2s;
-}
-
-.cta-primary:hover {
-  opacity: 0.88;
-}
-
-.cta-ghost {
-  display: inline-block;
-  padding: 0.75rem 2rem;
-  border: 1.5px solid rgba(255, 255, 255, 0.5);
-  color: rgba(255, 255, 255, 0.85);
-  border-radius: 6px;
-  text-decoration: none;
-  font-size: 0.95rem;
-  transition:
-    border-color 0.2s,
-    color 0.2s;
-}
-
-.cta-ghost:hover {
-  border-color: var(--color-on-primary);
-  color: var(--color-on-primary);
-}
-
-/* ── Featured ── */
-.featured-section {
-  max-width: 760px;
-  margin: 3rem auto 0;
-  padding: 0 2rem;
-}
-
-/* ── Menu cards ── */
-.menu-cards {
+.dept-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 1.5rem;
-  max-width: 960px;
-  margin: 2rem auto 0;
-  padding: 0 2rem;
+  gap: 0;
+  border-top: 1px solid var(--color-hairline-strong);
 }
 
-@media (max-width: 900px) {
-  .menu-cards {
-    grid-template-columns: 1fr;
-    max-width: 480px;
-  }
-}
-
-.card {
-  display: block;
-  background: var(--color-bg-subtle);
-  border: 1px solid var(--color-secondary);
-  border-radius: 12px;
-  padding: 2rem;
+.dept-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  padding: 2.4rem 1.8rem 2.2rem;
   text-decoration: none;
   color: inherit;
-  transition:
-    box-shadow 0.2s,
-    transform 0.2s;
-  text-align: center;
+  transition: background 0.3s ease;
+  border-right: 1px solid var(--color-hairline);
+  background: var(--color-bg-paper);
+}
+.dept-card:last-child {
+  border-right: none;
 }
 
-.card:hover {
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
-  transform: translateY(-2px);
+.dept-card::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto 0;
+  height: 2px;
+  background: var(--color-accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
-.card-icon {
-  font-size: 2.5rem;
-  display: block;
-  margin-bottom: 0.75rem;
+.dept-card:hover::before {
+  transform: scaleX(1);
 }
 
-.card h2 {
-  font-size: 1.25rem;
+.dept-card:hover {
+  background: var(--color-bg-elevated);
+}
+
+.dept-card:hover .dept-cta {
+  color: var(--color-accent);
+  letter-spacing: calc(var(--tracking-widest) + 0.04em);
+}
+
+.dept-num {
+  color: var(--color-bordeaux);
+  font-weight: 600;
+}
+:root.dark .dept-num {
+  color: var(--color-accent);
+}
+
+.dept-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: clamp(1.7rem, 3vw, 2.4rem);
+  font-style: italic;
+  letter-spacing: var(--tracking-tight);
   color: var(--color-text);
-  margin-bottom: 0.5rem;
+  line-height: 1.05;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 60;
 }
 
-.card p {
-  color: var(--color-text-faint);
-  font-size: 0.9rem;
+.dept-lead {
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  line-height: 1.55;
+  color: var(--color-text-secondary);
+}
+
+.dept-lead em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  font-weight: 500;
+  margin-right: 0.25em;
+}
+:root.dark .dept-lead em {
+  color: var(--color-accent);
+}
+
+.dept-cta {
+  margin-top: 0.6rem;
+  color: var(--color-text-muted);
+  transition:
+    color 0.25s ease,
+    letter-spacing 0.25s ease;
+}
+
+.dept-card--feature {
+  background: var(--color-bg-surface);
+}
+.dept-card--feature .dept-title {
+  color: var(--color-text);
+}
+
+/* ============================================================
+ * IV. Editorial desk (admin)
+ * ============================================================ */
+.editorial-desk {
+  max-width: 1280px;
+  margin: clamp(3rem, 6vw, 5rem) auto 0;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+.desk-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1px;
+  background: var(--color-hairline);
+  border: 1px solid var(--color-hairline);
+}
+
+.desk-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 1.8rem 1.6rem;
+  background: var(--color-bg-paper);
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.3s ease;
+  position: relative;
+}
+
+.desk-card:hover {
+  background: var(--color-accent-bg);
+}
+
+.desk-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .desk-tag {
+  color: var(--color-accent);
+}
+
+.desk-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-size: 1.4rem;
+  font-style: italic;
+  color: var(--color-text);
+}
+
+.desk-lead {
+  font-family: var(--font-serif);
+  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  line-height: 1.5;
+}
+
+/* ============================================================
+ * Responsive
+ * ============================================================ */
+@media (max-width: 980px) {
+  .hero-rail {
+    display: none;
+  }
+  .hero-grid {
+    margin-left: 0;
+  }
+  .hero-deco {
+    width: 100%;
+    right: -10%;
+    opacity: 0.45;
+  }
+  .dept-grid {
+    grid-template-columns: 1fr;
+  }
+  .dept-card {
+    border-right: none;
+    border-bottom: 1px solid var(--color-hairline);
+  }
+  .dept-card:last-child {
+    border-bottom: none;
+  }
+  .dept-br {
+    display: none;
+  }
 }
 
 @media (max-width: 600px) {
   .home {
-    margin: -1rem -1rem 0;
+    margin: -1.2rem -1.2rem 0;
   }
-
   .hero {
-    min-height: 300px;
+    padding: 3rem 1.5rem 4rem;
   }
-}
-
-/* ── Admin section ── */
-.admin-section {
-  max-width: 960px;
-  margin: 2rem auto 0;
-  padding: 0 2rem;
-}
-
-.admin-section-title {
-  font-size: 1rem;
-  color: var(--color-text-muted);
-  margin-bottom: 1rem;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-
-.admin-cards {
-  display: flex;
-  gap: 1rem;
-}
-
-.admin-card {
-  display: block;
-  background: #f5f0fa;
-  border: 1px solid #c4a8e0;
-  border-radius: 8px;
-  padding: 1rem 1.5rem;
-  text-decoration: none;
-  color: inherit;
-  transition:
-    box-shadow 0.2s,
-    transform 0.2s;
-}
-
-.admin-card:hover {
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-  transform: translateY(-1px);
-}
-
-.admin-card h3 {
-  font-size: 1rem;
-  color: #5a3a8a;
-  margin-bottom: 0.25rem;
-}
-
-.admin-card p {
-  color: var(--color-text-faint);
-  font-size: 0.85rem;
-}
-
-/* ── Dark mode overrides for purple-themed admin cards ── */
-:global(.dark .admin-card) {
-  background: #2a1f3a;
-  border-color: #6e4ea8;
-}
-
-:global(.dark .admin-card h3) {
-  color: #c4a8e0;
+  .hero-title {
+    font-size: clamp(2.4rem, 11vw, 3.6rem);
+  }
+  .hero-line-3 {
+    margin-left: 0.6em;
+  }
+  .section-head {
+    flex-wrap: wrap;
+    gap: 0.8rem;
+    margin-bottom: 1.5rem;
+  }
+  .section-rule {
+    flex: 1;
+  }
+  .section-meta {
+    margin-left: 0;
+    width: 100%;
+  }
+  .desk-grid {
+    grid-template-columns: 1fr;
+  }
 }
 </style>

--- a/app/components/templates/ListeningLogDetailTemplate.vue
+++ b/app/components/templates/ListeningLogDetailTemplate.vue
@@ -18,41 +18,56 @@ const handleDelete = async () => {
 </script>
 
 <template>
-  <div>
-    <div class="page-header">
-      <NuxtLink to="/listening-logs" class="back-link">← 鑑賞記録一覧</NuxtLink>
+  <article class="log-detail">
+    <header class="log-detail-head">
+      <NuxtLink to="/listening-logs" class="back-link">
+        <span aria-hidden="true">&larr;</span>
+        <span class="smallcaps">Back to recordings</span>
+      </NuxtLink>
       <div class="actions">
         <ButtonSecondary @click="router.push(`/listening-logs/${props.log.id}/edit`)">
-          編集
+          Edit
         </ButtonSecondary>
-        <ButtonDanger @click="handleDelete">削除</ButtonDanger>
+        <ButtonDanger @click="handleDelete">Delete</ButtonDanger>
       </div>
-    </div>
+    </header>
 
     <ListeningLogDetail :log="log" />
-  </div>
+  </article>
 </template>
 
 <style scoped>
-.page-header {
+.log-detail {
+  margin-bottom: 4rem;
+}
+
+.log-detail-head {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 2rem;
 }
 
 .back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.9rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .back-link:hover {
-  color: var(--color-text-secondary);
+  color: var(--color-accent);
+  gap: 0.65rem;
 }
 
 .actions {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
 }
 </style>

--- a/app/components/templates/ListeningLogEditTemplate.vue
+++ b/app/components/templates/ListeningLogEditTemplate.vue
@@ -12,9 +12,15 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>鑑賞記録を編集</PageTitle>
-    <ErrorMessage v-if="error" :message="error" />
+  <div class="form-page">
+    <NuxtLink to="/listening-logs" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to recordings</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="I / Recordings" meta="Edit">鑑賞記録を編集</PageTitle>
+
+    <ErrorMessage v-if="error" :message="error" variant="block" />
     <ListeningLogForm
       :initial-values="log"
       submit-label="更新する"
@@ -22,3 +28,26 @@ const emit = defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ListeningLogNewTemplate.vue
+++ b/app/components/templates/ListeningLogNewTemplate.vue
@@ -11,9 +11,38 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>鑑賞記録を追加</PageTitle>
-    <ErrorMessage v-if="error" :message="error" />
+  <div class="form-page">
+    <NuxtLink to="/listening-logs" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to recordings</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="I / Recordings" meta="New entry">鑑賞記録を追加</PageTitle>
+
+    <ErrorMessage v-if="error" :message="error" variant="block" />
     <ListeningLogForm submit-label="記録する" @submit="emit('submit', $event)" />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/ListeningLogStatisticsTemplate.test.ts
+++ b/app/components/templates/ListeningLogStatisticsTemplate.test.ts
@@ -16,7 +16,7 @@ describe("ListeningLogStatisticsTemplate", () => {
     const wrapper = await mountSuspended(ListeningLogStatisticsTemplate, {
       props: { statistics: stats },
     });
-    expect(wrapper.text()).toContain("鑑賞統計");
+    expect(wrapper.text()).toContain("統計");
   });
 
   it("一覧へ戻るリンクが表示される", async () => {

--- a/app/components/templates/ListeningLogStatisticsTemplate.vue
+++ b/app/components/templates/ListeningLogStatisticsTemplate.vue
@@ -7,27 +7,132 @@ defineProps<{
 </script>
 
 <template>
-  <div>
-    <PageHeader title="鑑賞統計" />
-    <div class="back-link-row">
-      <NuxtLink to="/listening-logs" class="back-link">← 鑑賞記録一覧へ戻る</NuxtLink>
-    </div>
+  <div class="stats-page">
+    <NuxtLink to="/listening-logs" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to recordings</span>
+    </NuxtLink>
+
+    <header class="stats-masthead">
+      <div class="masthead-meta">
+        <span class="meta-tag smallcaps">I / Recordings — Almanac</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-when smallcaps">Compiled today</span>
+      </div>
+
+      <h1 class="masthead-title">
+        <span class="title-jp">統計</span>
+        <span class="title-en"><em>Almanac</em></span>
+      </h1>
+
+      <p class="masthead-lede">
+        <em>What the year sounds like.</em> &mdash; あなたの聴いた音楽を、数字とグラフで眺める。
+      </p>
+    </header>
+
     <ListeningLogStatistics :statistics="statistics" />
   </div>
 </template>
 
 <style scoped>
-.back-link-row {
-  margin-bottom: 1.5rem;
+.stats-page {
+  margin-bottom: 4rem;
 }
 
 .back-link {
-  color: var(--color-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.95rem;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .back-link:hover {
-  text-decoration: underline;
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+
+.stats-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 0.5rem 0 2.4rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2.5rem;
+}
+
+.masthead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-when {
+  color: var(--color-text-muted);
+}
+
+.masthead-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.masthead-lede {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 38em;
+}
+
+.masthead-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  margin-right: 0.25em;
+}
+:root.dark .masthead-lede em {
+  color: var(--color-accent);
 }
 </style>

--- a/app/components/templates/ListeningLogsTemplate.test.ts
+++ b/app/components/templates/ListeningLogsTemplate.test.ts
@@ -79,7 +79,7 @@ describe("ListeningLogsTemplate", () => {
           filterState: { ...emptyFilter, keyword: "ベー" },
         },
       });
-      expect(wrapper.text()).toContain("1 / 5 件を表示中");
+      expect(wrapper.text()).toContain("Showing 1 of 5 entries");
     });
 
     it("ListeningLogFilter からの reset イベントを伝搬する", async () => {

--- a/app/components/templates/ListeningLogsTemplate.vue
+++ b/app/components/templates/ListeningLogsTemplate.vue
@@ -2,7 +2,7 @@
 import type { ListeningLog } from "~/types";
 import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
 
-defineProps<{
+const props = defineProps<{
   logs: ListeningLog[];
   filterState: ListeningLogFilterState;
   filterActive: boolean;
@@ -17,44 +17,164 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageHeader title="鑑賞記録" new-page-path="/listening-logs/new">+ 新しい記録</PageHeader>
-    <div class="toolbar">
-      <NuxtLink to="/listening-logs/statistics" class="stats-link">📊 統計を見る</NuxtLink>
-    </div>
+  <div class="logs-page">
+    <header class="logs-masthead">
+      <div class="masthead-meta">
+        <span class="meta-tag smallcaps">I / Recordings</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-count smallcaps numeric">
+          {{ props.totalCount.toString().padStart(3, "0") }}
+          {{ props.totalCount === 1 ? "entry" : "entries" }}
+        </span>
+      </div>
+
+      <h1 class="masthead-title">
+        <span class="title-jp">鑑賞記録</span>
+        <span class="title-en"><em>Listening Log</em></span>
+      </h1>
+
+      <p class="masthead-lede">
+        <em>A private journal of music.</em> &mdash; CD・配信・YouTube
+        で耳にした演奏を、書き留める。
+      </p>
+
+      <div class="masthead-actions">
+        <ButtonPrimary @click="$router.push('/listening-logs/new')"> + 新しい記録 </ButtonPrimary>
+        <NuxtLink to="/listening-logs/statistics" class="stats-link">
+          <span class="smallcaps">View Statistics</span>
+          <span aria-hidden="true">&rarr;</span>
+        </NuxtLink>
+      </div>
+    </header>
+
     <ListeningLogFilter
       :model-value="filterState"
       :is-active="filterActive"
       @update:model-value="emit('update:filterState', $event)"
       @reset="emit('reset-filter')"
     />
-    <p v-if="filterActive" class="filter-summary">
-      {{ logs.length }} / {{ totalCount }} 件を表示中
+    <p v-if="filterActive" class="filter-summary smallcaps numeric">
+      Showing {{ logs.length }} of {{ totalCount }} entries
     </p>
     <ListeningLogList :logs="logs" @delete="emit('delete', $event)" />
   </div>
 </template>
 
 <style scoped>
-.toolbar {
+.logs-page {
+  margin-bottom: 4rem;
+}
+
+.logs-masthead {
   display: flex;
-  justify-content: flex-end;
-  margin-bottom: 1rem;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.2rem 0 2.6rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2rem;
+}
+
+.masthead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-count {
+  color: var(--color-text-muted);
+}
+
+.masthead-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.masthead-lede {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 38em;
+}
+
+.masthead-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  margin-right: 0.25em;
+}
+:root.dark .masthead-lede em {
+  color: var(--color-accent);
+}
+
+.masthead-actions {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  margin-top: 0.4rem;
+  flex-wrap: wrap;
 }
 
 .stats-link {
-  color: var(--color-primary);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   text-decoration: none;
-  font-size: 0.95rem;
+  color: var(--color-text-muted);
+  border-bottom: 1px solid var(--color-hairline-strong);
+  padding: 0.4rem 0;
+  transition:
+    color 0.25s ease,
+    border-color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .stats-link:hover {
-  text-decoration: underline;
+  color: var(--color-accent);
+  border-bottom-color: var(--color-accent);
+  gap: 0.65rem;
 }
 
 .filter-summary {
   color: var(--color-text-muted);
-  font-size: 0.9rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.8rem;
 }
 </style>

--- a/app/components/templates/PieceDetailTemplate.test.ts
+++ b/app/components/templates/PieceDetailTemplate.test.ts
@@ -156,7 +156,7 @@ describe("PieceDetailTemplate", () => {
           composerName: "ベートーヴェン",
         },
       });
-      expect(wrapper.find(".kind-genre").text()).toBe("その他");
+      expect(wrapper.find(".kind-genre .badge-value").text()).toBe("その他");
     });
 
     it("genre が未設定の場合、ジャンルバッジが表示されない", async () => {
@@ -195,8 +195,8 @@ describe("PieceDetailTemplate", () => {
         },
       });
       expect(wrapper.find(".admin-actions").exists()).toBe(true);
-      expect(wrapper.find(".btn-secondary").exists()).toBe(true);
-      expect(wrapper.find(".btn-danger").exists()).toBe(true);
+      expect(wrapper.find("a.admin-link").exists()).toBe(true);
+      expect(wrapper.find(".admin-link--danger").exists()).toBe(true);
     });
 
     it("isAdmin が false のとき編集・削除ボタンが表示されない", async () => {
@@ -220,7 +220,7 @@ describe("PieceDetailTemplate", () => {
           composerName: "ベートーヴェン",
         },
       });
-      await wrapper.find(".btn-danger").trigger("click");
+      await wrapper.find(".admin-link--danger").trigger("click");
       expect(wrapper.emitted("delete")).toBeDefined();
     });
 
@@ -233,7 +233,7 @@ describe("PieceDetailTemplate", () => {
           composerName: "ベートーヴェン",
         },
       });
-      expect(wrapper.find(".btn-secondary").attributes("href")).toBe("/pieces/2/edit");
+      expect(wrapper.find("a.admin-link").attributes("href")).toBe("/pieces/2/edit");
     });
   });
 });

--- a/app/components/templates/PieceDetailTemplate.vue
+++ b/app/components/templates/PieceDetailTemplate.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { Piece, Rating } from "~/types";
 
-defineProps<{
+const props = defineProps<{
   piece: Piece | null;
   error: Error | null;
   isAdmin: boolean;
@@ -14,11 +14,19 @@ const emit = defineEmits<{
 }>();
 
 const hasStartedPlaying = ref(false);
+
+const shortId = computed(() => {
+  if (props.piece === null) return "";
+  return props.piece.id.slice(0, 6).toUpperCase();
+});
 </script>
 
 <template>
-  <div>
-    <NuxtLink to="/pieces" class="back-link">← 楽曲一覧</NuxtLink>
+  <article class="piece-detail">
+    <NuxtLink to="/pieces" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to repertoire</span>
+    </NuxtLink>
 
     <ErrorMessage
       v-if="error"
@@ -27,106 +35,269 @@ const hasStartedPlaying = ref(false);
     />
 
     <template v-else-if="piece">
-      <div class="piece-header">
-        <div class="piece-title">{{ piece.title }}</div>
-        <div class="piece-composer">{{ composerName }}</div>
+      <header class="piece-masthead">
+        <div class="piece-meta">
+          <span class="meta-tag smallcaps">II / Repertoire</span>
+          <span class="meta-rule" aria-hidden="true" />
+          <span class="meta-id smallcaps numeric">N&deg; {{ shortId }}</span>
+        </div>
+
+        <p class="piece-composer">{{ composerName }}</p>
+
+        <h1 class="piece-title">{{ piece.title }}</h1>
+
         <div class="piece-category-wrapper">
           <PieceCategoryList :piece="piece" />
         </div>
+
         <div v-if="isAdmin" class="admin-actions">
-          <NuxtLink :to="`/pieces/${piece.id}/edit`" class="btn-secondary">編集</NuxtLink>
-          <button class="btn-danger" @click="emit('delete', piece)">削除</button>
+          <NuxtLink :to="`/pieces/${piece.id}/edit`" class="admin-link">
+            <span class="smallcaps">Edit</span>
+          </NuxtLink>
+          <span class="admin-sep" aria-hidden="true">/</span>
+          <button class="admin-link admin-link--danger" @click="emit('delete', piece)">
+            <span class="smallcaps">Delete</span>
+          </button>
         </div>
-      </div>
+      </header>
 
       <template v-if="piece.videoUrl">
-        <VideoPlayer :video-url="piece.videoUrl" @play="hasStartedPlaying = true" />
+        <section class="piece-stage">
+          <span class="stage-tag smallcaps">Performance</span>
+          <div class="stage-frame">
+            <VideoPlayer :video-url="piece.videoUrl" @play="hasStartedPlaying = true" />
+          </div>
+        </section>
 
-        <QuickLogForm
-          v-if="hasStartedPlaying"
-          :composer="composerName"
-          :piece="piece.title"
-          @submit="emit('save', $event)"
-        />
+        <section v-if="hasStartedPlaying" class="piece-quicklog">
+          <header class="quicklog-head">
+            <span class="quicklog-num">&para;</span>
+            <h2 class="quicklog-title">Mark this listening</h2>
+            <span class="smallcaps quicklog-meta">いま聴いている演奏を、書き留める</span>
+          </header>
+          <QuickLogForm
+            :composer="composerName"
+            :piece="piece.title"
+            @submit="emit('save', $event)"
+          />
+        </section>
       </template>
     </template>
-  </div>
+  </article>
 </template>
 
 <style scoped>
+.piece-detail {
+  margin-bottom: 4rem;
+}
+
 .back-link {
-  display: inline-block;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
   color: var(--color-text-muted);
   text-decoration: none;
-  font-size: 0.9rem;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
 }
 
 .back-link:hover {
-  color: var(--color-text-secondary);
+  color: var(--color-accent);
+  gap: 0.65rem;
 }
 
-.piece-header {
-  margin-bottom: 1.5rem;
+.piece-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding-bottom: 2.5rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2.5rem;
+  position: relative;
 }
 
-.piece-title {
-  font-size: 1.5rem;
-  font-weight: bold;
-  color: var(--color-text);
-  margin-bottom: 0.3rem;
+.piece-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
 }
 
-.piece-composer {
-  font-size: 1rem;
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-id {
   color: var(--color-text-muted);
 }
 
+.piece-composer {
+  font-family: var(--font-sans);
+  font-size: 0.78rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
+  color: var(--color-text-muted);
+  margin-top: 0.4rem;
+}
+
+.piece-title {
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-style: italic;
+  font-size: clamp(2.2rem, 6vw, 4.4rem);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50,
+    "WONK" 1;
+  max-width: 18em;
+}
+
 .piece-category-wrapper {
-  margin-top: 0.5rem;
+  margin-top: 0.4rem;
 }
 
 .admin-actions {
   display: flex;
-  gap: 0.5rem;
+  align-items: center;
+  gap: 0.9rem;
   margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px dashed var(--color-hairline);
 }
 
-.btn-secondary {
-  display: inline-block;
-  padding: 0.4rem 1rem;
-  background: var(--color-bg-surface);
-  border: 1px solid var(--color-primary);
-  color: var(--color-primary);
-  border-radius: 4px;
-  font-size: 0.9rem;
+.admin-link {
+  background: transparent;
+  border: none;
+  padding: 0.3rem 0;
+  cursor: pointer;
+  color: var(--color-text-muted);
+  font-family: var(--font-sans);
+  position: relative;
   text-decoration: none;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+  transition: color 0.25s ease;
 }
 
-.btn-secondary:hover {
-  background: var(--color-primary);
-  color: var(--color-on-primary);
+.admin-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 0;
+  height: 1px;
+  background: currentColor;
+  transition: width 0.3s ease;
 }
 
-.btn-danger {
-  padding: 0.4rem 1rem;
+.admin-link:hover {
+  color: var(--color-accent);
+}
+
+.admin-link:hover::after {
+  width: 100%;
+}
+
+.admin-link--danger:hover {
+  color: var(--color-bordeaux);
+}
+:root.dark .admin-link--danger:hover {
+  color: var(--color-bordeaux);
+}
+
+.admin-sep {
+  color: var(--color-text-faint);
+  font-family: var(--font-display);
+  font-style: italic;
+}
+
+.piece-stage {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-bottom: 3rem;
+}
+
+.stage-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .stage-tag {
+  color: var(--color-accent);
+}
+
+.stage-frame {
+  position: relative;
+  border: 1px solid var(--color-hairline);
   background: var(--color-bg-surface);
-  border: 1px solid var(--color-danger);
-  color: var(--color-danger);
-  border-radius: 4px;
-  font-size: 0.9rem;
-  cursor: pointer;
-  transition:
-    background-color 0.2s,
-    color 0.2s;
+  padding: clamp(1rem, 2vw, 1.5rem);
 }
 
-.btn-danger:hover {
-  background: var(--color-danger);
-  color: var(--color-on-primary);
+.stage-frame::before,
+.stage-frame::after {
+  content: "";
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--color-accent);
+  pointer-events: none;
+}
+.stage-frame::before {
+  top: -1px;
+  left: -1px;
+  border-right: none;
+  border-bottom: none;
+}
+.stage-frame::after {
+  bottom: -1px;
+  right: -1px;
+  border-left: none;
+  border-top: none;
+}
+
+.piece-quicklog {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.quicklog-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.quicklog-num {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 1.4rem;
+  color: var(--color-accent);
+}
+
+.quicklog-title {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  flex: 1;
+}
+
+.quicklog-meta {
+  color: var(--color-text-muted);
 }
 </style>

--- a/app/components/templates/PieceEditTemplate.vue
+++ b/app/components/templates/PieceEditTemplate.vue
@@ -15,8 +15,13 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>楽曲を編集</PageTitle>
+  <div class="form-page">
+    <NuxtLink to="/pieces" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to repertoire</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="II / Repertoire" meta="Edit">楽曲を編集</PageTitle>
 
     <ErrorMessage v-if="fetchError" message="楽曲の取得に失敗しました。" variant="block" />
 
@@ -36,3 +41,26 @@ const emit = defineEmits<{
     </template>
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/PieceNewTemplate.vue
+++ b/app/components/templates/PieceNewTemplate.vue
@@ -13,8 +13,13 @@ const emit = defineEmits<{
 </script>
 
 <template>
-  <div>
-    <PageTitle>楽曲を追加</PageTitle>
+  <div class="form-page">
+    <NuxtLink to="/pieces" class="back-link">
+      <span aria-hidden="true">&larr;</span>
+      <span class="smallcaps">Back to repertoire</span>
+    </NuxtLink>
+
+    <PageTitle eyebrow="II / Repertoire" meta="New entry">楽曲を追加</PageTitle>
 
     <ErrorMessage v-if="error" :message="error" variant="block" />
 
@@ -26,3 +31,26 @@ const emit = defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+.form-page {
+  margin-bottom: 4rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  margin-bottom: 1.5rem;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+</style>

--- a/app/components/templates/PiecesTemplate.test.ts
+++ b/app/components/templates/PiecesTemplate.test.ts
@@ -28,7 +28,7 @@ describe("PiecesTemplate", () => {
     const wrapper = await mountSuspended(PiecesTemplate, {
       props: { ...baseProps, isAdmin: false },
     });
-    expect(wrapper.text()).toContain("楽曲マスタ");
+    expect(wrapper.find("h1.masthead-title").text()).toContain("楽曲");
   });
 
   it("isAdmin が true のとき新規追加ボタンが表示される", async () => {

--- a/app/components/templates/PiecesTemplate.vue
+++ b/app/components/templates/PiecesTemplate.vue
@@ -15,13 +15,37 @@ const emit = defineEmits<{
   loadMore: [];
   retry: [];
 }>();
+
+const pieceCount = computed(() => props.pieces.length);
 </script>
 
 <template>
-  <div>
-    <PageHeader title="楽曲マスタ" :new-page-path="props.isAdmin ? '/pieces/new' : undefined"
-      >+ 新しい楽曲</PageHeader
-    >
+  <div class="pieces-page">
+    <header class="pieces-masthead">
+      <div class="masthead-meta">
+        <span class="meta-tag smallcaps">II / Repertoire</span>
+        <span class="meta-rule" aria-hidden="true" />
+        <span class="meta-count smallcaps numeric">
+          {{ pieceCount.toString().padStart(3, "0") }}
+          {{ pieceCount === 1 ? "piece on file" : "pieces on file" }}
+        </span>
+      </div>
+
+      <h1 class="masthead-title">
+        <span class="title-jp">楽曲</span>
+        <span class="title-en"><em>Pieces</em></span>
+      </h1>
+
+      <p class="masthead-lede">
+        <em>A catalog of works.</em> &mdash; 交響曲、協奏曲、室内楽。<br />
+        登録された楽曲を時代と編成で巡る。
+      </p>
+
+      <div v-if="props.isAdmin" class="masthead-actions">
+        <ButtonPrimary @click="$router.push('/pieces/new')"> + 新しい楽曲 </ButtonPrimary>
+      </div>
+    </header>
+
     <PieceListInfinite
       :pieces="props.pieces"
       :error="props.error"
@@ -34,3 +58,103 @@ const emit = defineEmits<{
     />
   </div>
 </template>
+
+<style scoped>
+.pieces-page {
+  margin-bottom: 4rem;
+}
+
+.pieces-masthead {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.2rem 0 2.6rem;
+  border-bottom: 1px solid var(--color-hairline-strong);
+  margin-bottom: 2rem;
+  position: relative;
+}
+
+.masthead-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+}
+
+.meta-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .meta-tag {
+  color: var(--color-accent);
+}
+
+.meta-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.meta-count {
+  color: var(--color-text-muted);
+}
+
+.masthead-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(2.5rem, 7vw, 5rem);
+  line-height: 0.95;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.masthead-lede {
+  font-family: var(--font-serif);
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: var(--color-text-secondary);
+  max-width: 38em;
+}
+
+.masthead-lede em {
+  font-style: italic;
+  color: var(--color-bordeaux);
+  margin-right: 0.25em;
+}
+:root.dark .masthead-lede em {
+  color: var(--color-accent);
+}
+
+.masthead-actions {
+  margin-top: 0.4rem;
+}
+
+@media (max-width: 600px) {
+  .pieces-masthead {
+    padding-bottom: 2rem;
+  }
+  .masthead-title {
+    gap: 0.8rem;
+  }
+}
+</style>

--- a/app/layouts/auth.vue
+++ b/app/layouts/auth.vue
@@ -1,16 +1,20 @@
 <template>
   <div class="auth-layout">
-    <header class="auth-header">
-      <div class="auth-header-inner">
+    <header class="auth-masthead">
+      <div class="auth-masthead-inner">
         <NuxtLink to="/" class="logo" aria-label="ホームに戻る">
-          <img src="/logo.svg" alt="Nocturne" class="logo-img" />
           <span class="logo-text">Nocturne</span>
+          <span class="logo-mark" aria-hidden="true">&#9839;</span>
         </NuxtLink>
         <ThemeToggle />
       </div>
     </header>
     <main class="auth-main">
+      <span class="auth-side-mark" aria-hidden="true">N&deg;01</span>
       <slot />
+      <div class="auth-footnote smallcaps" aria-hidden="true">
+        a quarterly of classical listening
+      </div>
     </main>
   </div>
 </template>
@@ -20,41 +24,71 @@
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  background-color: var(--color-bg-base);
+  position: relative;
 }
 
-.auth-header {
+.auth-masthead {
   background-color: var(--color-header-bg);
   color: var(--color-header-text);
-  padding: 1rem 2rem;
+  position: relative;
 }
 
-.auth-header-inner {
+.auth-masthead::before,
+.auth-masthead::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-accent) 20%,
+    var(--color-accent) 80%,
+    transparent 100%
+  );
+  opacity: 0.45;
+}
+.auth-masthead::before {
+  top: 0;
+}
+.auth-masthead::after {
+  bottom: 0;
+}
+
+.auth-masthead-inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  max-width: 1200px;
+  max-width: 1280px;
   margin: 0 auto;
+  padding: 1.1rem 2.5rem;
 }
 
 .logo {
   display: inline-flex;
-  align-items: center;
-  gap: 0.6rem;
+  align-items: baseline;
+  gap: 0.4rem;
   text-decoration: none;
 }
 
-.logo-img {
-  height: 32px;
-  width: auto;
-  filter: var(--logo-filter);
+.logo-text {
+  font-family: var(--font-display);
+  font-weight: 400;
+  font-style: italic;
+  font-size: 1.7rem;
+  letter-spacing: -0.01em;
+  color: var(--color-header-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
 }
 
-.logo-text {
-  font-size: 1.3rem;
-  font-weight: bold;
-  color: var(--color-header-text);
-  letter-spacing: 0.08em;
-  font-style: italic;
+.logo-mark {
+  font-family: var(--font-display);
+  font-size: 1.1rem;
+  color: var(--color-accent);
 }
 
 .auth-main {
@@ -62,20 +96,63 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  padding: 2rem;
+  padding: 3rem 2rem;
+  position: relative;
+  isolation: isolate;
 }
 
-@media (max-width: 600px) {
-  .auth-header {
-    padding: 0.75rem;
-  }
+.auth-main::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(ellipse at 25% 30%, rgba(176, 138, 62, 0.06) 0%, transparent 60%),
+    radial-gradient(ellipse at 75% 70%, rgba(110, 31, 43, 0.04) 0%, transparent 50%);
+  pointer-events: none;
+  z-index: -1;
+}
 
-  .logo-img {
-    height: 26px;
+:root.dark .auth-main::before {
+  background:
+    radial-gradient(ellipse at 25% 30%, rgba(212, 173, 92, 0.1) 0%, transparent 60%),
+    radial-gradient(ellipse at 75% 70%, rgba(184, 89, 104, 0.06) 0%, transparent 50%);
+}
+
+.auth-side-mark {
+  position: absolute;
+  left: 2rem;
+  top: 50%;
+  transform: translateY(-50%) rotate(-90deg);
+  transform-origin: left center;
+  font-family: var(--font-display);
+  font-style: italic;
+  font-size: 0.85rem;
+  color: var(--color-accent);
+  letter-spacing: 0.12em;
+  opacity: 0.7;
+  white-space: nowrap;
+}
+
+.auth-footnote {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+@media (max-width: 760px) {
+  .auth-masthead-inner {
+    padding: 0.9rem 1.2rem;
   }
 
   .auth-main {
-    padding: 1rem;
+    padding: 2rem 1.2rem 4rem;
+  }
+
+  .auth-side-mark {
+    display: none;
   }
 }
 </style>

--- a/app/layouts/default.test.ts
+++ b/app/layouts/default.test.ts
@@ -33,14 +33,14 @@ describe("DefaultLayout - 未ログイン時", () => {
     const wrapper = await mountSuspended(DefaultLayout);
     const link = wrapper.find('a[href="/auth/user-register"]');
     expect(link.exists()).toBe(true);
-    expect(link.text()).toBe("新規登録");
+    expect(link.text()).toBe("Register");
   });
 
   it("「ログイン」リンクが表示される", async () => {
     const wrapper = await mountSuspended(DefaultLayout);
     const link = wrapper.find('a[href="/auth/login"]');
     expect(link.exists()).toBe(true);
-    expect(link.text()).toBe("ログイン");
+    expect(link.text()).toBe("Sign in");
   });
 
   it("「ログアウト」ボタンが表示されない", async () => {
@@ -58,21 +58,21 @@ describe("DefaultLayout - ナビゲーションリンク", () => {
     const wrapper = await mountSuspended(DefaultLayout);
     const link = wrapper.find('a[href="/listening-logs"]');
     expect(link.exists()).toBe(true);
-    expect(link.text()).toBe("鑑賞記録");
+    expect(link.find(".nav-label").text()).toBe("鑑賞記録");
   });
 
   it("「楽曲マスタ」リンクが表示される", async () => {
     const wrapper = await mountSuspended(DefaultLayout);
     const link = wrapper.find('a[href="/pieces"]');
     expect(link.exists()).toBe(true);
-    expect(link.text()).toBe("楽曲マスタ");
+    expect(link.find(".nav-label").text()).toBe("楽曲");
   });
 
   it("「コンサート記録」リンクが表示される", async () => {
     const wrapper = await mountSuspended(DefaultLayout);
     const link = wrapper.find('a[href="/concert-logs"]');
     expect(link.exists()).toBe(true);
-    expect(link.text()).toBe("コンサート記録");
+    expect(link.find(".nav-label").text()).toBe("演奏会");
   });
 });
 

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -8,198 +8,414 @@ watch(
     isLoggedIn.value = isAuthenticated();
   },
 );
+
+const today = new Date();
+const issueLabel = computed(() => {
+  const year = today.getFullYear();
+  const month = today.toLocaleString("en-US", { month: "long" }).toUpperCase();
+  const roman = ["", "I", "II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X", "XI", "XII"];
+  return `VOL. ${roman[today.getMonth() + 1]} · ${month} · ${year}`;
+});
 </script>
 
 <template>
   <div class="app">
-    <header class="app-header">
-      <nav>
-        <NuxtLink to="/" class="logo">
-          <img src="/logo.svg" alt="Nocturne" class="logo-img" />
-          <span class="logo-text">Nocturne</span>
-        </NuxtLink>
-        <ul class="nav-links">
-          <li><NuxtLink to="/listening-logs">鑑賞記録</NuxtLink></li>
-          <li><NuxtLink to="/pieces">楽曲マスタ</NuxtLink></li>
-          <li><NuxtLink to="/composers">作曲家マスタ</NuxtLink></li>
-          <li><NuxtLink to="/concert-logs">コンサート記録</NuxtLink></li>
-        </ul>
-        <ul v-if="!isLoggedIn" class="auth-links">
-          <li><NuxtLink to="/auth/user-register">新規登録</NuxtLink></li>
-          <li><NuxtLink to="/auth/login">ログイン</NuxtLink></li>
-        </ul>
-        <button v-if="isLoggedIn" class="logout-button" @click="logout">ログアウト</button>
-        <div class="theme-toggle-wrapper" :class="{ 'auth-aligned': !isLoggedIn }">
-          <ThemeToggle />
+    <header class="masthead">
+      <div class="masthead-inner">
+        <!-- 上段: 号数とテーマトグル -->
+        <div class="masthead-top">
+          <span class="issue-label smallcaps">{{ issueLabel }}</span>
+          <span class="motto smallcaps">A Quarterly of Classical Listening</span>
+          <div class="masthead-utils">
+            <span class="lat-long smallcaps" aria-hidden="true">35°41′N · 139°41′E</span>
+            <ThemeToggle />
+          </div>
         </div>
-      </nav>
+
+        <!-- 中段: マストヘッド + ナビ -->
+        <nav class="masthead-main" aria-label="Primary">
+          <NuxtLink to="/" class="logo" aria-label="Nocturne">
+            <span class="logo-text">Nocturne</span>
+            <span class="logo-mark" aria-hidden="true">&#9839;</span>
+          </NuxtLink>
+
+          <ul class="nav-links">
+            <li>
+              <NuxtLink to="/listening-logs">
+                <span class="nav-num smallcaps">01</span>
+                <span class="nav-label">鑑賞記録</span>
+              </NuxtLink>
+            </li>
+            <li>
+              <NuxtLink to="/pieces">
+                <span class="nav-num smallcaps">02</span>
+                <span class="nav-label">楽曲</span>
+              </NuxtLink>
+            </li>
+            <li>
+              <NuxtLink to="/composers">
+                <span class="nav-num smallcaps">03</span>
+                <span class="nav-label">作曲家</span>
+              </NuxtLink>
+            </li>
+            <li>
+              <NuxtLink to="/concert-logs">
+                <span class="nav-num smallcaps">04</span>
+                <span class="nav-label">演奏会</span>
+              </NuxtLink>
+            </li>
+          </ul>
+
+          <div class="masthead-auth">
+            <ul v-if="!isLoggedIn" class="auth-links">
+              <li><NuxtLink to="/auth/user-register">Register</NuxtLink></li>
+              <li class="sep" aria-hidden="true">·</li>
+              <li><NuxtLink to="/auth/login">Sign in</NuxtLink></li>
+            </ul>
+            <button v-else class="logout-button" @click="logout">Sign out</button>
+          </div>
+        </nav>
+      </div>
     </header>
+
     <main class="app-main">
       <slot />
     </main>
+
+    <footer class="colophon">
+      <div class="colophon-inner">
+        <span class="smallcaps">Nocturne &mdash; for solitary listening</span>
+        <span class="colophon-rule" aria-hidden="true" />
+        <span class="smallcaps">Set in Fraunces &amp; Inter Tight</span>
+      </div>
+    </footer>
   </div>
 </template>
 
 <style scoped>
-.app-header {
-  background-color: var(--color-header-bg);
-  color: var(--color-header-text);
-  padding: 1rem 2rem;
+.app {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
 }
 
-.app-header nav {
+/* ============================================================
+ * Masthead — Editorial Quarterly
+ * ============================================================ */
+.masthead {
+  background-color: var(--color-header-bg);
+  color: var(--color-header-text);
+  position: relative;
+}
+
+/* 上下にゴールドのヘアライン */
+.masthead::before,
+.masthead::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(
+    90deg,
+    transparent 0%,
+    var(--color-accent) 20%,
+    var(--color-accent) 80%,
+    transparent 100%
+  );
+  opacity: 0.45;
+}
+.masthead::before {
+  top: 0;
+}
+.masthead::after {
+  bottom: 0;
+}
+
+.masthead-inner {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 2.5rem;
+}
+
+/* ── 上段: 号数と日時 ── */
+.masthead-top {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 2rem;
-  max-width: 1200px;
-  margin: 0 auto;
+  padding: 0.55rem 0;
+  border-bottom: 1px solid rgba(184, 168, 136, 0.18);
+  font-size: 0.68rem;
+}
+
+.issue-label,
+.motto,
+.lat-long {
+  color: var(--color-header-text-muted);
+}
+
+.motto {
+  font-family: var(--font-serif);
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: 0.04em;
+  font-size: 0.78rem;
+  font-weight: 400;
+}
+
+.masthead-utils {
+  display: flex;
+  align-items: center;
+  gap: 1.2rem;
+}
+
+/* ── 中段: マストヘッド + ナビ ── */
+.masthead-main {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 2rem;
+  padding: 1.4rem 0 1.5rem;
 }
 
 .logo {
-  display: flex;
-  align-items: center;
-  gap: 0.6rem;
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.4rem;
   text-decoration: none;
-}
-
-.logo-img {
-  height: 32px;
-  width: auto;
-  filter: var(--logo-filter);
+  justify-self: start;
+  color: var(--color-header-text);
 }
 
 .logo-text {
-  font-size: 1.3rem;
-  font-weight: bold;
-  color: var(--color-header-text);
-  letter-spacing: 0.08em;
+  font-family: var(--font-display);
+  font-weight: 400;
   font-style: italic;
+  font-size: 2.4rem;
+  letter-spacing: -0.01em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
+  line-height: 1;
+  color: var(--color-header-text);
+}
+
+.logo-mark {
+  font-family: var(--font-display);
+  font-size: 1.4rem;
+  color: var(--color-accent);
+  font-weight: 300;
 }
 
 .nav-links {
   list-style: none;
   display: flex;
-  gap: 1.5rem;
+  gap: 2rem;
+  justify-self: center;
 }
 
 .nav-links a {
-  color: var(--color-header-text-muted);
+  display: inline-flex;
+  align-items: baseline;
+  gap: 0.35rem;
   text-decoration: none;
-  font-size: 0.95rem;
-  transition: color 0.2s;
-  white-space: nowrap;
+  color: var(--color-header-text);
+  font-family: var(--font-sans);
+  font-size: 0.92rem;
+  letter-spacing: 0.04em;
+  position: relative;
+  padding: 0.25rem 0;
+  transition: color 0.2s ease;
 }
 
-.nav-links a:hover,
+.nav-num {
+  font-size: 0.6rem;
+  color: var(--color-accent);
+  letter-spacing: 0.2em;
+  vertical-align: super;
+  line-height: 1;
+}
+
+.nav-label {
+  font-weight: 500;
+}
+
+.nav-links a::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: -2px;
+  width: 0;
+  height: 1px;
+  background: var(--color-accent);
+  transition:
+    width 0.3s cubic-bezier(0.4, 0, 0.2, 1),
+    left 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.nav-links a:hover::after,
+.nav-links a.router-link-active::after {
+  left: 0;
+  width: 100%;
+}
+
 .nav-links a.router-link-active {
-  color: var(--color-header-text);
+  color: var(--color-accent-soft);
+}
+
+.masthead-auth {
+  justify-self: end;
 }
 
 .auth-links {
   list-style: none;
   display: flex;
-  gap: 1.2rem;
-  margin-left: auto;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0;
+  padding: 0;
 }
 
 .auth-links a {
-  color: var(--color-header-text-muted);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-size: 1rem;
   text-decoration: none;
-  font-size: 0.95rem;
-  transition: color 0.2s;
-  white-space: nowrap;
+  color: var(--color-header-text);
+  transition: color 0.2s ease;
+  letter-spacing: 0.02em;
 }
 
 .auth-links a:hover {
-  color: var(--color-header-text);
+  color: var(--color-accent);
+}
+
+.auth-links .sep {
+  color: var(--color-header-text-muted);
+  font-family: var(--font-serif);
 }
 
 .logout-button {
-  margin-left: auto;
-  background: none;
-  border: 1px solid var(--color-header-text-muted);
-  color: var(--color-header-text-muted);
-  padding: 0.35rem 0.9rem;
-  border-radius: 4px;
-  font-size: 0.9rem;
+  background: transparent;
+  border: 1px solid var(--color-accent);
+  color: var(--color-header-text);
+  padding: 0.5rem 1.1rem;
+  font-family: var(--font-sans);
+  font-size: 0.7rem;
+  font-weight: 500;
+  letter-spacing: var(--tracking-widest);
+  text-transform: uppercase;
   cursor: pointer;
   transition:
-    background-color 0.2s,
-    color 0.2s;
+    background 0.25s ease,
+    color 0.25s ease;
 }
 
 .logout-button:hover {
-  background-color: var(--color-header-text-muted);
-  color: var(--color-header-bg);
+  background: var(--color-accent);
+  color: var(--color-bg-ink);
 }
 
-.theme-toggle-wrapper {
+/* ============================================================
+ * Main
+ * ============================================================ */
+.app-main {
+  flex: 1;
+  width: 100%;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2.5rem;
+}
+
+/* ============================================================
+ * Colophon (Footer)
+ * ============================================================ */
+.colophon {
+  border-top: 1px solid var(--color-hairline);
+  margin-top: 4rem;
+  padding: 1.5rem 2.5rem;
+}
+
+.colophon-inner {
+  max-width: 1280px;
+  margin: 0 auto;
   display: flex;
   align-items: center;
+  gap: 1.5rem;
+  font-size: 0.68rem;
 }
 
-.app-main {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 2rem;
+.colophon-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
 }
 
-@media (max-width: 720px) {
-  .app-header {
-    padding: 0.5rem 0.75rem;
+/* ============================================================
+ * Responsive
+ * ============================================================ */
+@media (max-width: 980px) {
+  .masthead-inner {
+    padding: 0 1.5rem;
   }
-
-  .app-header nav {
+  .masthead-top {
     flex-wrap: wrap;
-    gap: 0.5rem 0.75rem;
-    row-gap: 0.5rem;
+    gap: 0.5rem;
   }
-
-  .logo {
-    gap: 0.4rem;
+  .motto {
+    display: none;
   }
-
-  .logo-img {
-    height: 24px;
+  .masthead-main {
+    grid-template-columns: 1fr auto;
+    gap: 1rem;
+    padding: 1.1rem 0;
   }
-
   .logo-text {
-    font-size: 1.1rem;
+    font-size: 1.9rem;
   }
-
   .nav-links {
-    order: 3;
-    flex-basis: 100%;
+    grid-column: 1 / -1;
+    justify-self: stretch;
     justify-content: space-between;
     gap: 0.5rem;
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-    padding-bottom: 0.25rem;
+    padding-top: 0.6rem;
+    border-top: 1px solid rgba(184, 168, 136, 0.15);
   }
+  .nav-links a {
+    font-size: 0.8rem;
+  }
+  .masthead-auth {
+    justify-self: end;
+  }
+  .lat-long {
+    display: none;
+  }
+}
 
-  .nav-links a,
+@media (max-width: 600px) {
+  .masthead-inner {
+    padding: 0 1rem;
+  }
+  .app-main {
+    padding: 1.2rem;
+  }
   .auth-links a {
     font-size: 0.85rem;
   }
-
-  .auth-links {
-    margin-left: auto;
-    gap: 0.6rem;
+  .colophon {
+    padding: 1.2rem 1rem;
   }
-
-  .logout-button {
-    margin-left: auto;
-    padding: 0.3rem 0.6rem;
-    font-size: 0.8rem;
+  .colophon-inner {
+    flex-wrap: wrap;
   }
-
-  .app-main {
-    padding: 1rem;
+  .colophon-rule {
+    display: none;
   }
 }
 
 @media (max-width: 380px) {
-  .logo-text {
+  .nav-num {
     display: none;
   }
 }

--- a/app/pages/listening-logs/index.test.ts
+++ b/app/pages/listening-logs/index.test.ts
@@ -107,7 +107,7 @@ describe("ListeningLogsPage（検索フィルタ結合）", () => {
     await keywordInput.setValue("モーツァルト");
     await flushPromises();
     expect(wrapper.findAll(".btn-danger")).toHaveLength(1);
-    expect(wrapper.text()).toContain("1 / 2 件を表示中");
+    expect(wrapper.text()).toContain("Showing 1 of 2 entries");
   });
 
   it("条件をクリアすると全件に戻る", async () => {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -82,7 +82,35 @@
 | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `video.ts`     | YouTube URL の判定（`isYouTubeUrl`）、動画 ID 抽出（`extractYouTubeVideoId`）、埋め込み URL 変換（`toYouTubeEmbedUrl`） |
 
-#### テーマ（ライト/ダークモード）
+#### デザインシステム — Editorial Quarterly
+
+ヴィンテージ雑誌（The New Yorker / Le Monde diplomatique）の佇まいを参考にしたエディトリアル路線。ネイビー × アイボリー × シャンパンゴールドを基調に、ボルドーを補助アクセントに据える。
+
+##### タイポグラフィ
+
+- **ディスプレイ**: [`Fraunces`](https://fonts.google.com/specimen/Fraunces) — 1900 年代のオールドスタイルセリフ復刻。可変軸 `opsz` / `SOFT` / `WONK` でクラシック寄り〜エキセントリックを切替
+- **本文・UI**: [`Inter Tight`](https://fonts.google.com/specimen/Inter+Tight) — 情報密度の高い UI 用、`Inter` のコンパクト版
+- **引用・装飾**: [`Cormorant Garamond`](https://fonts.google.com/specimen/Cormorant+Garamond) — 19 世紀 Garamond 復刻、抒情性のある引用やキャプションに
+- **読み込み**: `app/assets/css/fonts.css` で Google Fonts を `@import`、`nuxt.config.ts` の `app.head` で `https://fonts.googleapis.com` への `preconnect` を設定
+- **トークン**: `theme.css` の `:root` で `--font-display` / `--font-serif` / `--font-sans` / `--font-numeric` と `--tracking-tight` 〜 `--tracking-widest` を定義
+- **`.smallcaps` / `.numeric`**: `app.vue` のグローバルクラス。雑誌風キャプションとタブラー数字の出力に使用
+
+##### カラーパレット（Editorial）
+
+- **背景（ライト）**: アイボリー系 `--color-bg-base: #f4ecdb` / `--color-bg-paper: #f8f1de` / `--color-bg-ink: #0a1226`（インキ用の濃紺）
+- **背景（ダーク）**: ネイビー系 `--color-bg-base: #0a1020` / `--color-bg-paper: #131c38` / `--color-bg-ink: #f4ecdb`（暗背景の反転インキ＝アイボリー）
+- **アクセント**: シャンパンゴールド `--color-accent`（light: `#b08a3e` / dark: `#d4ad5c`）、ボルドー `--color-bordeaux`（light: `#6e1f2b` / dark: `#b85968`）
+- **罫線**: `--color-hairline` / `--color-hairline-strong`（半透明の極細線、雑誌の組版的な区切りに使用）
+- **紙のテクスチャ**: `app.vue` の `body::before` で repeating-linear-gradient + radial-gradient の重ね合わせで紙の繊維感を再現
+
+##### モーション
+
+- **ページ遷移**: `nuxt.config.ts` の `app.pageTransition` / `layoutTransition` で `name: "page"` を指定。`app.vue` で `.page-enter-active` / `.page-leave-active` を CSS 定義（フェード + 微小なリフト）
+- **stagger reveal**: `.stagger-children` クラスを `<ul>` / グリッドに付けると、子要素が順次フェードイン（`@keyframes stagger-up`、最大 11 件目まで `animation-delay`）
+- **micro-interactions**: ナビゲーションのアンダーライン伸長、Item の左サイドゴールドバー、CTA の `letter-spacing` 拡張等
+- **アクセシビリティ**: `prefers-reduced-motion: reduce` でスクロールスムーズとアニメーションを無効化
+
+##### テーマ（ライト/ダークモード）
 
 - **モジュール**: [`@nuxtjs/color-mode`](https://color-mode.nuxtjs.org/) を採用。`<html>` ルート要素に `light` / `dark` クラスを付与する
 - **設定**（`nuxt.config.ts`）:
@@ -90,10 +118,19 @@
   - `fallback: "light"` — システム検出に失敗した場合のデフォルト
   - `classSuffix: ""` — クラス名を `light` / `dark`（接尾辞なし）に統一
   - `storageKey: "nocturne-color-mode"` — ユーザー選択を localStorage に保存
-- **カラーパレット定義**: `app/assets/css/theme.css` で `:root.light` / `:root.dark` ごとに CSS 変数（`--color-bg-base`、`--color-text`、`--color-primary` など意味的トークン）を定義し、各コンポーネントは `var(--xxx)` 経由で参照する
-- **ダークモードのカラーキー**: ネイビー寄りパレット（背景は `#0f1729`、サーフェスは `#1a2547`、プライマリは `#4a6ba8`）
+- **カラーパレット定義**: `app/assets/css/theme.css` で `:root.light` / `:root.dark` ごとに CSS 変数（`--color-bg-base`、`--color-text`、`--color-primary`、`--color-accent`、`--color-bordeaux` 等意味的トークン）を定義し、各コンポーネントは `var(--xxx)` 経由で参照する
 - **切替 UI**: `ThemeToggle` atom（月/太陽アイコンの円形ボタン）をヘッダー右端に配置。`default` レイアウトと `auth` レイアウトの両方で利用可能
 - **永続化**: ユーザー選択は localStorage に保存され、リロード後も維持される
+
+##### マストヘッド
+
+`default` レイアウトでは雑誌のマストヘッドを模した 2 段ヘッダーを採用:
+
+- **上段**: 号数表示（"VOL. V · MAY · 2026"、当月をローマ数字 + 英語月名に変換）、誌名サブタイトル（"A Quarterly of Classical Listening"）、緯度経度（35°41′N · 139°41′E）、テーマトグル
+- **中段**: ロゴ "Nocturne ♯" + ナンバリング付きナビゲーション（"01 鑑賞記録 / 02 楽曲 / 03 作曲家 / 04 演奏会"）+ 認証 (Sign in / Register / Sign out)
+- **アクセント**: 上下にゴールドのヘアライン（`linear-gradient` で両端をフェード）、ナビ現在地はゴールドのアンダーライン
+
+`auth` レイアウトは別マストヘッド + 4 隅ゴールドコーナー枠の `AuthFormContainer` + サイドマーク "Nº01" + フットノート「a quarterly of classical listening」を配置
 
 #### バックエンド
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -21,7 +21,17 @@ export default defineNuxtConfig({
     storageKey: "nocturne-color-mode",
   },
   components: [{ path: "~/components", pathPrefix: false }],
-  css: ["~/assets/css/theme.css"],
+  css: ["~/assets/css/fonts.css", "~/assets/css/theme.css"],
+  app: {
+    head: {
+      link: [
+        { rel: "preconnect", href: "https://fonts.googleapis.com" },
+        { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" },
+      ],
+    },
+    pageTransition: { name: "page", mode: "out-in" },
+    layoutTransition: { name: "page", mode: "out-in" },
+  },
   typescript: {
     strict: true,
   },


### PR DESCRIPTION
## Summary

ヴィンテージ雑誌（The New Yorker / Le Monde diplomatique）に着想を得たエディトリアル路線へフロントエンド全画面を刷新しました。クラシック音楽鑑賞アプリにふさわしい、知性と歴史性を感じさせるデザインを目指しています。

### デザイン方向性: Editorial Quarterly

- **タイポグラフィ**: ディスプレイ `Fraunces`（可変軸 SOFT/WONK でクラシック〜エキセントリックを切替）+ 本文 `Inter Tight` + 引用 `Cormorant Garamond`
- **カラー**: ネイビー × アイボリー × **シャンパンゴールド** × ボルドー（補助）
- **質感**: 紙の繊維感（repeating-linear-gradient + radial-gradient）、罫線/ヘアライン、4 隅ゴールドコーナーマーク
- **モーション**: ページ遷移フェード、リスト stagger reveal、ナビ下線伸長、`prefers-reduced-motion` 対応

## 主な変更

### 共通プリミティブ（atoms / molecules）
- `Button*` / `CategoryBadge` / `EmptyState` / `RequiredMark` / `ErrorMessage` を smallcaps + 罫線スタイルへ
- `TextInput` / `SelectInput` / `FormGroup` をアンダーライン式の罫線フィールドへ
- `PageHeader` / `PageTitle` にローマ数字 eyebrow とゴールド罫線

### マストヘッド
- `default` レイアウト: 2 段ヘッダー（号数 "VOL. V · MAY · 2026" + 緯度経度 / マストヘッド + ナンバリング付きナビ）
- `auth` レイアウト: 4 隅ゴールドコーナー枠の `AuthFormContainer` + サイドマーク "Nº01" + コロフォン
- 全ページにフッター "Set in Fraunces & Inter Tight"

### 主要画面
- **Home**: 大胆な "The art of listening, kept." + 五線譜ゴールド音符 + 巨大ローマ数字 "I" + Departments 三段組
- **Pieces / Composers / ListeningLogs / ConcertLogs**: バイリンガル見出し（漢字 + 英字イタリック）+ "001 piece on file" のメタ + リード文
- **Pieces 詳細**: Performance ステージ + Mark this listening の QuickLog
- **Composers 詳細**: Portrait ステージ + grayscale ホバー解除
- **統計（Almanac）**: 大数字サマリ + 罫線バーチャート
- **認証 3 画面**: バイリンガル "Sign In / ログイン" + Google ログインボタンのリファイン + コード入力の特大セリフ

### モーション
- `nuxt.config.ts` に `pageTransition` / `layoutTransition` 追加
- `.stagger-children` クラスで子要素が順次フェード（最大 11 件目まで delay）

### 仕様書
- `docs/SPEC.md` の「テーマ」節を「デザインシステム — Editorial Quarterly」へ拡張（タイポ / カラー / モーション / マストヘッド）

## Test plan

- [x] `pnpm run lint` — ESLint + Stylelint クリア
- [x] `pnpm run format:check` — Prettier クリア
- [x] `pnpm run test:frontend` — 721/721 passed
- [x] `pnpm run test:backend` — 602/602 passed
- [x] Playwright で Home / Pieces / Composers / Login のライト/ダーク両方を目視確認
- [ ] レビュアー: 主要画面のホバー / ページ遷移 / stagger reveal を実機で確認
- [ ] レビュアー: ログイン後の認証必須ページ（視聴ログ・コンサート・統計）の見た目確認
- [ ] レビュアー: モバイル幅（〜600px）でのマストヘッド・各 list の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)