### PR TITLE
chore: web-design-guidelines skill を APM 経由で追加

### DIFF
--- a/.claude/skills/web-design-guidelines/SKILL.md
+++ b/.claude/skills/web-design-guidelines/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: web-design-guidelines
+description: Review UI code for Web Interface Guidelines compliance. Use when asked to "review my UI", "check accessibility", "audit design", "review UX", or "check my site against best practices".
+metadata:
+  author: vercel
+  version: "1.0.0"
+  argument-hint: <file-or-pattern>
+---
+
+# Web Interface Guidelines
+
+Review files for compliance with Web Interface Guidelines.
+
+## How It Works
+
+1. Fetch the latest guidelines from the source URL below
+2. Read the specified files (or prompt user for files/pattern)
+3. Check against all rules in the fetched guidelines
+4. Output findings in the terse `file:line` format
+
+## Guidelines Source
+
+Fetch fresh guidelines before each review:
+
+```
+https://raw.githubusercontent.com/vercel-labs/web-interface-guidelines/main/command.md
+```
+
+Use WebFetch to retrieve the latest rules. The fetched content contains all the rules and output format instructions.
+
+## Usage
+
+When a user provides a file or pattern argument:
+1. Fetch guidelines from the source URL above
+2. Read the specified files
+3. Apply all rules from the fetched guidelines
+4. Output findings using the format specified in the guidelines
+
+If no files specified, ask the user which files to review.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -13,3 +13,13 @@ dependencies:
       - .claude/skills/frontend-design
       - .github/skills/frontend-design
     content_hash: sha256:063a0e6448123cd359ad0044cc46b0e490cc7964d45ef4bb9fd842bd2ffbca67
+  - repo_url: vercel-labs/agent-skills
+    host: github.com
+    resolved_commit: ce3e64e468f8fa09a2d075d102771838061fdac0
+    virtual_path: skills/web-design-guidelines
+    is_virtual: true
+    package_type: claude_skill
+    deployed_files:
+      - .claude/skills/web-design-guidelines
+      - .github/skills/web-design-guidelines
+    content_hash: sha256:a6a44d5498f7e8f68289902f3dedfc6f38ae0cee1e96527c80724cf27f727c2a

--- a/apm.yml
+++ b/apm.yml
@@ -3,3 +3,4 @@ version: 1.0.0
 dependencies:
   apm:
     - anthropics/skills/skills/frontend-design#5128e1865d670f5d6c9cef000e6dfc4e951fb5b9
+    - vercel-labs/agent-skills/skills/web-design-guidelines#ce3e64e468f8fa09a2d075d102771838061fdac0

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -237,8 +237,10 @@ export default withNuxt(
     },
   },
   // Markdown: コードブロックに言語タグがない場合に警告 (MD040)
+  // .claude/skills/ 配下は APM が同期する第三者管理のファイルのためチェック対象外
   {
     files: ["**/*.md"],
+    ignores: [".claude/skills/**/*.md"],
     plugins: {
       local: { rules: { md040: md040Rule } },
     },


### PR DESCRIPTION
## Summary

- `vercel-labs/agent-skills` の `web-design-guidelines` skill を APM 経由でプロジェクトに追加（SHA `ce3e64e` でピン留め）
- Vercel の Web Interface Guidelines を最新版で取得しつつ UI コードの a11y / UX / 設計違反をレビューする用途。`/web-design-guidelines` で起動可能
- `.claude/skills/` 配下は APM が同期する第三者管理ファイルのため、ESLint の MD040 ルール対象から除外

## 変更ファイル

- `apm.yml` — `vercel-labs/agent-skills/skills/web-design-guidelines#ce3e64e...` を追加
- `apm.lock.yaml` — APM が自動更新
- `eslint.config.mjs` — MD040 の対象から `.claude/skills/**/*.md` を除外
- `.claude/skills/web-design-guidelines/SKILL.md` — APM が配置（`.github/skills/` にも同時配置）

## Test plan

- [x] `apm install --dry-run` で 2 件のロック済み依存が解決されることを確認
- [x] `npx eslint .claude/skills/web-design-guidelines/SKILL.md` が ignore 経由でエラーにならないことを確認
- [x] `pre-commit` (`lint-staged`) と `commit-msg` (`commitlint`) を通過してコミット成功
- [x] `pre-push` のバックエンドテスト（602 件）通過
- [ ] マージ後、Claude Code セッションで `/web-design-guidelines` がスキル一覧に表示されることを確認

https://claude.ai/code/session_01N3bHavmSRiW4ShfGcpfFrt

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3bHavmSRiW4ShfGcpfFrt)_