### PR TITLE
feat(ui): 一覧アイテムの背景全体をタップで詳細ページへ遷移できるよう変更

### DIFF
--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -32,7 +32,9 @@ const lifespan = computed(() => formatLifespan(props.composer.birthYear, props.c
     </div>
 
     <div class="composer-main">
-      <h2 class="composer-name">{{ composer.name }}</h2>
+      <h2 class="composer-name">
+        <NuxtLink :to="`/composers/${composer.id}`">{{ composer.name }}</NuxtLink>
+      </h2>
       <div v-if="lifespan" class="composer-lifespan smallcaps numeric">{{ lifespan }}</div>
       <div class="composer-category-wrapper">
         <ComposerCategoryList :composer="composer" />
@@ -131,6 +133,17 @@ const lifespan = computed(() => formatLifespan(props.composer.birthYear, props.c
     "SOFT" 50;
 }
 
+.composer-name a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.composer-name a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
 .composer-lifespan {
   color: var(--color-text-muted);
   font-size: 0.75rem;
@@ -146,6 +159,8 @@ const lifespan = computed(() => formatLifespan(props.composer.birthYear, props.c
   gap: 0.6rem;
   flex-shrink: 0;
   align-items: center;
+  position: relative;
+  z-index: 1;
 }
 
 .btn-detail {

--- a/app/components/molecules/ConcertLogItem.vue
+++ b/app/components/molecules/ConcertLogItem.vue
@@ -20,7 +20,9 @@ const emit = defineEmits<{
         <span class="log-venue smallcaps">{{ concertLog.venue }}</span>
       </div>
 
-      <h2 class="log-title">{{ concertLog.title }}</h2>
+      <h2 class="log-title">
+        <NuxtLink :to="`/concert-logs/${concertLog.id}`">{{ concertLog.title }}</NuxtLink>
+      </h2>
 
       <dl class="log-credits">
         <template v-if="concertLog.conductor">
@@ -120,6 +122,21 @@ const emit = defineEmits<{
     "SOFT" 50;
 }
 
+.log-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.log-title a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.log-title a:hover {
+  color: var(--color-accent);
+}
+
 .log-credits {
   display: grid;
   grid-template-columns: minmax(80px, auto) 1fr;
@@ -145,6 +162,8 @@ const emit = defineEmits<{
   gap: 0.5rem;
   flex-shrink: 0;
   align-items: flex-end;
+  position: relative;
+  z-index: 1;
 }
 
 @media (max-width: 720px) {

--- a/app/components/molecules/ListeningLogItem.vue
+++ b/app/components/molecules/ListeningLogItem.vue
@@ -23,9 +23,7 @@ const emit = defineEmits<{
       </div>
 
       <h2 class="log-title">
-        <NuxtLink :to="`/listening-logs/${listeningLog.id}`">
-          {{ listeningLog.piece }}
-        </NuxtLink>
+        <NuxtLink :to="`/listening-logs/${listeningLog.id}`">{{ listeningLog.piece }}</NuxtLink>
       </h2>
 
       <div class="log-rating">
@@ -124,7 +122,12 @@ const emit = defineEmits<{
 .log-title a {
   color: var(--color-text);
   text-decoration: none;
-  transition: color 0.25s ease;
+}
+
+.log-title a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
 }
 
 .log-title a:hover {
@@ -160,6 +163,8 @@ const emit = defineEmits<{
   gap: 0.5rem;
   flex-shrink: 0;
   align-items: flex-end;
+  position: relative;
+  z-index: 1;
 }
 
 @media (max-width: 720px) {

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -38,7 +38,9 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
 
     <div class="piece-main">
       <p class="piece-composer smallcaps">{{ composerName }}</p>
-      <h2 class="piece-title">{{ piece.title }}</h2>
+      <h2 class="piece-title">
+        <NuxtLink :to="`/pieces/${piece.id}`">{{ piece.title }}</NuxtLink>
+      </h2>
       <div class="piece-category-wrapper">
         <PieceCategoryList :piece="piece" />
       </div>
@@ -91,6 +93,7 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
 
 .piece-thumbnail {
   position: relative;
+  z-index: 1;
   flex-shrink: 0;
   padding: 0;
   margin: 0;
@@ -165,6 +168,21 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
     "SOFT" 50;
 }
 
+.piece-title a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.piece-title a::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+}
+
+.piece-title a:hover {
+  color: var(--color-accent);
+}
+
 .piece-category-wrapper {
   margin-top: 0.4rem;
 }
@@ -174,6 +192,8 @@ const thumbnailAlt = computed(() => `${props.piece.title} の動画サムネイ�
   gap: 0.6rem;
   flex-shrink: 0;
   align-items: center;
+  position: relative;
+  z-index: 1;
 }
 
 .btn-detail {


### PR DESCRIPTION
## Summary

- 作曲家・楽曲・鑑賞記録・演奏会の各一覧アイテムで、背景全体をタップ／クリックすると詳細ページへ遷移できるよう変更
- h2 タイトルに `NuxtLink` を配置し、`::after { position: absolute; inset: 0 }` で stretched link パターンを実装
- Edit / Delete / Read ボタンおよびサムネイル再生ボタンは `position: relative; z-index: 1` でリンクの前面に出し、独立したクリック動作を維持

## Test plan

- [ ] 作曲家一覧：行の背景クリックで `/composers/{id}` へ遷移する
- [ ] 楽曲一覧：行の背景クリックで `/pieces/{id}` へ遷移する
- [ ] 鑑賞記録一覧：行の背景クリックで `/listening-logs/{id}` へ遷移する
- [ ] 演奏会一覧：行の背景クリックで `/concert-logs/{id}` へ遷移する
- [ ] Edit / Delete ボタンは引き続き正常に動作する
- [ ] 楽曲アイテムのサムネイル再生ボタンは引き続き正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)