### PR TITLE
fix(pieces): 動画 URL を全削除したときに空配列を送信するよう修正

### DIFF
--- a/app/components/organisms/PieceForm.test.ts
+++ b/app/components/organisms/PieceForm.test.ts
@@ -220,7 +220,7 @@ describe("PieceForm", () => {
       expect(emittedData.videoUrls).toEqual(["https://www.youtube.com/watch?v=abc"]);
     });
 
-    it("空の動画 URL は trim されて送信から除外され、全て空なら undefined", async () => {
+    it("空の動画 URL は trim されて送信から除外され、全て空なら空配列", async () => {
       const wrapper = await mountSuspended(PieceForm, {
         props: {
           composers: mockComposers,
@@ -234,7 +234,7 @@ describe("PieceForm", () => {
       await wrapper.find("form").trigger("submit.prevent");
       const emitted = wrapper.emitted("submit");
       const emittedData = emitted![0][0] as Record<string, unknown>;
-      expect(emittedData.videoUrls).toBeUndefined();
+      expect(emittedData.videoUrls).toEqual([]);
     });
 
     it("複数の動画 URL を配列として送信できる", async () => {

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -87,7 +87,7 @@ function handleSubmit() {
   emit("submit", {
     title: form.title,
     composerId: form.composerId,
-    videoUrls: trimmedVideoUrls.length === 0 ? undefined : trimmedVideoUrls,
+    videoUrls: trimmedVideoUrls.length === 0 ? [] : trimmedVideoUrls,
     genre: (form.genre === "" ? undefined : form.genre) as CreatePieceInput["genre"],
     era: (form.era === "" ? undefined : form.era) as CreatePieceInput["era"],
     formation: (form.formation === ""


### PR DESCRIPTION
Closes #637

## Summary

- `PieceForm.vue` で動画 URL をすべて削除して送信すると、`videoUrls: undefined` が送信されていたバグを修正
- SPEC では「`videoUrls` は空配列 `[]` で削除」と定義されているが、実装が `undefined` を送信していたため、バックエンドがフィールドの変更なしと判断し削除されなかった
- `undefined` → `[]` に修正し、テストの期待値も合わせて更新

## Test plan

- [ ] `pnpm run test:frontend` がグリーン（修正済み）
- [ ] 楽曲マスタ編集ページで動画 URL を全削除して保存すると、URL が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)