### PR TITLE
feat(pieces): 楽章コンポジットのリポジトリ実装と parentId-index GSI を追加

### DIFF
--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -28,12 +28,10 @@ const MOVEMENT_CLEARABLE_FIELDS = ["videoUrls"] as const;
  *
  * - root 限定列挙: `findRootById` / `findRootPage` は Work のみを返す（Movement は除外）
  * - `removeWorkCascade(id)`: Work 削除時に配下 Movement もまとめて削除
- * - Movement 単体取得は `findById`（kind-agnostic）で行う。Work 配下の Movement 一覧は
- *   PR2 で root を取得する API（アグリゲートとして Work と Movement をまとめて返す）を
- *   追加して提供する想定。子要素単独の列挙クエリ（旧 `findChildren`）は持たない
+ * - `findChildren(parentId)`: 親 Work 配下の Movement を `index` 昇順で全件取得
+ *   （新 GSI `parentId-index-index` を Query。楽章は最大 {@link MOVEMENTS_PER_WORK_MAX} 件想定）
+ * - Movement 単体取得は `findById`（kind-agnostic）で行う
  * - `replaceMovements(workId, movements)`: Movement 集合をアトミックに置換（PR3 で使用）
- *
- * 実装は PR2 で行う（PR1 では型のみ宣言）。
  */
 export type PieceRepository = {
   /** Work のみを返す（Movement は undefined を返す）。 */
@@ -49,6 +47,8 @@ export type PieceRepository = {
 
   /** kind を問わず id で取得する。Work でも Movement でも返す。 */
   findById(id: PieceId): Promise<Piece | undefined>;
+  /** 親 Work 配下の Movement を `index` 昇順で全件取得する。 */
+  findChildren(parentId: PieceId): Promise<PieceMovement[]>;
   saveMovement(movement: PieceMovement): Promise<void>;
   saveMovementWithOptimisticLock(movement: PieceMovement, prevUpdatedAt: string): Promise<void>;
   removeMovement(id: PieceId): Promise<void>;

--- a/backend/src/repositories/piece-repository.test.ts
+++ b/backend/src/repositories/piece-repository.test.ts
@@ -1,7 +1,31 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { PieceId } from "../domain/value-objects/ids";
+import type { Piece, PieceMovement, PieceWork } from "../types";
 import { DynamoDBPieceRepository } from "./piece-repository";
-import type { Piece } from "../types";
+
+const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
+
+vi.mock("@aws-sdk/client-dynamodb", () => ({
+  DynamoDBClient: vi.fn(),
+  ConditionalCheckFailedException: class ConditionalCheckFailedException extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = "ConditionalCheckFailedException";
+    }
+  },
+}));
+
+vi.mock("@aws-sdk/lib-dynamodb", async () => {
+  const actual =
+    await vi.importActual<typeof import("@aws-sdk/lib-dynamodb")>("@aws-sdk/lib-dynamodb");
+  return {
+    ...actual,
+    DynamoDBDocumentClient: {
+      from: vi.fn().mockReturnValue({ send: mockSend }),
+    },
+  };
+});
 
 const normalizeLegacyVideoUrl = DynamoDBPieceRepository.normalizeLegacyVideoUrl;
 
@@ -53,5 +77,200 @@ describe("normalizeLegacyVideoUrl", () => {
     const result = normalizeLegacyVideoUrl(data);
     expect(result?.videoUrls).toEqual(["https://new.example/video"]);
     expect((result as Piece & { videoUrl?: string }).videoUrl).toBeUndefined();
+  });
+});
+
+describe("normalizeLegacyKind", () => {
+  it("undefined はそのまま undefined を返す", () => {
+    expect(DynamoDBPieceRepository.normalizeLegacyKind(undefined)).toBeUndefined();
+  });
+
+  it("kind を持たない既存レコードは kind: 'work' を補完する", () => {
+    const legacy = {
+      id: "piece-1",
+      title: "交響曲第9番",
+      composerId: "00000000-0000-4000-8000-000000000001",
+      createdAt: "2024-01-15T20:00:00.000Z",
+      updatedAt: "2024-01-15T20:00:00.000Z",
+    } as unknown as Piece;
+    const result = DynamoDBPieceRepository.normalizeLegacyKind(legacy);
+    expect(result?.kind).toBe("work");
+  });
+
+  it("kind: 'work' を持つレコードはそのまま返す", () => {
+    const result = DynamoDBPieceRepository.normalizeLegacyKind(basePiece);
+    expect(result).toEqual(basePiece);
+  });
+
+  it("kind: 'movement' を持つレコードはそのまま返す", () => {
+    const movement: PieceMovement = {
+      kind: "movement",
+      id: "movement-1",
+      parentId: "piece-1",
+      index: 0,
+      title: "第1楽章",
+      createdAt: "2024-01-15T20:00:00.000Z",
+      updatedAt: "2024-01-15T20:00:00.000Z",
+    };
+    const result = DynamoDBPieceRepository.normalizeLegacyKind(movement);
+    expect(result).toEqual(movement);
+  });
+});
+
+const PARENT_ID = "00000000-0000-4000-8000-00000000aaaa";
+const CHILD_1_ID = "00000000-0000-4000-8000-00000000bbb1";
+const CHILD_2_ID = "00000000-0000-4000-8000-00000000bbb2";
+
+const makeMovement = (id: string, index: number, parentId = PARENT_ID): PieceMovement => ({
+  kind: "movement",
+  id,
+  parentId,
+  index,
+  title: `第${index + 1}楽章`,
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+});
+
+describe("findChildren", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+  });
+
+  it("parentId-index-index GSI を Query して Movement を index 昇順で返す", async () => {
+    const child1 = makeMovement(CHILD_1_ID, 0);
+    const child2 = makeMovement(CHILD_2_ID, 1);
+    mockSend.mockResolvedValueOnce({ Items: [child1, child2], LastEvaluatedKey: undefined });
+
+    const repo = new DynamoDBPieceRepository();
+    const result = await repo.findChildren(PieceId.from(PARENT_ID));
+
+    expect(result).toEqual([child1, child2]);
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const queryArg = mockSend.mock.calls[0]?.[0];
+    expect(queryArg?.input?.IndexName).toBe("parentId-index-index");
+    expect(queryArg?.input?.KeyConditionExpression).toBe("parentId = :parentId");
+    expect(queryArg?.input?.ExpressionAttributeValues?.[":parentId"]).toBe(PARENT_ID);
+  });
+
+  it("LastEvaluatedKey が返ったら次ページも取得する", async () => {
+    const child1 = makeMovement(CHILD_1_ID, 0);
+    const child2 = makeMovement(CHILD_2_ID, 1);
+    const cursor = { id: child1.id, parentId: PARENT_ID, index: 0 };
+    mockSend
+      .mockResolvedValueOnce({ Items: [child1], LastEvaluatedKey: cursor })
+      .mockResolvedValueOnce({ Items: [child2], LastEvaluatedKey: undefined });
+
+    const repo = new DynamoDBPieceRepository();
+    const result = await repo.findChildren(PieceId.from(PARENT_ID));
+
+    expect(result).toEqual([child1, child2]);
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const secondQuery = mockSend.mock.calls[1]?.[0];
+    expect(secondQuery?.input?.ExclusiveStartKey).toEqual(cursor);
+  });
+
+  it("Work レコードが紛れ込んだ場合は除外する", async () => {
+    const child = makeMovement(CHILD_1_ID, 0);
+    const intruderWork: PieceWork = { ...basePiece, id: "intruder" } as PieceWork;
+    mockSend.mockResolvedValueOnce({
+      Items: [child, intruderWork],
+      LastEvaluatedKey: undefined,
+    });
+
+    const repo = new DynamoDBPieceRepository();
+    const result = await repo.findChildren(PieceId.from(PARENT_ID));
+
+    expect(result).toEqual([child]);
+  });
+
+  it("該当 Movement が無い場合は空配列を返す", async () => {
+    mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+    const repo = new DynamoDBPieceRepository();
+    const result = await repo.findChildren(PieceId.from(PARENT_ID));
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("removeWorkCascade", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+  });
+
+  it("子 Movement が無い場合は単純な DeleteCommand を発行する", async () => {
+    mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    mockSend.mockResolvedValueOnce({});
+
+    const repo = new DynamoDBPieceRepository();
+    await repo.removeWorkCascade(PieceId.from(PARENT_ID));
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const deleteArg = mockSend.mock.calls[1]?.[0];
+    expect(deleteArg?.input?.Key).toEqual({ id: PARENT_ID });
+    expect(deleteArg?.input?.TableName).toBeDefined();
+  });
+
+  it("子 Movement がある場合は TransactWriteItems で Work と Movement を一括削除する", async () => {
+    const child1 = makeMovement(CHILD_1_ID, 0);
+    const child2 = makeMovement(CHILD_2_ID, 1);
+    mockSend.mockResolvedValueOnce({ Items: [child1, child2], LastEvaluatedKey: undefined });
+    mockSend.mockResolvedValueOnce({});
+
+    const repo = new DynamoDBPieceRepository();
+    await repo.removeWorkCascade(PieceId.from(PARENT_ID));
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const txArg = mockSend.mock.calls[1]?.[0];
+    const transactItems = txArg?.input?.TransactItems;
+    expect(transactItems).toHaveLength(3);
+    expect(transactItems?.[0]?.Delete?.Key).toEqual({ id: PARENT_ID });
+    expect(transactItems?.[1]?.Delete?.Key).toEqual({ id: CHILD_1_ID });
+    expect(transactItems?.[2]?.Delete?.Key).toEqual({ id: CHILD_2_ID });
+  });
+});
+
+describe("replaceMovements", () => {
+  beforeEach(() => {
+    mockSend.mockReset();
+  });
+
+  it("既存子の Delete + 新規 Put を 1 つの TransactWriteItems で実行する", async () => {
+    const existing = makeMovement(CHILD_1_ID, 0);
+    const next1 = makeMovement(CHILD_2_ID, 0);
+    const next2 = makeMovement("00000000-0000-4000-8000-00000000bbb3", 1);
+    mockSend.mockResolvedValueOnce({ Items: [existing], LastEvaluatedKey: undefined });
+    mockSend.mockResolvedValueOnce({});
+
+    const repo = new DynamoDBPieceRepository();
+    await repo.replaceMovements(PieceId.from(PARENT_ID), [next1, next2]);
+
+    expect(mockSend).toHaveBeenCalledTimes(2);
+    const txArg = mockSend.mock.calls[1]?.[0];
+    const transactItems = txArg?.input?.TransactItems;
+    expect(transactItems).toHaveLength(3);
+    expect(transactItems?.[0]?.Delete?.Key).toEqual({ id: CHILD_1_ID });
+    expect(transactItems?.[1]?.Put?.Item).toEqual(next1);
+    expect(transactItems?.[2]?.Put?.Item).toEqual(next2);
+  });
+
+  it("既存子も新規 Movement も 0 件の場合は何もしない（送信 0 回）", async () => {
+    mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+
+    const repo = new DynamoDBPieceRepository();
+    await repo.replaceMovements(PieceId.from(PARENT_ID), []);
+
+    // findChildren のクエリだけ。TransactWrite は呼ばれない。
+    expect(mockSend).toHaveBeenCalledTimes(1);
+  });
+
+  it("parentId が一致しない Movement が混ざっている場合は例外を投げる", async () => {
+    const wrongParent = makeMovement(CHILD_1_ID, 0, "00000000-0000-4000-8000-00000000ffff");
+
+    const repo = new DynamoDBPieceRepository();
+    await expect(repo.replaceMovements(PieceId.from(PARENT_ID), [wrongParent])).rejects.toThrow(
+      /All movements must belong to the specified workId/,
+    );
+    expect(mockSend).not.toHaveBeenCalled();
   });
 });

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -1,4 +1,10 @@
-import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
+import {
+  DeleteCommand,
+  GetCommand,
+  PutCommand,
+  QueryCommand,
+  TransactWriteCommand,
+} from "@aws-sdk/lib-dynamodb";
 
 import type { PieceRepository } from "../domain/piece";
 import type { PieceId } from "../domain/value-objects/ids";
@@ -6,6 +12,18 @@ import type { Piece, PieceMovement, PieceWork } from "../types";
 import { dynamo, putItemWithOptimisticLock, scanPage, TABLE_PIECES } from "../utils/dynamodb";
 
 type LegacyVideoUrlPiece = Piece & { videoUrl?: string };
+
+/**
+ * `parentId-index-index` GSI で Movement を演奏順取得するためのインデックス名。
+ * CDK の `piecesTable.addGlobalSecondaryIndex` と一致させる。
+ */
+const MOVEMENTS_GSI_INDEX_NAME = "parentId-index-index";
+
+/**
+ * 1 トランザクションで TransactWriteItems に渡せる最大件数（DynamoDB の上限）。
+ * 既存子の Delete + 新規 Put + Work 1 件で運用しても収まるよう、ハード上限値で扱う。
+ */
+const TRANSACT_WRITE_MAX_ITEMS = 100;
 
 export class DynamoDBPieceRepository implements PieceRepository {
   /**
@@ -30,9 +48,10 @@ export class DynamoDBPieceRepository implements PieceRepository {
 
   /**
    * 既存 DB レコード（`kind` を持たない）を Composite モデルに合わせて補完する。
-   * 既存データは全て Work として扱う（Movement は PR2 以降で書き込みを開始）。
+   * `kind` バックフィル移行（PR4）の完了前でも既存データを Work として読めるようにする。
+   * 書き込みは常に `kind` を含むため、上書きで自然に正規化される。
    */
-  private static normalizeKind(item: Piece | undefined): Piece | undefined {
+  static normalizeLegacyKind(item: Piece | undefined): Piece | undefined {
     if (item === undefined) {
       return undefined;
     }
@@ -44,7 +63,7 @@ export class DynamoDBPieceRepository implements PieceRepository {
   }
 
   private static readPiece(item: Piece | undefined): Piece | undefined {
-    return DynamoDBPieceRepository.normalizeKind(
+    return DynamoDBPieceRepository.normalizeLegacyKind(
       DynamoDBPieceRepository.normalizeLegacyVideoUrl(item),
     );
   }
@@ -89,11 +108,33 @@ export class DynamoDBPieceRepository implements PieceRepository {
     });
   }
 
+  /**
+   * Work 削除時に配下 Movement もまとめて削除する。
+   * Movement 集合は `parentId-index-index` GSI から取得し、Work + Movement を
+   * 1 つの TransactWriteItems で原子的に削除する。
+   */
   async removeWorkCascade(id: PieceId): Promise<void> {
-    // PR1 時点では Movement が DB に存在しないため、Work 単体の削除と等価。
-    // PR2 で root 取得（Work + Movements をアグリゲートで返す API）と合わせて
-    // 子レコードのカスケード削除を有効化する。
-    await dynamo.send(new DeleteCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }));
+    const children = await this.findChildren(id);
+    if (children.length === 0) {
+      await dynamo.send(new DeleteCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }));
+      return;
+    }
+    const totalItems = children.length + 1;
+    if (totalItems > TRANSACT_WRITE_MAX_ITEMS) {
+      throw new Error(
+        `Work cascade exceeds DynamoDB transaction limit (${totalItems} > ${TRANSACT_WRITE_MAX_ITEMS})`,
+      );
+    }
+    await dynamo.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          { Delete: { TableName: TABLE_PIECES, Key: { id: id.value } } },
+          ...children.map((m) => ({
+            Delete: { TableName: TABLE_PIECES, Key: { id: m.id } },
+          })),
+        ],
+      }),
+    );
   }
 
   async findById(id: PieceId): Promise<Piece | undefined> {
@@ -101,6 +142,33 @@ export class DynamoDBPieceRepository implements PieceRepository {
       new GetCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }),
     );
     return DynamoDBPieceRepository.readPiece(result.Item as Piece | undefined);
+  }
+
+  /**
+   * 親 Work 配下の Movement を `parentId-index-index` GSI で `index` 昇順に全件取得する。
+   * `Limit` は付けず（楽章は最大 {@link MOVEMENTS_PER_WORK_MAX} 件想定）、
+   * 1 ページに収まらない場合は `LastEvaluatedKey` で全件を吸収する。
+   */
+  async findChildren(parentId: PieceId): Promise<PieceMovement[]> {
+    const items: PieceMovement[] = [];
+    let exclusiveStartKey: Record<string, unknown> | undefined;
+    do {
+      const result = await dynamo.send(
+        new QueryCommand({
+          TableName: TABLE_PIECES,
+          IndexName: MOVEMENTS_GSI_INDEX_NAME,
+          KeyConditionExpression: "parentId = :parentId",
+          ExpressionAttributeValues: { ":parentId": parentId.value },
+          ExclusiveStartKey: exclusiveStartKey,
+        }),
+      );
+      const page = (result.Items ?? [])
+        .map((raw) => DynamoDBPieceRepository.readPiece(raw as Piece | undefined))
+        .filter(DynamoDBPieceRepository.isMovement);
+      items.push(...page);
+      exclusiveStartKey = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (exclusiveStartKey !== undefined);
+    return items;
   }
 
   async saveMovement(movement: PieceMovement): Promise<void> {
@@ -127,10 +195,39 @@ export class DynamoDBPieceRepository implements PieceRepository {
     await dynamo.send(new DeleteCommand({ TableName: TABLE_PIECES, Key: { id: id.value } }));
   }
 
-  async replaceMovements(_workId: PieceId, _movements: PieceMovement[]): Promise<void> {
-    // PR3 で実装する。PR1 時点ではエンドポイントが無いためスタブのまま。
-    void _workId;
-    void _movements;
-    throw new Error("replaceMovements is not implemented yet (PR3)");
+  /**
+   * Work 配下の Movement 集合をアトミックに置換する。
+   * 既存の子要素を全て削除し、新しい子要素を Put する操作を 1 つの
+   * TransactWriteItems で実行する。並び替え・追加・削除の混在も同時に反映される。
+   *
+   * DynamoDB の TransactWriteItems は 1 トランザクション最大 100 アイテムのため、
+   * `(既存件数 + 新規件数)` が 100 を超える場合はエラーを投げる。
+   */
+  async replaceMovements(workId: PieceId, movements: PieceMovement[]): Promise<void> {
+    if (movements.some((m) => m.parentId !== workId.value)) {
+      throw new Error("All movements must belong to the specified workId");
+    }
+    const existing = await this.findChildren(workId);
+    const totalItems = existing.length + movements.length;
+    if (totalItems > TRANSACT_WRITE_MAX_ITEMS) {
+      throw new Error(
+        `replaceMovements exceeds DynamoDB transaction limit (${totalItems} > ${TRANSACT_WRITE_MAX_ITEMS})`,
+      );
+    }
+    if (totalItems === 0) {
+      return;
+    }
+    await dynamo.send(
+      new TransactWriteCommand({
+        TransactItems: [
+          ...existing.map((m) => ({
+            Delete: { TableName: TABLE_PIECES, Key: { id: m.id } },
+          })),
+          ...movements.map((m) => ({
+            Put: { TableName: TABLE_PIECES, Item: m },
+          })),
+        ],
+      }),
+    );
   }
 }

--- a/backend/src/usecases/piece-usecase.test.ts
+++ b/backend/src/usecases/piece-usecase.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import type { PieceRepository } from "../domain/piece";
+import { PieceId } from "../domain/value-objects/ids";
+import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "../types";
+import { MovementUsecase, PieceUsecase, WorkUsecase } from "./piece-usecase";
+
+const TEST_COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
+const TEST_WORK_ID = "00000000-0000-4000-8000-00000000aaaa";
+const TEST_MOVEMENT_ID = "00000000-0000-4000-8000-00000000bbbb";
+
+const makeMockRepo = (): PieceRepository => ({
+  findRootById: vi.fn(),
+  findRootPage: vi.fn(),
+  saveWork: vi.fn(),
+  saveWorkWithOptimisticLock: vi.fn(),
+  removeWorkCascade: vi.fn(),
+  findById: vi.fn(),
+  findChildren: vi.fn(),
+  saveMovement: vi.fn(),
+  saveMovementWithOptimisticLock: vi.fn(),
+  removeMovement: vi.fn(),
+  replaceMovements: vi.fn(),
+});
+
+const makeWork = (overrides: Partial<PieceWork> = {}): PieceWork => ({
+  kind: "work",
+  id: TEST_WORK_ID,
+  title: "交響曲第9番",
+  composerId: TEST_COMPOSER_ID,
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+  ...overrides,
+});
+
+const makeMovement = (overrides: Partial<PieceMovement> = {}): PieceMovement => ({
+  kind: "movement",
+  id: TEST_MOVEMENT_ID,
+  parentId: TEST_WORK_ID,
+  index: 0,
+  title: "第1楽章",
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+  ...overrides,
+});
+
+describe("WorkUsecase", () => {
+  let repo: PieceRepository;
+  let usecase: WorkUsecase;
+
+  beforeEach(() => {
+    repo = makeMockRepo();
+    usecase = new WorkUsecase(repo);
+  });
+
+  describe("create", () => {
+    it("Work を生成して saveWork を呼び出す", async () => {
+      const input: CreateWorkInput = {
+        kind: "work",
+        title: "交響曲第9番",
+        composerId: TEST_COMPOSER_ID,
+      };
+      const result = await usecase.create(input);
+
+      expect(result.kind).toBe("work");
+      expect(result.title).toBe("交響曲第9番");
+      expect(result.composerId).toBe(TEST_COMPOSER_ID);
+      expect(result.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(repo.saveWork).toHaveBeenCalledWith(result);
+    });
+  });
+
+  describe("get", () => {
+    it("findRootById で取得した Work を返す", async () => {
+      const work = makeWork();
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(work);
+
+      const result = await usecase.get(PieceId.from(TEST_WORK_ID));
+
+      expect(result).toEqual(work);
+    });
+
+    it("Work が存在しない場合は NotFound 相当のエラー（404 Status）を投げる", async () => {
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(undefined);
+
+      await expect(usecase.get(PieceId.from(TEST_WORK_ID))).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe("update", () => {
+    it("既存 Work を更新して楽観的ロック付きで保存する", async () => {
+      const existing = makeWork();
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(existing);
+
+      const result = await usecase.update(PieceId.from(TEST_WORK_ID), {
+        kind: "work",
+        title: "更新後タイトル",
+      });
+
+      expect(result.title).toBe("更新後タイトル");
+      expect(repo.saveWorkWithOptimisticLock).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "更新後タイトル" }),
+        existing.updatedAt,
+      );
+    });
+  });
+
+  describe("delete", () => {
+    it("removeWorkCascade を呼び出す", async () => {
+      await usecase.delete(PieceId.from(TEST_WORK_ID));
+      expect(repo.removeWorkCascade).toHaveBeenCalledWith(
+        expect.objectContaining({ value: TEST_WORK_ID }),
+      );
+    });
+  });
+
+  describe("list", () => {
+    it("findRootPage を呼び出して Paginated を返す", async () => {
+      vi.mocked(repo.findRootPage).mockResolvedValueOnce({
+        items: [makeWork()],
+        lastEvaluatedKey: undefined,
+      });
+
+      const result = await usecase.list({ limit: 10 });
+
+      expect(result.items).toHaveLength(1);
+      expect(result.nextCursor).toBeNull();
+    });
+  });
+});
+
+describe("MovementUsecase", () => {
+  let repo: PieceRepository;
+  let usecase: MovementUsecase;
+
+  beforeEach(() => {
+    repo = makeMockRepo();
+    usecase = new MovementUsecase(repo);
+  });
+
+  describe("create", () => {
+    it("Movement を生成して saveMovement を呼び出す", async () => {
+      const input: CreateMovementInput = {
+        kind: "movement",
+        parentId: TEST_WORK_ID,
+        index: 0,
+        title: "第1楽章",
+      };
+      const result = await usecase.create(input);
+
+      expect(result.kind).toBe("movement");
+      expect(result.parentId).toBe(TEST_WORK_ID);
+      expect(result.index).toBe(0);
+      expect(repo.saveMovement).toHaveBeenCalledWith(result);
+    });
+  });
+
+  describe("get", () => {
+    it("Movement を返す", async () => {
+      const movement = makeMovement();
+      vi.mocked(repo.findById).mockResolvedValueOnce(movement);
+
+      const result = await usecase.get(PieceId.from(TEST_MOVEMENT_ID));
+
+      expect(result).toEqual(movement);
+    });
+
+    it("Work が返ってきた場合は 404", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeWork());
+
+      await expect(usecase.get(PieceId.from(TEST_MOVEMENT_ID))).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+
+    it("undefined の場合は 404", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(undefined);
+
+      await expect(usecase.get(PieceId.from(TEST_MOVEMENT_ID))).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe("update", () => {
+    it("Movement の楽観的ロック付き保存が走る", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeMovement());
+
+      await usecase.update(PieceId.from(TEST_MOVEMENT_ID), {
+        kind: "movement",
+        title: "改題",
+      });
+
+      expect(repo.saveMovementWithOptimisticLock).toHaveBeenCalled();
+    });
+  });
+
+  describe("delete", () => {
+    it("removeMovement を呼び出す", async () => {
+      await usecase.delete(PieceId.from(TEST_MOVEMENT_ID));
+      expect(repo.removeMovement).toHaveBeenCalled();
+    });
+  });
+
+  describe("listChildren", () => {
+    it("findChildren の結果をそのまま返す", async () => {
+      const m = makeMovement();
+      vi.mocked(repo.findChildren).mockResolvedValueOnce([m]);
+
+      const result = await usecase.listChildren(PieceId.from(TEST_WORK_ID));
+
+      expect(result).toEqual([m]);
+    });
+  });
+
+  describe("replaceMovements", () => {
+    it("replaceMovements リポジトリ操作に委譲する", async () => {
+      const m = makeMovement();
+      await usecase.replaceMovements(PieceId.from(TEST_WORK_ID), [m]);
+      expect(repo.replaceMovements).toHaveBeenCalledWith(
+        expect.objectContaining({ value: TEST_WORK_ID }),
+        [m],
+      );
+    });
+  });
+});
+
+describe("PieceUsecase (facade)", () => {
+  let repo: PieceRepository;
+  let usecase: PieceUsecase;
+
+  beforeEach(() => {
+    repo = makeMockRepo();
+    usecase = new PieceUsecase(repo);
+  });
+
+  describe("create", () => {
+    it("kind=work の場合は Work を作成する", async () => {
+      const result = await usecase.create({
+        kind: "work",
+        title: "交響曲第9番",
+        composerId: TEST_COMPOSER_ID,
+      });
+      expect(result.kind).toBe("work");
+      expect(repo.saveWork).toHaveBeenCalled();
+      expect(repo.saveMovement).not.toHaveBeenCalled();
+    });
+
+    it("kind=movement の場合は Movement を作成する", async () => {
+      const result = await usecase.create({
+        kind: "movement",
+        parentId: TEST_WORK_ID,
+        index: 0,
+        title: "第1楽章",
+      });
+      expect(result.kind).toBe("movement");
+      expect(repo.saveMovement).toHaveBeenCalled();
+      expect(repo.saveWork).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getNode", () => {
+    it("Work でも Movement でも kind を問わず取得できる", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeMovement());
+
+      const result = await usecase.getNode(PieceId.from(TEST_MOVEMENT_ID));
+
+      expect(result.kind).toBe("movement");
+    });
+
+    it("見つからない場合は 404", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(undefined);
+
+      await expect(usecase.getNode(PieceId.from(TEST_MOVEMENT_ID))).rejects.toMatchObject({
+        statusCode: 404,
+      });
+    });
+  });
+
+  describe("update", () => {
+    it("Work レコードに対する update は saveWorkWithOptimisticLock を呼ぶ", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeWork());
+
+      await usecase.update(PieceId.from(TEST_WORK_ID), { kind: "work", title: "改題" });
+
+      expect(repo.saveWorkWithOptimisticLock).toHaveBeenCalled();
+      expect(repo.saveMovementWithOptimisticLock).not.toHaveBeenCalled();
+    });
+
+    it("Movement レコードに対する update は saveMovementWithOptimisticLock を呼ぶ", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeMovement());
+
+      await usecase.update(PieceId.from(TEST_MOVEMENT_ID), { kind: "movement", title: "改題" });
+
+      expect(repo.saveMovementWithOptimisticLock).toHaveBeenCalled();
+      expect(repo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
+    });
+
+    it("kind 不一致は TypeError", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeWork());
+
+      await expect(
+        usecase.update(PieceId.from(TEST_WORK_ID), { kind: "movement", title: "改題" }),
+      ).rejects.toThrow(TypeError);
+    });
+  });
+});

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -1,8 +1,21 @@
+import createError from "http-errors";
+
 import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "../domain/piece";
 import type { PieceRepository } from "../domain/piece";
 import { PieceId } from "../domain/value-objects/ids";
 import { DynamoDBPieceRepository } from "../repositories/piece-repository";
-import type { CreatePieceInput, Paginated, Piece, PieceWork, UpdatePieceInput } from "../types";
+import type {
+  CreateMovementInput,
+  CreatePieceInput,
+  CreateWorkInput,
+  Paginated,
+  Piece,
+  PieceMovement,
+  PieceWork,
+  UpdateMovementInput,
+  UpdatePieceInput,
+  UpdateWorkInput,
+} from "../types";
 import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
@@ -11,48 +24,39 @@ export { PieceId };
 const ENTITY_NAME = "Piece";
 
 /**
- * 楽曲マスタのユースケース。
+ * Work（親楽曲）専用ユースケース。
  *
- * - PR1 時点で公開している API は引き続き Work（親楽曲）のみを対象とする
- *   （`list` は `findRootPage` で Work だけを列挙、`get`/`update`/`delete` も Work 限定）。
- * - 内部ではドメインの Composite モデル（Work / Movement）と新リポジトリ I/F を利用する。
- * - Movement 系のエンドポイントは PR2 以降で追加する。
+ * - リスト・取得は root（Work）のみを返す（`findRootPage` / `findRootById` 経由）。
+ * - 削除は `removeWorkCascade` で配下 Movement までまとめて削除する。
+ * - Movement の操作は {@link MovementUsecase} を使うこと。
  */
-export class PieceUsecase {
+export class WorkUsecase {
   constructor(private readonly repo: PieceRepository) {}
 
-  async create(input: CreatePieceInput): Promise<Piece> {
-    const entity = PieceComponent.create(input);
+  async create(input: CreateWorkInput): Promise<PieceWork> {
+    const entity = PieceWorkEntity.create(input);
     const plain = entity.toPlain();
-    if (entity instanceof PieceWorkEntity) {
-      await this.repo.saveWork(plain as PieceWork);
-    } else if (entity instanceof PieceMovementEntity) {
-      await this.repo.saveMovement(entity.toPlain());
-    }
+    await this.repo.saveWork(plain);
     return plain;
   }
 
   async list(options: {
     limit: number;
     exclusiveStartKey?: Record<string, unknown>;
-  }): Promise<Paginated<Piece>> {
+  }): Promise<Paginated<PieceWork>> {
     return toPaginatedResult(await this.repo.findRootPage(options));
   }
 
-  async get(id: PieceId): Promise<Piece> {
+  async get(id: PieceId): Promise<PieceWork> {
     return findByIdOrNotFound((id) => this.repo.findRootById(id), id, ENTITY_NAME);
   }
 
-  async update(id: PieceId, input: UpdatePieceInput): Promise<Piece> {
-    const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
-    const entity = PieceComponent.reconstruct(current);
-    const updated = PieceComponent.applyUpdate(entity, input);
+  async update(id: PieceId, input: UpdateWorkInput): Promise<PieceWork> {
+    const current = await findByIdOrNotFound((id) => this.repo.findRootById(id), id, ENTITY_NAME);
+    const entity = PieceWorkEntity.reconstruct(current);
+    const updated = entity.mergeUpdate(input);
     const plain = updated.toPlain();
-    if (updated instanceof PieceWorkEntity) {
-      await this.repo.saveWorkWithOptimisticLock(plain as PieceWork, current.updatedAt);
-    } else {
-      await this.repo.saveMovementWithOptimisticLock(updated.toPlain(), current.updatedAt);
-    }
+    await this.repo.saveWorkWithOptimisticLock(plain, current.updatedAt);
     return plain;
   }
 
@@ -61,4 +65,116 @@ export class PieceUsecase {
   }
 }
 
-export const createPieceUsecase = () => new PieceUsecase(new DynamoDBPieceRepository());
+/**
+ * Movement（楽章）専用ユースケース。
+ *
+ * - 取得・更新・削除は kind を Movement に限定する（Work が紛れ込んだら 404 扱い）。
+ * - 集合操作 `replaceMovements` は PR3 のエンドポイントから呼ばれる。
+ */
+export class MovementUsecase {
+  constructor(private readonly repo: PieceRepository) {}
+
+  async create(input: CreateMovementInput): Promise<PieceMovement> {
+    const entity = PieceMovementEntity.create(input);
+    const plain = entity.toPlain();
+    await this.repo.saveMovement(plain);
+    return plain;
+  }
+
+  async get(id: PieceId): Promise<PieceMovement> {
+    const item = await this.repo.findById(id);
+    if (item === undefined || item.kind !== "movement") {
+      throw new createError.NotFound(`${ENTITY_NAME} not found`);
+    }
+    return item;
+  }
+
+  async update(id: PieceId, input: UpdateMovementInput): Promise<PieceMovement> {
+    const current = await this.get(id);
+    const entity = PieceMovementEntity.reconstruct(current);
+    const updated = entity.mergeUpdate(input);
+    const plain = updated.toPlain();
+    await this.repo.saveMovementWithOptimisticLock(plain, current.updatedAt);
+    return plain;
+  }
+
+  async delete(id: PieceId): Promise<void> {
+    await this.repo.removeMovement(id);
+  }
+
+  async listChildren(parentId: PieceId): Promise<PieceMovement[]> {
+    return this.repo.findChildren(parentId);
+  }
+
+  async replaceMovements(workId: PieceId, movements: PieceMovement[]): Promise<void> {
+    await this.repo.replaceMovements(workId, movements);
+  }
+}
+
+/**
+ * `/pieces` ハンドラ向けの Composite ファサード。
+ *
+ * - 既存ハンドラ（`POST /pieces` 等）は kind に応じた dispatch を期待しており、
+ *   このファサードを介して Work / Movement それぞれのユースケースに振り分ける。
+ * - `getNode(id)` は kind を問わず単一ノードを取得する（PR3 で `/pieces/{id}/children` などから利用予定）。
+ * - `list` / `get` の振る舞いは root（Work）限定で従来通り。
+ */
+export class PieceUsecase {
+  private readonly work: WorkUsecase;
+  private readonly movement: MovementUsecase;
+
+  constructor(private readonly repo: PieceRepository) {
+    this.work = new WorkUsecase(repo);
+    this.movement = new MovementUsecase(repo);
+  }
+
+  async create(input: CreatePieceInput): Promise<Piece> {
+    if (input.kind === "work") {
+      return this.work.create(input);
+    }
+    return this.movement.create(input);
+  }
+
+  async list(options: {
+    limit: number;
+    exclusiveStartKey?: Record<string, unknown>;
+  }): Promise<Paginated<PieceWork>> {
+    return this.work.list(options);
+  }
+
+  async get(id: PieceId): Promise<PieceWork> {
+    return this.work.get(id);
+  }
+
+  /**
+   * kind を問わず単一ノード（Work または Movement）を取得する。
+   * 旧 `kind` 欠落レコードは Repository 側で `kind: "work"` に補完されて返る。
+   */
+  async getNode(id: PieceId): Promise<Piece> {
+    return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
+  }
+
+  async update(id: PieceId, input: UpdatePieceInput): Promise<Piece> {
+    const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
+    const entity = PieceComponent.reconstruct(current);
+    const updated = PieceComponent.applyUpdate(entity, input);
+    if (updated instanceof PieceWorkEntity) {
+      const plain = updated.toPlain();
+      await this.repo.saveWorkWithOptimisticLock(plain, current.updatedAt);
+      return plain;
+    }
+    const plain = updated.toPlain();
+    await this.repo.saveMovementWithOptimisticLock(plain, current.updatedAt);
+    return plain;
+  }
+
+  async delete(id: PieceId): Promise<void> {
+    await this.repo.removeWorkCascade(id);
+  }
+}
+
+export const createWorkUsecase = (): WorkUsecase => new WorkUsecase(new DynamoDBPieceRepository());
+export const createMovementUsecase = (): MovementUsecase =>
+  new MovementUsecase(new DynamoDBPieceRepository());
+export const createPieceUsecase = (): PieceUsecase =>
+  new PieceUsecase(new DynamoDBPieceRepository());

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -83,6 +83,15 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       removalPolicy: cdk.RemovalPolicy.RETAIN,
     });
 
+    // parentId + index でコンポジット楽曲（Work 配下の Movement）を演奏順に取得する GSI。
+    // PartitionKey が parentId のみのため、kind="work" のレコード（parentId 不在）は当該インデックスに射影されない。
+    piecesTable.addGlobalSecondaryIndex({
+      indexName: "parentId-index-index",
+      partitionKey: { name: "parentId", type: dynamodb.AttributeType.STRING },
+      sortKey: { name: "index", type: dynamodb.AttributeType.NUMBER },
+      projectionType: dynamodb.ProjectionType.ALL,
+    });
+
     // -------------------------
     // DynamoDB テーブル（作曲家マスタ）
     // -------------------------

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -444,10 +444,10 @@ classical-music-lake/
 - **リポジトリ I/F**: `PieceRepository` は **root（Work）操作と子（Movement）操作を明確に分ける**
   - root 限定列挙: `findRootById` / `findRootPage` は Work のみを返す（Movement は除外）
   - kind を問わず単体取得: `findById(id)` は Work / Movement のいずれも返す（更新フローで使用）
-  - Movement 一覧は **アグリゲートとして root を取得する API**（PR2 で追加予定。Work と
-    Movements をまとめて返す）に集約する。子要素単独の列挙クエリ（`findChildren`）は
-    持たない（独立に呼ぶユースケースが無いため）
-  - カスケード: `removeWorkCascade(id)` は Work 削除時に配下 Movement もまとめて削除する想定
-  - `replaceMovements(workId, movements)` で Movement 集合をアトミック置換（PR3 で実装）
+  - 子要素列挙: `findChildren(parentId)` は新 GSI `parentId-index-index` を Query して Movement を `index` 昇順で全件取得する。`removeWorkCascade` / `replaceMovements` の前段処理として内部的に利用するほか、PR3 以降の Movement 一覧 API（`GET /pieces/{id}/children`）の基盤となる
+  - カスケード: `removeWorkCascade(id)` は Work 削除時に配下 Movement を `findChildren` で集めて、Work + Movement を 1 つの TransactWriteItems で原子的に削除する
+  - `replaceMovements(workId, movements)` は既存子の Delete + 新規 Put を 1 つの TransactWriteItems で実行する（PR3 のエンドポイントから呼ばれる）。DynamoDB の TransactWriteItems 上限 100 件を超える場合は例外を投げる
 - **バリデーション**: `createPieceSchema` / `updatePieceSchema` は `z.discriminatedUnion("kind", [...])` で Work / Movement を判別する。両 Work / Movement のオブジェクトは `.strict()` で未知フィールドを拒否し、Work に `parentId` / `index` を、Movement に `composerId` / カテゴリ系を含めると 400 を返す
-- **PR1 時点の挙動**: 既存 API のレスポンスに `kind: "work"` が増える以外は互換。Movement 専用エンドポイントは追加していない。`DynamoDBPieceRepository` は既存レコード（`kind` を持たない）を読み込み時に `kind: "work"` で正規化することで後方互換を保つ。Movement の永続化は PR2、Movement 集合の REST エンドポイント追加は PR3 で行う
+- **ユースケース**: `WorkUsecase`（Work 専用）/ `MovementUsecase`（Movement 専用）/ `PieceUsecase`（kind を判別して dispatch するファサード）の 3 種に分割。`/pieces` ハンドラは従来どおり `PieceUsecase` を経由し、`PieceUsecase.getNode(id)` で kind を問わない単一ノード取得をサポートする（PR3 の `/pieces/{id}/children` 等で利用予定）
+- **PR1 時点の挙動**: 既存 API のレスポンスに `kind: "work"` が増える以外は互換。Movement 専用エンドポイントは追加していない。`DynamoDBPieceRepository` は既存レコード（`kind` を持たない）を読み込み時に `kind: "work"` で正規化することで後方互換を保つ
+- **PR2 時点の挙動**: GSI と Movement 集合操作（`findChildren` / `removeWorkCascade` / `replaceMovements`）が利用可能になった。外向き REST エンドポイントは未追加（PR3 で `GET /pieces/{id}/children`・`PUT /pieces/{workId}/movements` を追加予定）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -137,9 +137,10 @@ interface ListeningLog {
 
 - **テーブル名**: `classical-music-pieces`
 - **PK**: `id` (String)
+- **GSI**: `parentId-index-index` — PartitionKey=`parentId` (String) / SortKey=`index` (Number) / ProjectionType=ALL。Work 配下の Movement を `index` 昇順で取得するために使用する（`DynamoDBPieceRepository.findChildren` / `removeWorkCascade` / `replaceMovements` から参照）。Work レコードは `parentId` を持たないため当該 GSI には射影されず、Query は Movement のみを返す
 - **削除ポリシー**: 全環境 RETAIN
 
-楽曲は `kind` で判別されるコンポジット（Work / Movement）として扱う。Work は親楽曲、Movement は楽章であり、同じ DynamoDB テーブルに格納する（PR1 時点では Movement レコードは未作成。kind 不明な既存データは読み込み時に `kind: "work"` を補完する互換ロジックを `DynamoDBPieceRepository` に持つ）。
+楽曲は `kind` で判別されるコンポジット（Work / Movement）として扱う。Work は親楽曲、Movement は楽章であり、同じ DynamoDB テーブルに格納する（kind 不明な既存データは読み込み時に `kind: "work"` を補完する互換ロジックを `DynamoDBPieceRepository` に持つ）。
 
 ```typescript
 type PieceGenre =
@@ -192,6 +193,7 @@ type Piece = PieceWork | PieceMovement;
 > - 2026-04: `composer`（自由入力）→ `composerId`（参照）。旧データは `backend/src/migrations/piece-composer-id/index.ts` で一括変換（`MigrationsStack` に分離。詳細は `docs/OPERATIONS.md`）
 > - 2026-05: `videoUrl`（単一）→ `videoUrls`（配列）。`DynamoDBPieceRepository` の読み込み時に透過的に正規化されるため、明示的な移行 Lambda は持たない
 > - 2026-05: `Piece` を Composite（`PieceWork` / `PieceMovement`）に再設計（PR1）。既存レコードは `kind` を持たないため、`DynamoDBPieceRepository` が読み込み時に `kind: "work"` を補完する。書き込み時は常に `kind` を含める。Movement の永続化と専用エンドポイントは PR2 / PR3 で追加する
+> - 2026-05: 楽曲テーブルに `parentId-index-index` GSI を追加（PR2）。`DynamoDBPieceRepository.findChildren` / `removeWorkCascade`（カスケード削除）/ `replaceMovements`（TransactWriteItems による集合置換）を有効化。GSI のバックフィルは AWS 側で非同期に走るため、PR3 デプロイ前に CloudWatch でステータスが `ACTIVE` になっていることを確認すること
 
 > **任意項目の更新**: Work では `era` / `genre` / `formation` / `region` を空文字で送信するとフィールドが削除される。`videoUrls` は空配列 `[]` で削除（Work / Movement 共通）。
 


### PR DESCRIPTION
## 概要

楽曲マスタの usecase 層を Work（親楽曲）と Movement（楽章）に分離し、それぞれ専用のユースケースクラスを導入します。同時にリポジトリに Movement 取得・削除・置換機能を実装し、DynamoDB の新 GSI `parentId-index-index` を活用して楽章を演奏順に管理できるようにします。

## 変更の種類

- [x] 新機能
- [x] リファクタリング
- [x] テスト

## 変更内容

### Usecase 層の再構成
- **`WorkUsecase`**: Work（親楽曲）専用。`create` / `list` / `get` / `update` / `delete` を提供
  - `delete` は `removeWorkCascade` で配下 Movement をまとめて削除
- **`MovementUsecase`**: Movement（楽章）専用。`create` / `get` / `update` / `delete` / `listChildren` / `replaceMovements` を提供
  - `get` は kind を Movement に限定（Work が紛れ込んだら 404）
- **`PieceUsecase`**: 既存ハンドラ向けのファサード。`create` / `list` / `get` / `update` / `delete` で kind に応じて dispatch
  - 新メソッド `getNode(id)` で kind を問わず単一ノード取得（PR3 で `/pieces/{id}/children` などから利用予定）

### リポジトリ機能拡張
- **`findChildren(parentId)`**: 新 GSI `parentId-index-index` を Query して Movement を `index` 昇順で全件取得
  - ページネーション対応（`LastEvaluatedKey` で複数ページを吸収）
  - Work レコードが紛れ込んだ場合は除外
- **`removeWorkCascade(id)`**: Work 削除時に配下 Movement をまとめて削除
  - Movement が無い場合は単純な DeleteCommand
  - Movement がある場合は TransactWriteItems で原子的に削除
- **`replaceMovements(workId, movements)`**: Movement 集合をアトミック置換
  - 既存子を全て削除し、新しい子を Put する操作を 1 つの TransactWriteItems で実行
  - 並び替え・追加・削除の混在に対応
- **`normalizeLegacyKind(item)`**: 既存 DB レコード（`kind` 欠落）を補完（public static に変更してテスト可能に）

### インフラ・スキーマ更新
- CDK: `piecesTable` に GSI `parentId-index-index` を追加（PartitionKey=`parentId` / SortKey=`index`）
- SPEC.md: テーブルスキーマに GSI 定義を追加

### テスト
- **`piece-usecase.test.ts`** (新規): WorkUsecase / MovementUsecase / PieceUsecase の全メソッドをカバー（309 行）
  - create / get / update / delete / list / listChildren / replaceMovements の動作確認
  - エラーケース（404、kind 不一致）の検証
- **`piece-repository.test.ts`** (拡張): 既存の `normalizeLegacyVideoUrl` テストに加え、以下を追加
  - `normalizeLegacyKind`: 既存レコード補完の動

https://claude.ai/code/session_015zrmuUDcudaqQAvAcnCiQe