### PR TITLE
feat(pieces): 楽章 API と kind 共通 CRUD・集合一括差し替えを追加

### DIFF
--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -52,8 +52,18 @@ export type PieceRepository = {
   saveMovement(movement: PieceMovement): Promise<void>;
   saveMovementWithOptimisticLock(movement: PieceMovement, prevUpdatedAt: string): Promise<void>;
   removeMovement(id: PieceId): Promise<void>;
-  /** Work 配下の Movement 集合を一括置換する（PR3 用）。 */
-  replaceMovements(workId: PieceId, movements: PieceMovement[]): Promise<void>;
+  /**
+   * Work 配下の Movement 集合を一括置換する。
+   *
+   * `workOptimisticLock` を渡すと Work の楽観的ロック付き Put（`updatedAt = :prevUpdatedAt`）を
+   * 同一 TransactWriteItems に含めて Work の `updatedAt` も同時に進める。
+   * 競合した場合はリポジトリ実装が 409 Conflict を投げる。
+   */
+  replaceMovements(
+    workId: PieceId,
+    movements: PieceMovement[],
+    workOptimisticLock?: { work: PieceWork; prevUpdatedAt: string },
+  ): Promise<void>;
 };
 
 function toUrlArray(values: readonly string[] | undefined): Url[] | undefined {

--- a/backend/src/handlers/pieces/children.test.ts
+++ b/backend/src/handlers/pieces/children.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent, Context } from "aws-lambda";
+
+import { handler } from "./children";
+
+const mockRepo = vi.hoisted(() => ({
+  saveWork: vi.fn(),
+  saveWorkWithOptimisticLock: vi.fn(),
+  removeWorkCascade: vi.fn(),
+  findRootById: vi.fn(),
+  findRootPage: vi.fn(),
+  findById: vi.fn(),
+  findChildren: vi.fn(),
+  saveMovement: vi.fn(),
+  saveMovementWithOptimisticLock: vi.fn(),
+  removeMovement: vi.fn(),
+  replaceMovements: vi.fn(),
+}));
+
+vi.mock("../../repositories/piece-repository", () => ({
+  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+const mockContext = {} as Context;
+const mockCallback = { signal: new AbortController().signal };
+
+function makeEvent(id?: string): APIGatewayProxyEvent {
+  return {
+    body: null,
+    headers: {},
+    multiValueHeaders: {},
+    httpMethod: "GET",
+    isBase64Encoded: false,
+    path: `/pieces/${id ?? ""}/children`,
+    pathParameters: id === undefined ? null : { id },
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    stageVariables: null,
+    requestContext: {} as APIGatewayProxyEvent["requestContext"],
+    resource: "",
+  };
+}
+
+describe("GET /pieces/{id}/children (children)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("id がない場合は 400 を返す", async () => {
+    const result = await handler(makeEvent(), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
+  });
+
+  it("子 Movement の配列を 200 で返す", async () => {
+    const movements = [
+      {
+        kind: "movement" as const,
+        id: "mov-1",
+        parentId: "abc-123",
+        index: 0,
+        title: "第1楽章",
+        createdAt: "2024-01-15T21:00:00.000Z",
+        updatedAt: "2024-01-15T21:00:00.000Z",
+      },
+      {
+        kind: "movement" as const,
+        id: "mov-2",
+        parentId: "abc-123",
+        index: 1,
+        title: "第2楽章",
+        createdAt: "2024-01-15T21:00:00.000Z",
+        updatedAt: "2024-01-15T21:00:00.000Z",
+      },
+    ];
+    mockRepo.findChildren.mockResolvedValueOnce(movements);
+
+    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "[]");
+    expect(body).toHaveLength(2);
+    expect(body[0].kind).toBe("movement");
+    expect(body[0].id).toBe("mov-1");
+    expect(body[0].index).toBe(0);
+  });
+
+  it("該当する子 Movement が無ければ空配列を返す", async () => {
+    mockRepo.findChildren.mockResolvedValueOnce([]);
+
+    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(200);
+    expect(JSON.parse(result?.body ?? "[]")).toEqual([]);
+  });
+
+  it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.findChildren.mockRejectedValueOnce(new Error("DynamoDB error"));
+    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(500);
+  });
+});

--- a/backend/src/handlers/pieces/children.ts
+++ b/backend/src/handlers/pieces/children.ts
@@ -1,0 +1,21 @@
+import { createHandler } from "../../utils/middleware";
+import { getIdParam } from "../../utils/path-params";
+import { ok } from "../../utils/response";
+import { createMovementUsecase, PieceId } from "../../usecases/piece-usecase";
+
+const usecase = createMovementUsecase();
+
+/**
+ * GET /pieces/{id}/children
+ *
+ * 親 Work 配下の Movement を `index` 昇順で全件返す。
+ * 認証不要（参照系の他エンドポイント `GET /pieces` / `GET /pieces/{id}` と同じ）。
+ *
+ * Movement のレスポンスには `composerId` は含まれない（親 Work から継承）。
+ * 親が存在しない場合は空配列を返す（GSI Query は親 Work の存在を要求しない）。
+ */
+export const handler = createHandler(async (event) => {
+  const id = getIdParam(event, PieceId.from);
+  const movements = await usecase.listChildren(id);
+  return ok(movements);
+});

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -48,6 +48,25 @@ function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxy
   return makeBaseEvent(overrides);
 }
 
+const workItem = {
+  kind: "work" as const,
+  id: "test-id-123",
+  title: "交響曲第9番",
+  composerId: "00000000-0000-4000-8000-000000000001",
+  createdAt: "2024-01-15T21:00:00.000Z",
+  updatedAt: "2024-01-15T21:00:00.000Z",
+};
+
+const movementItem = {
+  kind: "movement" as const,
+  id: "mov-1",
+  parentId: "test-id-123",
+  index: 0,
+  title: "第1楽章",
+  createdAt: "2024-01-15T21:00:00.000Z",
+  updatedAt: "2024-01-15T21:00:00.000Z",
+};
+
 describe("DELETE /pieces/{id} (delete)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -59,21 +78,35 @@ describe("DELETE /pieces/{id} (delete)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  it("正常に削除して 204 を返す", async () => {
+  it("Work を指定すると removeWorkCascade で cascade 削除し 204 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(workItem);
     mockRepo.removeWorkCascade.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
+    expect(mockRepo.removeWorkCascade).toHaveBeenCalledWith(PieceId.from("test-id-123"));
+    expect(mockRepo.removeMovement).not.toHaveBeenCalled();
   });
 
-  it("正しい id で Repository.removeWorkCascade を呼び出す", async () => {
-    mockRepo.removeWorkCascade.mockResolvedValueOnce(undefined);
-    await handler(makeEvent("test-id-123"), mockContext, mockCallback);
+  it("Movement を指定すると removeMovement で単独削除し 204 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(movementItem);
+    mockRepo.removeMovement.mockResolvedValueOnce(undefined);
+    const result = await handler(makeEvent("mov-1"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(204);
+    expect(mockRepo.removeMovement).toHaveBeenCalledWith(PieceId.from("mov-1"));
+    expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+  });
 
-    expect(mockRepo.removeWorkCascade).toHaveBeenCalledWith(PieceId.from("test-id-123"));
+  it("存在しない id は冪等に 204 を返し、削除呼び出しは行わない", async () => {
+    mockRepo.findById.mockResolvedValueOnce(undefined);
+    const result = await handler(makeEvent("not-found"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(204);
+    expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+    expect(mockRepo.removeMovement).not.toHaveBeenCalled();
   });
 
   it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.findById.mockResolvedValueOnce(workItem);
     mockRepo.removeWorkCascade.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
@@ -88,13 +121,17 @@ describe("DELETE /pieces/{id} (delete)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.findById).not.toHaveBeenCalled();
       expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+      expect(mockRepo.removeMovement).not.toHaveBeenCalled();
     });
 
     it("認証クレームがない場合は 403 を返し、削除しない", async () => {
       const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
       expect(result?.statusCode).toBe(403);
+      expect(mockRepo.findById).not.toHaveBeenCalled();
       expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+      expect(mockRepo.removeMovement).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/handlers/pieces/get.test.ts
+++ b/backend/src/handlers/pieces/get.test.ts
@@ -64,14 +64,14 @@ describe("GET /pieces/{id} (get)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(undefined);
+    mockRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("not-found-id"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("Piece not found");
   });
 
   it("正常に取得して 200 を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(testPiece);
+    mockRepo.findById.mockResolvedValueOnce(testPiece);
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
 
@@ -83,8 +83,26 @@ describe("GET /pieces/{id} (get)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findRootById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
+  });
+
+  it("Movement も id で取得できる（kind を問わず単一ノード）", async () => {
+    const movement = {
+      kind: "movement" as const,
+      id: "mov-1",
+      parentId: "abc-123",
+      index: 0,
+      title: "第1楽章",
+      createdAt: "2024-01-15T21:00:00.000Z",
+      updatedAt: "2024-01-15T21:00:00.000Z",
+    };
+    mockRepo.findById.mockResolvedValueOnce(movement);
+    const result = await handler(makeEvent("mov-1"), mockContext, mockCallback);
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.kind).toBe("movement");
+    expect(body.id).toBe("mov-1");
   });
 });

--- a/backend/src/handlers/pieces/get.ts
+++ b/backend/src/handlers/pieces/get.ts
@@ -5,8 +5,14 @@ import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
+/**
+ * GET /pieces/{id}
+ *
+ * kind を問わず単一ノード（Work または Movement）を返す。
+ * Movement のレスポンスには `composerId` は含まれない（親 Work からの継承）。
+ */
 export const handler = createHandler(async (event) => {
   const id = getIdParam(event, PieceId.from);
-  const piece = await usecase.get(id);
+  const piece = await usecase.getNode(id);
   return ok(piece);
 });

--- a/backend/src/handlers/pieces/replace-movements.test.ts
+++ b/backend/src/handlers/pieces/replace-movements.test.ts
@@ -1,0 +1,262 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { APIGatewayProxyEvent } from "aws-lambda";
+import createError from "http-errors";
+
+import { handler } from "./replace-movements";
+import {
+  makeAdminEvent,
+  makeAuthEvent,
+  makeEvent as makeBaseEvent,
+  mockCallback,
+  mockContext,
+  TEST_COMPOSER_ID,
+  TEST_USER_ID,
+} from "../../test/fixtures";
+
+const mockRepo = vi.hoisted(() => ({
+  saveWork: vi.fn(),
+  saveWorkWithOptimisticLock: vi.fn(),
+  removeWorkCascade: vi.fn(),
+  findRootById: vi.fn(),
+  findRootPage: vi.fn(),
+  findById: vi.fn(),
+  findChildren: vi.fn(),
+  saveMovement: vi.fn(),
+  saveMovementWithOptimisticLock: vi.fn(),
+  removeMovement: vi.fn(),
+  replaceMovements: vi.fn(),
+}));
+
+vi.mock("../../repositories/piece-repository", () => ({
+  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
+    return mockRepo;
+  }),
+}));
+
+const TEST_WORK_ID = "00000000-0000-4000-8000-00000000aaaa";
+
+const existingWork = {
+  kind: "work" as const,
+  id: TEST_WORK_ID,
+  title: "交響曲第9番",
+  composerId: TEST_COMPOSER_ID,
+  createdAt: "2024-01-15T20:00:00.000Z",
+  updatedAt: "2024-01-15T20:00:00.000Z",
+};
+
+type AuthMode = "admin" | "non-admin" | "none";
+
+function makeEvent(
+  workId?: string,
+  body?: string | null,
+  auth: AuthMode = "admin",
+): APIGatewayProxyEvent {
+  const overrides: Partial<APIGatewayProxyEvent> = {
+    body: body === undefined ? null : body,
+    httpMethod: "PUT",
+    path: `/pieces/${workId ?? ""}/movements`,
+    pathParameters: workId === undefined ? null : { id: workId },
+  };
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeBaseEvent(overrides);
+}
+
+describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("workId がない場合は 400 を返す", async () => {
+    const result = await handler(
+      makeEvent(undefined, JSON.stringify({ movements: [] })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
+  });
+
+  describe("リクエストボディ異常系", () => {
+    it.each<[string | null, number, string]>([
+      [null, 400, "Request body is required"],
+      ["null", 400, "Request body is required"],
+      ["[]", 400, "Request body must be a JSON object"],
+      ["invalid json", 422, "Invalid or malformed JSON was provided"],
+    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
+      const result = await handler(makeEvent(TEST_WORK_ID, body), mockContext, mockCallback);
+      expect(result?.statusCode).toBe(statusCode);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
+  });
+
+  it("movements に index 重複があると 400 を返す", async () => {
+    const result = await handler(
+      makeEvent(
+        TEST_WORK_ID,
+        JSON.stringify({
+          movements: [
+            { index: 0, title: "第1楽章" },
+            { index: 0, title: "第2楽章（同じ index）" },
+          ],
+        }),
+      ),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(400);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe(
+      "movements must not contain duplicate index values",
+    );
+    expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+  });
+
+  it("movements に title が空の項目があると 400 を返す", async () => {
+    const result = await handler(
+      makeEvent(
+        TEST_WORK_ID,
+        JSON.stringify({
+          movements: [{ index: 0, title: "" }],
+        }),
+      ),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(400);
+  });
+
+  it("movements の件数が MOVEMENTS_PER_WORK_MAX を超えると 400 を返す", async () => {
+    const movements = Array.from({ length: 50 }, (_, i) => ({ index: i, title: `${i}` }));
+    const result = await handler(
+      makeEvent(TEST_WORK_ID, JSON.stringify({ movements })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(400);
+  });
+
+  it("Work が存在しない場合は 404 を返す", async () => {
+    mockRepo.findRootById.mockResolvedValueOnce(undefined);
+    const result = await handler(
+      makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(404);
+  });
+
+  it("正常に置換して 200 と movements 配列を返す", async () => {
+    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockRepo.findChildren.mockResolvedValueOnce([]);
+    mockRepo.replaceMovements.mockResolvedValueOnce(undefined);
+
+    const result = await handler(
+      makeEvent(
+        TEST_WORK_ID,
+        JSON.stringify({
+          movements: [
+            { index: 0, title: "第1楽章" },
+            { index: 1, title: "第2楽章" },
+          ],
+        }),
+      ),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.movements).toHaveLength(2);
+    expect(body.movements[0].kind).toBe("movement");
+    expect(body.movements[0].parentId).toBe(TEST_WORK_ID);
+    expect(body.movements[0].title).toBe("第1楽章");
+    expect(body.movements[0].id).toMatch(/^[0-9a-f-]{36}$/);
+  });
+
+  it("空配列を渡すと既存 Movement が全削除される（レスポンスは空配列）", async () => {
+    const existingMovement = {
+      kind: "movement" as const,
+      id: "mov-1",
+      parentId: TEST_WORK_ID,
+      index: 0,
+      title: "旧第1楽章",
+      createdAt: "2024-01-15T20:00:00.000Z",
+      updatedAt: "2024-01-15T20:00:00.000Z",
+    };
+    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockRepo.findChildren.mockResolvedValueOnce([existingMovement]);
+    mockRepo.replaceMovements.mockResolvedValueOnce(undefined);
+
+    const result = await handler(
+      makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [] })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(200);
+    expect(JSON.parse(result?.body ?? "{}")).toEqual({ movements: [] });
+  });
+
+  it("楽観的ロック競合時に 409 を返す", async () => {
+    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockRepo.findChildren.mockResolvedValueOnce([]);
+    mockRepo.replaceMovements.mockRejectedValueOnce(
+      new createError.Conflict("Piece was updated by another request"),
+    );
+
+    const result = await handler(
+      makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(409);
+    expect(JSON.parse(result?.body ?? "{}").message).toBe("Piece was updated by another request");
+  });
+
+  it("Repository エラー時に 500 を返す", async () => {
+    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockRepo.findChildren.mockResolvedValueOnce([]);
+    mockRepo.replaceMovements.mockRejectedValueOnce(new Error("DynamoDB error"));
+
+    const result = await handler(
+      makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] })),
+      mockContext,
+      mockCallback,
+    );
+    expect(result?.statusCode).toBe(500);
+  });
+
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返す", async () => {
+      const result = await handler(
+        makeEvent(
+          TEST_WORK_ID,
+          JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] }),
+          "non-admin",
+        ),
+        mockContext,
+        mockCallback,
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      expect(mockRepo.findRootById).not.toHaveBeenCalled();
+      expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+    });
+
+    it("認証クレームがない場合は 403 を返す", async () => {
+      const result = await handler(
+        makeEvent(
+          TEST_WORK_ID,
+          JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] }),
+          "none",
+        ),
+        mockContext,
+        mockCallback,
+      );
+      expect(result?.statusCode).toBe(403);
+      expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/backend/src/handlers/pieces/replace-movements.ts
+++ b/backend/src/handlers/pieces/replace-movements.ts
@@ -1,0 +1,28 @@
+import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
+import { parseRequestBody } from "../../utils/parsing";
+import { getIdParam } from "../../utils/path-params";
+import { ok } from "../../utils/response";
+import { replaceMovementsSchema } from "../../utils/schemas";
+import { createMovementUsecase, PieceId } from "../../usecases/piece-usecase";
+
+const usecase = createMovementUsecase();
+
+/**
+ * PUT /pieces/{workId}/movements
+ *
+ * 親 Work 配下の Movement 集合を一括差し替えする（admin 必須）。
+ * 並び替え・追加・削除を 1 つの DynamoDB TransactWriteItems で原子的に反映する。
+ *
+ * - リクエストボディ: `{ movements: [{ id?, index, title, videoUrls? }, ...] }`
+ *   - `id` を指定すると既存 Movement の更新（`createdAt` を引き継ぐ）。省略時は新規採番。
+ *   - 同じ Work 内で `index` の重複は 400 で拒否される（`replaceMovementsSchema` の `.refine`）。
+ * - 楽観的ロック: Work の `updatedAt` を ifMatch にして同一トランザクションに含める。
+ *   競合時は 409 Conflict を返す。
+ * - 上限: `MOVEMENTS_PER_WORK_MAX = 49` 件まで。
+ */
+export const handler = createAdminHandler(async (event) => {
+  const workId = getIdParam(event, PieceId.from);
+  const input = parseRequestBody(event.body as unknown, replaceMovementsSchema);
+  const movements = await usecase.replaceAll(workId, input.movements);
+  return ok({ movements });
+}).use(jsonBodyParser);

--- a/backend/src/repositories/piece-repository.test.ts
+++ b/backend/src/repositories/piece-repository.test.ts
@@ -273,4 +273,27 @@ describe("replaceMovements", () => {
     );
     expect(mockSend).not.toHaveBeenCalled();
   });
+
+  it("workOptimisticLock を渡すと Work の楽観的ロック付き Put をトランザクションの先頭に含める", async () => {
+    const next = makeMovement(CHILD_1_ID, 0);
+    const work: PieceWork = { ...basePiece, id: PARENT_ID } as PieceWork;
+    mockSend.mockResolvedValueOnce({ Items: [], LastEvaluatedKey: undefined });
+    mockSend.mockResolvedValueOnce({});
+
+    const repo = new DynamoDBPieceRepository();
+    await repo.replaceMovements(PieceId.from(PARENT_ID), [next], {
+      work,
+      prevUpdatedAt: "2024-01-15T20:00:00.000Z",
+    });
+
+    const txArg = mockSend.mock.calls[1]?.[0];
+    const transactItems = txArg?.input?.TransactItems;
+    expect(transactItems).toHaveLength(2);
+    expect(transactItems?.[0]?.Put?.Item).toEqual(work);
+    expect(transactItems?.[0]?.Put?.ConditionExpression).toBe("updatedAt = :prevUpdatedAt");
+    expect(transactItems?.[0]?.Put?.ExpressionAttributeValues?.[":prevUpdatedAt"]).toBe(
+      "2024-01-15T20:00:00.000Z",
+    );
+    expect(transactItems?.[1]?.Put?.Item).toEqual(next);
+  });
 });

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -1,3 +1,4 @@
+import { TransactionCanceledException } from "@aws-sdk/client-dynamodb";
 import {
   DeleteCommand,
   GetCommand,
@@ -5,6 +6,7 @@ import {
   QueryCommand,
   TransactWriteCommand,
 } from "@aws-sdk/lib-dynamodb";
+import createError from "http-errors";
 
 import type { PieceRepository } from "../domain/piece";
 import type { PieceId } from "../domain/value-objects/ids";
@@ -200,15 +202,24 @@ export class DynamoDBPieceRepository implements PieceRepository {
    * 既存の子要素を全て削除し、新しい子要素を Put する操作を 1 つの
    * TransactWriteItems で実行する。並び替え・追加・削除の混在も同時に反映される。
    *
+   * `workOptimisticLock` を渡すと、Work の楽観的ロック付き Put（条件式: `updatedAt = :prevUpdatedAt`）
+   * を同一トランザクションに含めて Work の `updatedAt` も同時に進める。Work の更新が他リクエストと
+   * 競合した場合、トランザクション全体がロールバックされる。
+   *
    * DynamoDB の TransactWriteItems は 1 トランザクション最大 100 アイテムのため、
-   * `(既存件数 + 新規件数)` が 100 を超える場合はエラーを投げる。
+   * `(既存件数 + 新規件数 + Work 更新の有無)` が 100 を超える場合はエラーを投げる。
    */
-  async replaceMovements(workId: PieceId, movements: PieceMovement[]): Promise<void> {
+  async replaceMovements(
+    workId: PieceId,
+    movements: PieceMovement[],
+    workOptimisticLock?: { work: PieceWork; prevUpdatedAt: string },
+  ): Promise<void> {
     if (movements.some((m) => m.parentId !== workId.value)) {
       throw new Error("All movements must belong to the specified workId");
     }
     const existing = await this.findChildren(workId);
-    const totalItems = existing.length + movements.length;
+    const workItemCount = workOptimisticLock === undefined ? 0 : 1;
+    const totalItems = existing.length + movements.length + workItemCount;
     if (totalItems > TRANSACT_WRITE_MAX_ITEMS) {
       throw new Error(
         `replaceMovements exceeds DynamoDB transaction limit (${totalItems} > ${TRANSACT_WRITE_MAX_ITEMS})`,
@@ -217,17 +228,38 @@ export class DynamoDBPieceRepository implements PieceRepository {
     if (totalItems === 0) {
       return;
     }
-    await dynamo.send(
-      new TransactWriteCommand({
-        TransactItems: [
-          ...existing.map((m) => ({
-            Delete: { TableName: TABLE_PIECES, Key: { id: m.id } },
-          })),
-          ...movements.map((m) => ({
-            Put: { TableName: TABLE_PIECES, Item: m },
-          })),
-        ],
-      }),
-    );
+    const transactItems: NonNullable<
+      ConstructorParameters<typeof TransactWriteCommand>[0]["TransactItems"]
+    > = [];
+    if (workOptimisticLock !== undefined) {
+      transactItems.push({
+        Put: {
+          TableName: TABLE_PIECES,
+          Item: workOptimisticLock.work,
+          ConditionExpression: "updatedAt = :prevUpdatedAt",
+          ExpressionAttributeValues: { ":prevUpdatedAt": workOptimisticLock.prevUpdatedAt },
+        },
+      });
+    }
+    existing.forEach((m) => {
+      transactItems.push({ Delete: { TableName: TABLE_PIECES, Key: { id: m.id } } });
+    });
+    movements.forEach((m) => {
+      transactItems.push({ Put: { TableName: TABLE_PIECES, Item: m } });
+    });
+    try {
+      await dynamo.send(new TransactWriteCommand({ TransactItems: transactItems }));
+    } catch (err) {
+      // Work の楽観的ロックが衝突するとトランザクション全体がキャンセルされる。
+      // CancellationReasons[0]（Work の Put）が ConditionalCheckFailed であれば 409 Conflict に変換する。
+      if (
+        err instanceof TransactionCanceledException &&
+        workOptimisticLock !== undefined &&
+        err.CancellationReasons?.[0]?.Code === "ConditionalCheckFailed"
+      ) {
+        throw new createError.Conflict("Piece was updated by another request");
+      }
+      throw err;
+    }
   }
 }

--- a/backend/src/usecases/piece-usecase.test.ts
+++ b/backend/src/usecases/piece-usecase.test.ts
@@ -215,14 +215,76 @@ describe("MovementUsecase", () => {
     });
   });
 
-  describe("replaceMovements", () => {
-    it("replaceMovements リポジトリ操作に委譲する", async () => {
-      const m = makeMovement();
-      await usecase.replaceMovements(PieceId.from(TEST_WORK_ID), [m]);
+  describe("replaceAll", () => {
+    it("Work が見つからない場合は 404", async () => {
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(undefined);
+
+      await expect(
+        usecase.replaceAll(PieceId.from(TEST_WORK_ID), [{ index: 0, title: "第1楽章" }]),
+      ).rejects.toMatchObject({ statusCode: 404 });
+    });
+
+    it("既存子を全削除し、新規 Movement に id を採番して TransactWriteItems で書き込む", async () => {
+      const work = makeWork();
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(work);
+      vi.mocked(repo.findChildren).mockResolvedValueOnce([]);
+
+      const result = await usecase.replaceAll(PieceId.from(TEST_WORK_ID), [
+        { index: 0, title: "第1楽章" },
+        { index: 1, title: "第2楽章" },
+      ]);
+
+      expect(result).toHaveLength(2);
+      expect(result[0]?.kind).toBe("movement");
+      expect(result[0]?.parentId).toBe(TEST_WORK_ID);
+      expect(result[0]?.title).toBe("第1楽章");
+      expect(result[0]?.id).toMatch(/^[0-9a-f-]{36}$/);
+      expect(result[1]?.id).not.toBe(result[0]?.id);
+
       expect(repo.replaceMovements).toHaveBeenCalledWith(
         expect.objectContaining({ value: TEST_WORK_ID }),
-        [m],
+        result,
+        expect.objectContaining({
+          prevUpdatedAt: work.updatedAt,
+          work: expect.objectContaining({ id: work.id, updatedAt: expect.any(String) }),
+        }),
       );
+    });
+
+    it("既存 Movement と同じ id を渡すと createdAt を引き継ぎつつ updatedAt は新しくなる", async () => {
+      const work = makeWork();
+      const existing = makeMovement({
+        id: TEST_MOVEMENT_ID,
+        index: 0,
+        createdAt: "2023-01-01T00:00:00.000Z",
+      });
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(work);
+      vi.mocked(repo.findChildren).mockResolvedValueOnce([existing]);
+
+      const result = await usecase.replaceAll(PieceId.from(TEST_WORK_ID), [
+        { id: TEST_MOVEMENT_ID, index: 0, title: "改題" },
+      ]);
+
+      expect(result[0]?.id).toBe(TEST_MOVEMENT_ID);
+      expect(result[0]?.title).toBe("改題");
+      expect(result[0]?.createdAt).toBe(existing.createdAt);
+      expect(result[0]?.updatedAt).not.toBe(existing.updatedAt);
+    });
+
+    it("Work の updatedAt を ifMatch にして同一トランザクション内で更新する", async () => {
+      const work = makeWork({ updatedAt: "2024-01-15T20:00:00.000Z" });
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(work);
+      vi.mocked(repo.findChildren).mockResolvedValueOnce([]);
+
+      await usecase.replaceAll(PieceId.from(TEST_WORK_ID), [{ index: 0, title: "第1楽章" }]);
+
+      const call = vi.mocked(repo.replaceMovements).mock.calls[0];
+      expect(call?.[2]).toMatchObject({
+        prevUpdatedAt: "2024-01-15T20:00:00.000Z",
+      });
+      // updatedWork は新しい updatedAt に進んでいる
+      const updatedWork = call?.[2]?.work as { updatedAt: string };
+      expect(updatedWork.updatedAt).not.toBe("2024-01-15T20:00:00.000Z");
     });
   });
 });
@@ -304,6 +366,60 @@ describe("PieceUsecase (facade)", () => {
       await expect(
         usecase.update(PieceId.from(TEST_WORK_ID), { kind: "movement", title: "改題" }),
       ).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("delete", () => {
+    it("Work の場合は removeWorkCascade を呼ぶ", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeWork());
+
+      await usecase.delete(PieceId.from(TEST_WORK_ID));
+
+      expect(repo.removeWorkCascade).toHaveBeenCalled();
+      expect(repo.removeMovement).not.toHaveBeenCalled();
+    });
+
+    it("Movement の場合は removeMovement を呼ぶ", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(makeMovement());
+
+      await usecase.delete(PieceId.from(TEST_MOVEMENT_ID));
+
+      expect(repo.removeMovement).toHaveBeenCalled();
+      expect(repo.removeWorkCascade).not.toHaveBeenCalled();
+    });
+
+    it("存在しない id は冪等（何も呼ばない）", async () => {
+      vi.mocked(repo.findById).mockResolvedValueOnce(undefined);
+
+      await usecase.delete(PieceId.from(TEST_WORK_ID));
+
+      expect(repo.removeWorkCascade).not.toHaveBeenCalled();
+      expect(repo.removeMovement).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("resolveComposerId", () => {
+    it("Work ノードはそのまま composerId を返す", async () => {
+      const result = await usecase.resolveComposerId(makeWork());
+
+      expect(result.value).toBe(TEST_COMPOSER_ID);
+    });
+
+    it("Movement ノードは親 Work の composerId を返す", async () => {
+      const otherComposerId = "00000000-0000-4000-8000-000000000099";
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(makeWork({ composerId: otherComposerId }));
+
+      const result = await usecase.resolveComposerId(makeMovement());
+
+      expect(result.value).toBe(otherComposerId);
+    });
+
+    it("Movement の親 Work が存在しない場合は 404", async () => {
+      vi.mocked(repo.findRootById).mockResolvedValueOnce(undefined);
+
+      await expect(usecase.resolveComposerId(makeMovement())).rejects.toMatchObject({
+        statusCode: 404,
+      });
     });
   });
 });

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -2,7 +2,7 @@ import createError from "http-errors";
 
 import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "../domain/piece";
 import type { PieceRepository } from "../domain/piece";
-import { PieceId } from "../domain/value-objects/ids";
+import { ComposerId, PieceId } from "../domain/value-objects/ids";
 import { DynamoDBPieceRepository } from "../repositories/piece-repository";
 import type {
   CreateMovementInput,
@@ -22,6 +22,18 @@ import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
 export { PieceId };
 
 const ENTITY_NAME = "Piece";
+
+/**
+ * Movement 集合一括差し替えの入力型。
+ * - `id` は省略可能。指定されない場合は新規 UUID を採番する（追加扱い）。
+ * - `parentId` はパスパラメータの workId から付与するため受け取らない。
+ */
+export type ReplaceMovementInput = {
+  id?: string;
+  index: number;
+  title: string;
+  videoUrls?: string[];
+};
 
 /**
  * Work（親楽曲）専用ユースケース。
@@ -106,8 +118,46 @@ export class MovementUsecase {
     return this.repo.findChildren(parentId);
   }
 
-  async replaceMovements(workId: PieceId, movements: PieceMovement[]): Promise<void> {
-    await this.repo.replaceMovements(workId, movements);
+  /**
+   * Work 配下の Movement 集合を一括置換する。Work の `updatedAt` も同時に進める（楽観的ロック付き）。
+   *
+   * - Work が存在しなければ 404 を投げる。
+   * - 既存 Movement は内部で全件削除し、入力された `movements` のみ残る。
+   * - `id` を持つ入力は既存 Movement の更新（`createdAt` を引き継ぐ）、無ければ新規採番。
+   * - Work の楽観的ロックが衝突した場合は repository が 409 Conflict を投げる。
+   */
+  async replaceAll(workId: PieceId, movements: ReplaceMovementInput[]): Promise<PieceMovement[]> {
+    const currentWork = await findByIdOrNotFound(
+      (id) => this.repo.findRootById(id),
+      workId,
+      ENTITY_NAME,
+    );
+    const existingChildren = await this.repo.findChildren(workId);
+    const existingById = new Map(existingChildren.map((m) => [m.id, m]));
+    const now = new Date().toISOString();
+    const newMovements: PieceMovement[] = movements.map((m) => {
+      // id 指定 + 既存に存在 → 更新（createdAt を保持）。それ以外は新規採番。
+      const matched = m.id !== undefined ? existingById.get(m.id) : undefined;
+      const id = matched?.id ?? PieceId.generate().value;
+      const createdAt = matched?.createdAt ?? now;
+      return {
+        kind: "movement" as const,
+        id,
+        parentId: workId.value,
+        index: m.index,
+        title: m.title,
+        videoUrls: m.videoUrls,
+        createdAt,
+        updatedAt: now,
+      };
+    });
+    // Work の updatedAt を進める（同一トランザクション内で楽観的ロック）
+    const updatedWork: PieceWork = { ...currentWork, updatedAt: now };
+    await this.repo.replaceMovements(workId, newMovements, {
+      work: updatedWork,
+      prevUpdatedAt: currentWork.updatedAt,
+    });
+    return newMovements;
   }
 }
 
@@ -154,6 +204,26 @@ export class PieceUsecase {
     return findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
   }
 
+  /**
+   * 任意ノード（Work / Movement）から `composerId` を解決する。
+   * - Work: 自身の `composerId` を返す。
+   * - Movement: 親 Work を引き、親の `composerId` を返す。親が存在しなければ 404。
+   *
+   * Movement の API レスポンスには `composerId` を載せないが、内部処理（鑑賞記録の作曲家解決など）で
+   * 親 Work からの継承を必要とするユースケースのために提供する。
+   */
+  async resolveComposerId(node: Piece): Promise<ComposerId> {
+    if (node.kind === "work") {
+      return ComposerId.from(node.composerId);
+    }
+    const parent = await findByIdOrNotFound(
+      (id) => this.repo.findRootById(id),
+      PieceId.from(node.parentId),
+      ENTITY_NAME,
+    );
+    return ComposerId.from(parent.composerId);
+  }
+
   async update(id: PieceId, input: UpdatePieceInput): Promise<Piece> {
     const current = await findByIdOrNotFound((id) => this.repo.findById(id), id, ENTITY_NAME);
     const entity = PieceComponent.reconstruct(current);
@@ -168,8 +238,22 @@ export class PieceUsecase {
     return plain;
   }
 
+  /**
+   * kind を判別して削除する。
+   * - Work: 配下 Movement までまとめて cascade 削除
+   * - Movement: 単独削除（親 Work には影響しない）
+   * - 存在しない id は冪等に扱い、何もせず終了する（DELETE 系の慣例どおり）
+   */
   async delete(id: PieceId): Promise<void> {
-    await this.repo.removeWorkCascade(id);
+    const item = await this.repo.findById(id);
+    if (item === undefined) {
+      return;
+    }
+    if (item.kind === "work") {
+      await this.repo.removeWorkCascade(id);
+      return;
+    }
+    await this.repo.removeMovement(id);
   }
 }
 

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -168,9 +168,10 @@ export const updatePieceSchema = z.discriminatedUnion("kind", [
 ]);
 
 /**
- * Work 配下の Movement 集合を一括置換するための入力スキーマ（PR3 で実エンドポイントを追加する用途）。
+ * Work 配下の Movement 集合を一括置換するための入力スキーマ（`PUT /pieces/{workId}/movements`）。
  * - `kind` は不要。常に movement 集合として扱う。
  * - 1 Work あたりの最大件数は {@link MOVEMENTS_PER_WORK_MAX}。
+ * - 同一 Work 内で `index` の重複は許容しない（演奏順を一意に決めるため）。
  */
 export const replaceMovementsSchema = z.object({
   movements: z
@@ -193,10 +194,10 @@ export const replaceMovementsSchema = z.object({
         videoUrls: videoUrlsSchema.optional(),
       }),
     )
-    .max(
-      MOVEMENTS_PER_WORK_MAX,
-      `movements must contain at most ${MOVEMENTS_PER_WORK_MAX} entries`,
-    ),
+    .max(MOVEMENTS_PER_WORK_MAX, `movements must contain at most ${MOVEMENTS_PER_WORK_MAX} entries`)
+    .refine((items) => new Set(items.map((m) => m.index)).size === items.length, {
+      message: "movements must not contain duplicate index values",
+    }),
 });
 
 const emailSchema = z.email("email must be a valid email address").trim();

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -408,6 +408,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const getPiece = fn("GetPiece", "handlers/pieces/get.ts");
     const updatePiece = fn("UpdatePiece", "handlers/pieces/update.ts");
     const deletePiece = fn("DeletePiece", "handlers/pieces/delete.ts");
+    const getPieceChildren = fn("GetPieceChildren", "handlers/pieces/children.ts");
+    const replacePieceMovements = fn(
+      "ReplacePieceMovements",
+      "handlers/pieces/replace-movements.ts",
+    );
 
     const authRegister = fn("AuthRegister", "handlers/auth/register.ts");
     const authLogin = fn("AuthLogin", "handlers/auth/login.ts");
@@ -497,7 +502,11 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     piecesTable.grantWriteData(createPiece);
     piecesTable.grantReadData(getPiece);
     piecesTable.grantReadWriteData(updatePiece);
-    piecesTable.grantWriteData(deletePiece);
+    // delete は kind 判定で Movement の場合は単独削除、Work の場合は cascade（子 Movement の Query が必要）
+    piecesTable.grantReadWriteData(deletePiece);
+    piecesTable.grantReadData(getPieceChildren);
+    // replace-movements は親 Work の取得・既存子 Movement の Query・TransactWriteItems を行うため Read+Write 両方必要
+    piecesTable.grantReadWriteData(replacePieceMovements);
     concertLogsTable.grantReadData(concertLogsList);
     concertLogsTable.grantWriteData(concertLogsCreate);
     concertLogsTable.grantReadData(concertLogsGet);
@@ -605,6 +614,14 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     pieceResource.addMethod("PUT", integ(updatePiece), withAuth);
     pieceResource.addMethod("DELETE", integ(deletePiece), withAuth);
 
+    // /pieces/{id}/children: 親 Work 配下の Movement 一覧（参照系のため認証不要）
+    const pieceChildrenResource = pieceResource.addResource("children");
+    pieceChildrenResource.addMethod("GET", integ(getPieceChildren), withoutAuth);
+
+    // /pieces/{workId}/movements: Movement 集合の一括差し替え（admin 必須）
+    const pieceMovementsResource = pieceResource.addResource("movements");
+    pieceMovementsResource.addMethod("PUT", integ(replacePieceMovements), withAuth);
+
     // /composers
     // 参照系（GET）は公開。書き込み系（POST/PUT/DELETE）は withAuth でトークン検証し、
     // ハンドラ側で admin グループ判定を実施する
@@ -652,6 +669,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       getPiece,
       updatePiece,
       deletePiece,
+      getPieceChildren,
+      replacePieceMovements,
       authRegister,
       authLogin,
       authVerifyEmail,
@@ -709,6 +728,8 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
       ["GET", "PUT", "DELETE", "OPTIONS"],
       ["Content-Type", "Authorization"],
     );
+    this.addCors(pieceChildrenResource, ["GET", "OPTIONS"]);
+    this.addCors(pieceMovementsResource, ["PUT", "OPTIONS"], ["Content-Type", "Authorization"]);
     this.addCors(composersResource, ["GET", "POST", "OPTIONS"], ["Content-Type", "Authorization"]);
     this.addCors(
       composerResource,
@@ -828,6 +849,8 @@ function handler(event) {
       getPiece,
       updatePiece,
       deletePiece,
+      getPieceChildren,
+      replacePieceMovements,
       authRegister,
       authLogin,
       authVerifyEmail,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,12 +96,14 @@ classical-music-lake/
 │       │   ├── get.ts
 │       │   ├── update.ts
 │       │   └── delete.ts
-│       ├── pieces/               # 楽曲マスタ Lambda 関数
-│       │   ├── create.ts
-│       │   ├── list.ts
-│       │   ├── get.ts
-│       │   ├── update.ts
-│       │   └── delete.ts
+│       ├── pieces/               # 楽曲マスタ Lambda 関数（Work / Movement 共通）
+│       │   ├── create.ts             # POST /pieces (kind で Work / Movement を分岐)
+│       │   ├── list.ts               # GET /pieces (root の Work のみ)
+│       │   ├── get.ts                # GET /pieces/{id} (kind を問わず単一ノード)
+│       │   ├── update.ts             # PUT /pieces/{id} (kind 共通の単一更新)
+│       │   ├── delete.ts             # DELETE /pieces/{id} (Work は cascade、Movement は単独)
+│       │   ├── children.ts           # GET /pieces/{id}/children (Movement 一覧)
+│       │   └── replace-movements.ts  # PUT /pieces/{workId}/movements (集合一括差し替え)
 │       ├── migrations/           # 一時的なデータ移行スクリプト（レイヤードアーキテクチャから独立）
 │       │   └── piece-composer-id/
 │       │       └── index.ts      # composer(string) → composerId 移行（手動 invoke 専用）
@@ -398,10 +400,10 @@ classical-music-lake/
 - **状態**: Cognito グループによるロールベースアクセス制御を実装済み（ワーク015-02 / 015-03）
 - **実装内容**:
   - `admin` Cognito グループを CDK で全環境に定義（`CfnUserPoolGroup`）。グループ所属ユーザーの ID/Access Token には `cognito:groups: ["admin"]` クレームが付与される
-  - 楽曲マスタ書き込み API（`POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`）は `admin` グループのみ実行可能
+  - 楽曲マスタ書き込み API（`POST /pieces` / `PUT /pieces/{id}` / `DELETE /pieces/{id}` / `PUT /pieces/{workId}/movements`）は `admin` グループのみ実行可能
     - API Gateway の Cognito Authorizer で認証を強制（未認証は 401 Unauthorized）
     - Lambda ハンドラ内の `requireAdmin(event)`（`backend/src/utils/auth.ts`）で `cognito:groups` を検査し、非管理者には 403 Forbidden を返す
-  - 楽曲マスタ参照 API（`GET /pieces` / `GET /pieces/{id}`）は認証不要で公開のまま
+  - 楽曲マスタ参照 API（`GET /pieces` / `GET /pieces/{id}` / `GET /pieces/{id}/children`）は認証不要で公開のまま
 - **設計上の判断**: Cognito Authorizer にはグループ強制機能が無いため、Authorizer（トークン署名検証）と Lambda 内判定（グループ検査）の二段構えとする
 - **運用**: `admin` グループの付与・剥奪は AWS CLI／コンソールによる手動運用。グループ変更は再ログイン後に ID Token に反映される（`docs/OPERATIONS.md` 参照）
 
@@ -443,11 +445,20 @@ classical-music-lake/
   - `PieceMovementEntity extends PieceComponent`: 楽章。`parentId: PieceId` で Work を参照、`index: MovementIndex`（0..999）で演奏順を表す
 - **リポジトリ I/F**: `PieceRepository` は **root（Work）操作と子（Movement）操作を明確に分ける**
   - root 限定列挙: `findRootById` / `findRootPage` は Work のみを返す（Movement は除外）
-  - kind を問わず単体取得: `findById(id)` は Work / Movement のいずれも返す（更新フローで使用）
-  - 子要素列挙: `findChildren(parentId)` は新 GSI `parentId-index-index` を Query して Movement を `index` 昇順で全件取得する。`removeWorkCascade` / `replaceMovements` の前段処理として内部的に利用するほか、PR3 以降の Movement 一覧 API（`GET /pieces/{id}/children`）の基盤となる
+  - kind を問わず単体取得: `findById(id)` は Work / Movement のいずれも返す（更新・削除フローで使用）
+  - 子要素列挙: `findChildren(parentId)` は新 GSI `parentId-index-index` を Query して Movement を `index` 昇順で全件取得する。`removeWorkCascade` / `replaceMovements` の前段処理として内部的に利用するほか、Movement 一覧 API（`GET /pieces/{id}/children`）の基盤となる
   - カスケード: `removeWorkCascade(id)` は Work 削除時に配下 Movement を `findChildren` で集めて、Work + Movement を 1 つの TransactWriteItems で原子的に削除する
-  - `replaceMovements(workId, movements)` は既存子の Delete + 新規 Put を 1 つの TransactWriteItems で実行する（PR3 のエンドポイントから呼ばれる）。DynamoDB の TransactWriteItems 上限 100 件を超える場合は例外を投げる
-- **バリデーション**: `createPieceSchema` / `updatePieceSchema` は `z.discriminatedUnion("kind", [...])` で Work / Movement を判別する。両 Work / Movement のオブジェクトは `.strict()` で未知フィールドを拒否し、Work に `parentId` / `index` を、Movement に `composerId` / カテゴリ系を含めると 400 を返す
-- **ユースケース**: `WorkUsecase`（Work 専用）/ `MovementUsecase`（Movement 専用）/ `PieceUsecase`（kind を判別して dispatch するファサード）の 3 種に分割。`/pieces` ハンドラは従来どおり `PieceUsecase` を経由し、`PieceUsecase.getNode(id)` で kind を問わない単一ノード取得をサポートする（PR3 の `/pieces/{id}/children` 等で利用予定）
+  - `replaceMovements(workId, movements, workOptimisticLock?)` は既存子の Delete + 新規 Put を 1 つの TransactWriteItems で実行する。`workOptimisticLock` を渡すと Work の楽観的ロック付き Put（`updatedAt = :prevUpdatedAt`）を同一トランザクションに含めて Work の `updatedAt` も同時に進める（`replaceAll` 経由で常に渡す）。DynamoDB の TransactWriteItems 上限 100 件を超える場合は例外を投げる
+- **バリデーション**: `createPieceSchema` / `updatePieceSchema` は `z.discriminatedUnion("kind", [...])` で Work / Movement を判別する。両 Work / Movement のオブジェクトは `.strict()` で未知フィールドを拒否し、Work に `parentId` / `index` を、Movement に `composerId` / カテゴリ系を含めると 400 を返す。`replaceMovementsSchema` は `.refine()` で同一 Work 内の `index` 重複を拒否する
+- **ユースケース**: `WorkUsecase`（Work 専用）/ `MovementUsecase`（Movement 専用、`replaceAll(workId, items)` で集合一括差し替え）/ `PieceUsecase`（kind を判別して dispatch するファサード）の 3 種に分割。`/pieces` 単一ノードハンドラは `PieceUsecase` を経由し、`PieceUsecase.getNode(id)` で kind を問わず取得、`PieceUsecase.delete(id)` で kind を判別して cascade / 単独削除を分岐する。`PieceUsecase.resolveComposerId(node)` は Movement の親 Work から `composerId` を解決するヘルパー（API レスポンスには `composerId` を載せないが、内部の作曲家解決で使用）
+- **API エンドポイント**:
+  - `GET /pieces`（root の Work のみ、ページング）/ `GET /pieces/{id}`（kind 問わず）/ `GET /pieces/{id}/children`（Movement 一覧、認証不要）
+  - `POST /pieces`（kind 分岐）/ `PUT /pieces/{id}`（kind 共通単一更新）/ `DELETE /pieces/{id}`（kind 判別）/ `PUT /pieces/{workId}/movements`（集合一括差し替え、admin 必須）
+- **集合一括差し替え（`PUT /pieces/{workId}/movements`）の設計**:
+  - 並び替え・追加・削除を「Work 配下の楽章リスト全体」の更新として捉える
+  - Work の `updatedAt` を ifMatch 条件にして同一 TransactWriteItems で原子的に処理。競合時は 409 Conflict
+  - 上限は `MOVEMENTS_PER_WORK_MAX = 49`（`既存 49 削除 + 新規 49 Put + Work 1 件更新 = 99` で TransactWriteItems の上限 100 以下）
+  - 個別更新は `PUT /pieces/{movementId}`（軽量更新向け）、並び替え系は本エンドポイントで使い分ける二段構え
 - **PR1 時点の挙動**: 既存 API のレスポンスに `kind: "work"` が増える以外は互換。Movement 専用エンドポイントは追加していない。`DynamoDBPieceRepository` は既存レコード（`kind` を持たない）を読み込み時に `kind: "work"` で正規化することで後方互換を保つ
-- **PR2 時点の挙動**: GSI と Movement 集合操作（`findChildren` / `removeWorkCascade` / `replaceMovements`）が利用可能になった。外向き REST エンドポイントは未追加（PR3 で `GET /pieces/{id}/children`・`PUT /pieces/{workId}/movements` を追加予定）
+- **PR2 時点の挙動**: GSI と Movement 集合操作（`findChildren` / `removeWorkCascade` / `replaceMovements`）が利用可能になった。外向き REST エンドポイントは未追加
+- **PR3 時点の挙動**: Movement 一覧 / 集合一括差し替え用の REST エンドポイントを追加。`GET /pieces/{id}` を kind を問わない単一ノード取得に拡張、`DELETE /pieces/{id}` を kind 判別で cascade / 単独削除に分岐する

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -186,7 +186,7 @@ interface PieceMovement {
 type Piece = PieceWork | PieceMovement;
 ```
 
-> 1 Work あたりの Movement 件数の上限は `MOVEMENTS_PER_WORK_MAX = 64`、`index` の許容範囲は `MOVEMENT_INDEX_MIN..MOVEMENT_INDEX_MAX = 0..999`（`shared/constants.ts`）。
+> 1 Work あたりの Movement 件数の上限は `MOVEMENTS_PER_WORK_MAX = 49`、`index` の許容範囲は `MOVEMENT_INDEX_MIN..MOVEMENT_INDEX_MAX = 0..999`（`shared/constants.ts`）。49 という値は `PUT /pieces/{workId}/movements` の TransactWriteItems 上限（100 アイテム / 件）に収まるよう、最悪ケース（既存 49 削除 + 新規 49 Put + Work 1 件更新 = 99）から導出している。
 
 > **マイグレーション履歴**:
 >
@@ -194,6 +194,7 @@ type Piece = PieceWork | PieceMovement;
 > - 2026-05: `videoUrl`（単一）→ `videoUrls`（配列）。`DynamoDBPieceRepository` の読み込み時に透過的に正規化されるため、明示的な移行 Lambda は持たない
 > - 2026-05: `Piece` を Composite（`PieceWork` / `PieceMovement`）に再設計（PR1）。既存レコードは `kind` を持たないため、`DynamoDBPieceRepository` が読み込み時に `kind: "work"` を補完する。書き込み時は常に `kind` を含める。Movement の永続化と専用エンドポイントは PR2 / PR3 で追加する
 > - 2026-05: 楽曲テーブルに `parentId-index-index` GSI を追加（PR2）。`DynamoDBPieceRepository.findChildren` / `removeWorkCascade`（カスケード削除）/ `replaceMovements`（TransactWriteItems による集合置換）を有効化。GSI のバックフィルは AWS 側で非同期に走るため、PR3 デプロイ前に CloudWatch でステータスが `ACTIVE` になっていることを確認すること
+> - 2026-05: Movement 用 API（`GET /pieces/{id}/children` / `PUT /pieces/{workId}/movements`）と Work / Movement 横断の単一ノード API（`GET /pieces/{id}` / `PUT /pieces/{id}` / `DELETE /pieces/{id}`）を追加（PR3）。`MOVEMENTS_PER_WORK_MAX` を 64 → 49 に下げて TransactWriteItems の上限内に収める
 
 > **任意項目の更新**: Work では `era` / `genre` / `formation` / `region` を空文字で送信するとフィールドが削除される。`videoUrls` は空配列 `[]` で削除（Work / Movement 共通）。
 
@@ -305,10 +306,24 @@ interface ConcertLog {
 
 ### 4.5 楽曲マスタ API（`/pieces`）
 
-- **参照**: `GET /pieces`（カーソル型ページング）/ `GET /pieces/{id}`。**認証不要**
-- **書き込み**: `POST` / `PUT /{id}` / `DELETE /{id}`。**`admin` グループ必須**
+楽曲はコンポジット（Work / Movement）として扱う（§3.2）。同じ `/pieces/{id}` でも `kind` により挙動が分岐する。
+
+- **参照**: `GET /pieces`（root の Work のみ）/ `GET /pieces/{id}`（kind 問わず）/ `GET /pieces/{id}/children`（Movement 一覧）。**認証不要**
+- **書き込み**: `POST` / `PUT /{id}` / `DELETE /{id}` / `PUT /{workId}/movements`。**`admin` グループ必須**
   - 認証ヘッダーなし: `401 Unauthorized`（API Gateway Authorizer）
   - 認証済みだが非 admin: `403 Forbidden` + `{ "message": "Admin privilege required" }`
+
+#### エンドポイント一覧
+
+| メソッド | パス                         | 認証 | 概要                                                                                             |
+| -------- | ---------------------------- | ---- | ------------------------------------------------------------------------------------------------ |
+| `GET`    | `/pieces`                    | 不要 | Work（root）のカーソル型ページング。Movement は含まれない                                        |
+| `GET`    | `/pieces/{id}`               | 不要 | kind を問わず単一ノードを取得（Work でも Movement でも返す）                                     |
+| `GET`    | `/pieces/{id}/children`      | 不要 | 親 Work 配下の Movement を `index` 昇順で返す（`{ items: PieceMovement[] }` ではなく素直な配列） |
+| `POST`   | `/pieces`                    | 必須 | `kind` に応じて Work / Movement を作成                                                           |
+| `PUT`    | `/pieces/{id}`               | 必須 | kind 共通の単一更新（kind 不一致は 400）。楽観的ロック付き                                       |
+| `DELETE` | `/pieces/{id}`               | 必須 | kind を判別。Work なら配下 Movement まで cascade、Movement なら単独削除                          |
+| `PUT`    | `/pieces/{workId}/movements` | 必須 | Movement 集合の一括差し替え（並び替え・追加・削除）。Work の楽観的ロック付き                     |
 
 #### `GET /pieces` カーソル型ページング
 
@@ -317,11 +332,37 @@ interface ConcertLog {
 | `limit`  | 50   | 1〜100、範囲外は `400 Bad Request`       |
 | `cursor` | なし | 前回 `nextCursor` を渡す。不正値は `400` |
 
-レスポンス: `{ "items": Piece[], "nextCursor": "opaque-base64url" | null }`。`nextCursor` 無しで終端。
+レスポンス: `{ "items": PieceWork[], "nextCursor": "opaque-base64url" | null }`。`nextCursor` 無しで終端。Work のみが返される（Movement は `parentId-index-index` GSI に射影されるが、ベーステーブルの Scan 結果から `kind === "movement"` を除外している）。
 
 **カーソル仕様**: `base64url(JSON.stringify({ v: 1, k: LastEvaluatedKey }))` の不透明文字列。形式は Zod の `z.base64url()` で検証、デコード後の不正・未知バージョンは `decodeCursor` で検出して 400。**HMAC は付与しない**（楽曲マスタは全ユーザ共通でテナント境界を越えるリスク無し）。
 
 **ソート順**: DynamoDB Scan の戻り順（順不同）。
+
+#### `GET /pieces/{id}/children`
+
+親 Work 配下の Movement を `index` 昇順で全件返す。`parentId-index-index` GSI を利用。
+
+- レスポンス: `PieceMovement[]`（直接配列、`composerId` は含まれない）
+- 親 Work が存在しない `id` を渡しても 200 + 空配列を返す（GSI Query は親の存在を要求しない）
+
+#### `PUT /pieces/{workId}/movements`
+
+親 Work 配下の Movement 集合を一括差し替えする。並び替え・追加・削除を 1 つの DynamoDB TransactWriteItems で原子的に反映する。
+
+- **リクエストボディ**: `{ "movements": [{ "id"?, "index", "title", "videoUrls"? }, ...] }`
+  - `id` を指定すると既存 Movement の更新（`createdAt` を引き継ぐ）。省略時は新規 UUID を採番
+  - `index` は 0〜999 の整数。**同じ Work 内で重複は 400 Bad Request**（`replaceMovementsSchema.refine`）
+  - `title` は 1〜200 文字
+  - `videoUrls` は最大 10 件、URL 形式
+- **件数上限**: `MOVEMENTS_PER_WORK_MAX = 49` 件（既存 49 削除 + 新規 49 Put + Work 1 件更新 = 99 で TransactWriteItems の上限 100 以下）
+- **楽観的ロック**: Work の `updatedAt` を ifMatch 条件にして同一トランザクションで Work の `updatedAt` を進める。競合時は `409 Conflict` + `{ "message": "Piece was updated by another request" }`
+- **Work が存在しない場合**: `404 Not Found`
+- **レスポンス**: `{ "movements": PieceMovement[] }` 200 OK
+
+#### Movement のレスポンスポリシー
+
+- Movement の API レスポンスには `composerId` を含めない（親 Work から継承するため）
+- フロント側で楽章の作曲家を表示する場合は、親 Work を別途 fetch する（`GET /pieces/{parentId}`）
 
 ### 4.6 作曲家マスタ API（`/composers`）
 
@@ -354,8 +395,8 @@ interface ConcertLog {
 #### Lambda
 
 - **ランタイム**: Node.js 24.x
-- **関数数**: 26 個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
-  - 視聴ログ × 5 / 楽曲マスタ × 5 / 作曲家マスタ × 5 / コンサート記録 × 5 / 認証系 × 5（register・login・verify-email・resend-verification-code・refresh）/ PreSignUp トリガー × 1
+- **関数数**: 28 個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
+  - 視聴ログ × 5 / 楽曲マスタ × 7（CRUD 5 + `getPieceChildren` + `replacePieceMovements`）/ 作曲家マスタ × 5 / コンサート記録 × 5 / 認証系 × 5（register・login・verify-email・resend-verification-code・refresh）/ PreSignUp トリガー × 1
 - **環境変数**: `DYNAMO_TABLE_{LISTENING_LOGS,PIECES,CONCERT_LOGS,COMPOSERS}`、`COGNITO_USER_POOL_ID` / `COGNITO_CLIENT_ID`（認証系のみ）、`CORS_ALLOW_ORIGIN`
 
 #### Cognito

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -43,8 +43,13 @@ export type PieceKind = (typeof PIECE_KINDS)[number];
 /**
  * 1 つの Work に紐付けられる Movement の最大数。
  * UI / バリデーションの双方で参照する。
+ *
+ * 上限値の根拠: Movement の集合一括差し替え（`PUT /pieces/{workId}/movements`）は
+ * 1 つの DynamoDB TransactWriteItems で実行する。最大 100 アイテム / トランザクション
+ * の制約があるため、最悪ケース（既存 49 削除 + 新規 49 Put + Work 1 件の更新）= 99 で 100
+ * 以下に収まるよう 49 に抑える。
  */
-export const MOVEMENTS_PER_WORK_MAX = 64;
+export const MOVEMENTS_PER_WORK_MAX = 49;
 
 /**
  * Movement の `index` 値（演奏順）の許容範囲。0 始まり。


### PR DESCRIPTION
## 概要

楽曲マスタの Movement（楽章）専用 API と Work / Movement 横断の単一ノード API を実装します。Movement の集合一括差し替え、子要素の一覧取得、単一ノードの削除時に kind を判別した処理分岐を追加します。

## 変更の種類

- [x] 新機能
- [x] リファクタリング
- [x] テスト

## 変更内容

### 新規エンドポイント

- **`GET /pieces/{id}/children`**: 親 Work 配下の Movement を `index` 昇順で全件返す（認証不要）
- **`PUT /pieces/{workId}/movements`**: Movement 集合を一括差し替え。並び替え・追加・削除を 1 つの DynamoDB TransactWriteItems で原子的に反映（admin 必須）
  - リクエストボディ: `{ movements: [{ id?, index, title, videoUrls? }, ...] }`
  - `id` 指定時は既存 Movement の更新（`createdAt` を引き継ぐ）、省略時は新規採番
  - 同一 Work 内で `index` の重複は 400 で拒否
  - Work の `updatedAt` を楽観的ロック（ifMatch）にして同一トランザクションに含める。競合時は 409 Conflict

### ユースケース層の拡張

- **`MovementUsecase.replaceAll()`**: Movement 集合一括置換の実装
  - 既存子を全削除し、新規 Movement に id を採番
  - Work の `updatedAt` を進める（楽観的ロック付き）
  - 404（Work 不在）/ 409（ロック競合）を投げる

- **`PieceUsecase.delete()`**: kind 判別による削除処理の分岐
  - Work: `removeWorkCascade`（配下 Movement も削除）
  - Movement: `removeMovement`（単独削除）
  - 存在しない id は冪等に扱う（DELETE 系の慣例）

- **`PieceUsecase.resolveComposerId()`**: 任意ノードから `composerId` を解決
  - Work: 自身の `composerId` を返す
  - Movement: 親 Work を引き、親の `composerId` を返す

### リポジトリ層の拡張

- **`DynamoDBPieceRepository.replaceMovements()`**: 楽観的ロック対応
  - `workOptimisticLock` パラメータで Work の条件付き Put をトランザクションに含める
  - TransactionCanceledException を 409 Conflict に変換

### ハンドラ層

- **`handlers/pieces/children.ts`**: Movement 一覧取得ハンドラ
- **`handlers/pieces/replace-movements.ts`**: Movement 集合置換ハンドラ（admin 必須）
- **`handlers/pieces/get.ts`**: kind を問わず単一ノード取得に対応
- **`handlers/pieces/delete.ts`**: kind 判別による削除処理の分岐

### 定数・スキーマの更新

- **`MOVEMENTS_PER_WORK_MAX`**: 64 → 49 に引き下げ
  - 根拠: TransactWriteItems の 100 アイテム上限に収まるよう、最悪ケース（既存 49 削除 + 新規 49 Put + Work 1 件更新

https://claude.ai/code/session_014QgMvwbRCDLpKxor6UwbZ7