### PR TITLE
feat(migrations): 楽曲レコードの kind バックフィル移行 Lambda を追加

### DIFF
--- a/backend/src/migrations/piece-kind-backfill/index.test.ts
+++ b/backend/src/migrations/piece-kind-backfill/index.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { runMigration } from "./index";
+
+type PieceRecord = {
+  id: string;
+  kind?: string;
+  title?: string;
+  composerId?: string;
+  parentId?: string;
+  index?: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const makePiece = (id: string, overrides: Partial<PieceRecord> = {}): PieceRecord => ({
+  id,
+  title: `曲 ${id}`,
+  composerId: "composer-1",
+  createdAt: "2024-06-01T09:00:00.000Z",
+  updatedAt: "2024-06-01T09:00:00.000Z",
+  ...overrides,
+});
+
+describe("runMigration (piece-kind-backfill)", () => {
+  const savePiece = vi.fn();
+
+  const runWithFixtures = (pieces: PieceRecord[], options: { dryRun?: boolean } = {}) =>
+    runMigration(
+      {
+        scanAllPieces: async () => pieces,
+        savePiece,
+      },
+      options,
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("kind が未設定の Piece は kind=work が付与される", async () => {
+    const pieces = [makePiece("p1"), makePiece("p2")];
+    const summary = await runWithFixtures(pieces);
+
+    expect(summary.total).toBe(2);
+    expect(summary.backfilled).toBe(2);
+    expect(summary.skippedAlreadyKind).toBe(0);
+    expect(savePiece).toHaveBeenCalledTimes(2);
+    const saved = savePiece.mock.calls.map((call) => call[0] as PieceRecord);
+    expect(saved[0].kind).toBe("work");
+    expect(saved[1].kind).toBe("work");
+  });
+
+  it("既に kind=work を持つ Piece は skip する（べき等性）", async () => {
+    const pieces = [makePiece("p1", { kind: "work" }), makePiece("p2")];
+    const summary = await runWithFixtures(pieces);
+
+    expect(summary.backfilled).toBe(1);
+    expect(summary.skippedAlreadyKind).toBe(1);
+    expect(savePiece).toHaveBeenCalledTimes(1);
+    const saved = savePiece.mock.calls[0][0] as PieceRecord;
+    expect(saved.id).toBe("p2");
+  });
+
+  it("既に kind=movement を持つ Piece も skip する（べき等性）", async () => {
+    const pieces = [
+      makePiece("m1", { kind: "movement", parentId: "p1", index: 0 }),
+      makePiece("p1", { kind: "work" }),
+      makePiece("p2"),
+    ];
+    const summary = await runWithFixtures(pieces);
+
+    expect(summary.total).toBe(3);
+    expect(summary.backfilled).toBe(1);
+    expect(summary.skippedAlreadyKind).toBe(2);
+    expect(savePiece).toHaveBeenCalledTimes(1);
+    const saved = savePiece.mock.calls[0][0] as PieceRecord;
+    expect(saved.id).toBe("p2");
+    expect(saved.kind).toBe("work");
+  });
+
+  it("dryRun=true のとき write 系は呼ばれない", async () => {
+    const pieces = [makePiece("p1"), makePiece("p2")];
+    const summary = await runWithFixtures(pieces, { dryRun: true });
+
+    expect(summary.dryRun).toBe(true);
+    expect(summary.backfilled).toBe(2);
+    expect(savePiece).not.toHaveBeenCalled();
+  });
+
+  it("既存フィールド（id / createdAt / updatedAt / 他属性）は変更しない", async () => {
+    const pieces = [
+      makePiece("p1", {
+        composerId: "composer-x",
+        createdAt: "2024-01-02T03:04:05.000Z",
+        updatedAt: "2024-01-02T03:04:05.000Z",
+      }),
+    ];
+    await runWithFixtures(pieces);
+
+    const saved = savePiece.mock.calls[0][0] as PieceRecord;
+    expect(saved.id).toBe("p1");
+    expect(saved.composerId).toBe("composer-x");
+    expect(saved.createdAt).toBe("2024-01-02T03:04:05.000Z");
+    expect(saved.updatedAt).toBe("2024-01-02T03:04:05.000Z");
+    expect(saved.kind).toBe("work");
+  });
+
+  it("空のテーブルでもエラーにならず total=0 を返す", async () => {
+    const summary = await runWithFixtures([]);
+
+    expect(summary.total).toBe(0);
+    expect(summary.backfilled).toBe(0);
+    expect(summary.skippedAlreadyKind).toBe(0);
+    expect(savePiece).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/migrations/piece-kind-backfill/index.ts
+++ b/backend/src/migrations/piece-kind-backfill/index.ts
@@ -1,0 +1,120 @@
+import { DynamoDBClient } from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, PutCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
+
+/**
+ * Piece の `kind` フィールドが未設定のレコードに `kind = "work"` を埋める一発移行スクリプト。
+ *
+ * Composite モデル（PR1）導入前に作成されたレコードは `kind` を持たない。
+ * `DynamoDBPieceRepository` は読み込み時に `kind: "work"` を補完して動作するが、
+ * 永続化されたデータ自体を正規化することで透過的な互換ロジックを将来削除可能にする。
+ *
+ * 既存のレイヤードアーキテクチャ（handlers / usecases / repositories / domain）とは独立しており、
+ * 一時的な移行コードが本体の依存関係を汚さないように `backend/src/migrations/` 配下に閉じ込めている。
+ *
+ * 動作:
+ * - べき等: 既に `kind` を持つ Piece は skip する（`kind === "work" | "movement"`）
+ * - `kind` 未設定の Piece に `kind = "work"` を付与して PutItem
+ * - `id` / `createdAt` / `updatedAt` を含む既存フィールドは触らない（updatedAt も更新しない）
+ * - `dryRun: true` のとき DB 書き込みを行わずログ出力のみ
+ */
+
+type PieceRecord = {
+  id: string;
+  kind?: string;
+  createdAt: string;
+  updatedAt: string;
+  [key: string]: unknown;
+};
+
+export type MigrateEvent = {
+  dryRun?: boolean;
+};
+
+export type MigrateSummary = {
+  total: number;
+  backfilled: number;
+  skippedAlreadyKind: number;
+  dryRun: boolean;
+};
+
+export type MigrationDeps = {
+  scanAllPieces: () => Promise<PieceRecord[]>;
+  savePiece: (piece: PieceRecord) => Promise<void>;
+};
+
+export async function runMigration(
+  deps: MigrationDeps,
+  event: MigrateEvent = {},
+): Promise<MigrateSummary> {
+  const dryRun = event.dryRun === true;
+  const pieces = await deps.scanAllPieces();
+
+  const summary: MigrateSummary = {
+    total: pieces.length,
+    backfilled: 0,
+    skippedAlreadyKind: 0,
+    dryRun,
+  };
+
+  for (const piece of pieces) {
+    if (piece.kind === "work" || piece.kind === "movement") {
+      summary.skippedAlreadyKind += 1;
+      console.log({ pieceId: piece.id, action: "skipped-already-kind", kind: piece.kind });
+      continue;
+    }
+
+    const backfilled: PieceRecord = { ...piece, kind: "work" };
+    if (!dryRun) {
+      await deps.savePiece(backfilled);
+    }
+    summary.backfilled += 1;
+    console.log({
+      pieceId: piece.id,
+      action: dryRun ? "would-backfill-kind" : "backfilled-kind",
+      kind: "work",
+    });
+  }
+
+  console.log({ action: "migration-complete", ...summary });
+  return summary;
+}
+
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (value === undefined || value === "") {
+    throw new Error(`Required environment variable is missing: ${name}`);
+  }
+  return value;
+}
+
+function makeDefaultDeps(): MigrationDeps {
+  const client = new DynamoDBClient({ region: process.env.AWS_REGION ?? "ap-northeast-1" });
+  const dynamo = DynamoDBDocumentClient.from(client, {
+    marshallOptions: { removeUndefinedValues: true },
+  });
+  const piecesTable = requireEnv("DYNAMO_TABLE_PIECES");
+
+  const scanAll = async (): Promise<PieceRecord[]> => {
+    const items: PieceRecord[] = [];
+    let cursor: Record<string, unknown> | undefined;
+    do {
+      const result = await dynamo.send(
+        new ScanCommand({ TableName: piecesTable, ExclusiveStartKey: cursor }),
+      );
+      items.push(...((result.Items ?? []) as PieceRecord[]));
+      cursor = result.LastEvaluatedKey as Record<string, unknown> | undefined;
+    } while (cursor !== undefined);
+    return items;
+  };
+
+  return {
+    scanAllPieces: scanAll,
+    savePiece: async (piece) => {
+      await dynamo.send(new PutCommand({ TableName: piecesTable, Item: piece }));
+    },
+  };
+}
+
+export const handler = async (event: MigrateEvent = {}): Promise<MigrateSummary> => {
+  return runMigration(makeDefaultDeps(), event);
+};

--- a/cdk/lib/migrations-stack.ts
+++ b/cdk/lib/migrations-stack.ts
@@ -76,6 +76,43 @@ export class MigrationsStack extends cdk.Stack {
       },
       role: this.makeMigrationRole("MigratePieceComposerRole", [piecesTable, composersTable]),
     });
+
+    // -------------------------
+    // Migration: Piece.kind バックフィル（PR4）
+    // 既存レコードに `kind = "work"` を埋める。手動 invoke 専用、API Gateway には接続しない。
+    // 全件 Scan + PutItem を含むため、メモリと reservedConcurrency を `MigratePieceComposer` と
+    // 揃える。IAM は piecesTable のみ。
+    // -------------------------
+    const migratePieceKindBackfillLogGroup = new logs.LogGroup(
+      this,
+      "MigratePieceKindBackfillLogGroup",
+      {
+        retention: logs.RetentionDays.THREE_MONTHS,
+        removalPolicy,
+      },
+    );
+
+    new lambdaNodejs.NodejsFunction(this, "MigratePieceKindBackfill", {
+      // prettier-ignore
+      entry: path.join(backendSrcDir, "migrations/piece-kind-backfill/index.ts"), // NOSONAR
+      handler: "handler",
+      runtime: lambda.Runtime.NODEJS_24_X,
+      architecture: lambda.Architecture.ARM_64,
+      memorySize: 512,
+      timeout: cdk.Duration.seconds(60),
+      tracing: lambda.Tracing.ACTIVE,
+      reservedConcurrentExecutions: 1,
+      environment: {
+        DYNAMO_TABLE_PIECES: piecesTableName,
+      },
+      logGroup: migratePieceKindBackfillLogGroup,
+      bundling: {
+        minify: true,
+        sourceMap: false,
+        target: "es2022",
+      },
+      role: this.makeMigrationRole("MigratePieceKindBackfillRole", [piecesTable]),
+    });
   }
 
   /**

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -413,3 +413,92 @@ aws dynamodb restore-table-from-backup \
 5. S3 同期（フロント差し替え）
 6. CloudFront invalidation
 7. 移行完了確認後、任意のタイミングで `cdk destroy MigrationsStack[-<stage>]` でスタック破棄
+
+---
+
+## Piece の `kind` バックフィル移行手順
+
+楽曲マスタを Composite モデル（Work / Movement）に再設計（PR1）するより前に作成された `Piece` レコードは `kind` フィールドを持たない。読み込み時には `DynamoDBPieceRepository` が `kind: "work"` を補完するため API レスポンスは正常だが、永続化されたデータ自体を正規化することで透過的な互換ロジックを将来削除可能にする。
+
+### 前提
+
+- 移行 Lambda は `MigrationsStack[-<stage>]` に所属する。ソースは `backend/src/migrations/piece-kind-backfill/index.ts`
+- `MigrationsStack[-<stage>]` をデプロイすると `MigratePieceKindBackfill` Lambda が作成される（API Gateway には接続されない）
+- 対象テーブル: `classical-music-pieces[-<stage>]`（`ClassicalMusicLakeStack[-<stage>]` 側で作成済みのものをテーブル名で参照）
+- IAM は piecesTable のみ。`reservedConcurrentExecutions: 1` で同時実行禁止
+- 依存関係: PR2（`parentId-index-index` GSI 追加）のデプロイが各環境に伝播済みであること（GSI バックフィルが走るとテーブルへの書き込み I/O が一時的に上がるため、移行は GSI が ACTIVE になってから実施する）
+- **べき等**: `kind` が既に `"work"` または `"movement"` のレコードは skip される。何度実行しても安全
+
+### 実行手順（環境ごとに `dev → stg → prod` の順で実施）
+
+> 推奨スパン: dev で実行 → 24 時間後に stg → 1 週間後に prod。各段で問題が無いことを確認してから次の環境へ進む。
+
+#### 1. オンデマンドバックアップの取得（必須）
+
+```bash
+STAGE=dev  # stg / prod
+aws dynamodb create-backup \
+  --table-name classical-music-pieces-${STAGE} \
+  --backup-name "pre-kind-backfill-$(date +%Y%m%d)"
+```
+
+> prod は `-<stage>` サフィックスなし（`classical-music-pieces`）。
+
+#### 2. dry-run でログ確認
+
+```bash
+FUNC=$(aws lambda list-functions \
+  --query "Functions[?contains(FunctionName, 'MigratePieceKindBackfill')].FunctionName | [0]" \
+  --output text)
+
+aws lambda invoke \
+  --function-name $FUNC \
+  --payload '{"dryRun": true}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/kind-backfill-dry-run.json
+
+cat /tmp/kind-backfill-dry-run.json
+```
+
+CloudWatch Logs から:
+
+- `total` / `backfilled` / `skippedAlreadyKind` のサマリを確認
+- `would-backfill-kind` の各行を目視レビュー（`pieceId` のサンプリング確認）
+- 想定件数と乖離があれば次の手順に進まない
+
+#### 3. 本番モードで invoke
+
+```bash
+aws lambda invoke \
+  --function-name $FUNC \
+  --payload '{"dryRun": false}' \
+  --cli-binary-format raw-in-base64-out \
+  /tmp/kind-backfill-run.json
+
+cat /tmp/kind-backfill-run.json
+```
+
+レスポンスの `backfilled` 件数と dry-run の件数が一致することを確認する。
+
+#### 4. 再実行（べき等）
+
+途中で失敗した場合や追加で `kind` 欠損レコードが見つかった場合は、再度 `{"dryRun": false}` で invoke する。既に `kind` を持つ Piece は自動 skip される（べき等）。
+
+#### 5. 確認
+
+- 1 件サンプリング: `aws dynamodb get-item --table-name classical-music-pieces[-<stage>] --key '{"id": {"S": "<対象ID>"}}'` で `kind` 属性が `"work"` になっていることを確認
+- 全件確認（小規模環境のみ）: `aws dynamodb scan --table-name classical-music-pieces[-<stage>] --filter-expression 'attribute_not_exists(kind)' --output json` の `Count` が 0 になっていること
+- フロントエンドで楽曲一覧・詳細ページが従来どおり表示されることを確認
+
+### ロールバック
+
+`kind` の付与のみであり、`updatedAt` も触らないためロールバックの必要は通常ない。万一テーブル全体を巻き戻す必要がある場合は、手順 1 のオンデマンドバックアップから別テーブル名で復元し、差分確認後に本番テーブルへ差し替える。
+
+### 移行完了後
+
+全環境（dev / stg / prod）で `skippedAlreadyKind === total` となり `backfilled === 0` になることを確認したら、別 PR で次のクリーンアップを行う:
+
+1. `cdk/lib/migrations-stack.ts` から `MigratePieceKindBackfill` Lambda・LogGroup・IAM ロールを削除
+2. `backend/src/migrations/piece-kind-backfill/` ディレクトリを削除
+3. `docs/OPERATIONS.md` の本セクションを削除
+4. （任意）`DynamoDBPieceRepository.normalizeLegacyKind` の互換ロジックも別 PR で除去できる


### PR DESCRIPTION
Closes #643

## Summary

- 既存の `Piece` レコード（`kind` 未設定）に `kind = "work"` を埋めるべき等な移行 Lambda を `MigrationsStack` に追加
- `id` / `createdAt` / `updatedAt` を含む既存フィールドは触らず、`kind = "work" | "movement"` を持つレコードは skip する設計
- dev → stg → prod の順で手動 invoke する運用手順を `docs/OPERATIONS.md` に追記

## 変更内容

### `backend/src/migrations/piece-kind-backfill/`

- `index.ts`: `piece-composer-id/index.ts` を雛形に、`scanAllPieces` → `kind` が無いものに `kind = "work"` を `PutItem` する Lambda を追加。`dryRun` 対応 + サマリログ
- `index.test.ts`: べき等性（`kind=work` / `kind=movement` のスキップ）、dryRun、既存フィールド保持、空テーブルを検証（6 ケース）

### `cdk/lib/migrations-stack.ts`

- `MigratePieceKindBackfill` Lambda を追加（`MigratePieceComposer` のコピー）
  - `memorySize: 512` / `timeout: 60s` / `reservedConcurrentExecutions: 1`
  - IAM は `piecesTable` のみ（`composersTable` には触らない）
  - 専用 LogGroup (`MigratePieceKindBackfillLogGroup`) を追加

### `docs/OPERATIONS.md`

- 「Piece の `kind` バックフィル移行手順」セクションを追加
  - dev → stg → prod の順、各環境で dryRun → 本番 invoke → ログ確認
  - 移行完了後に Lambda を CDK から削除する別 PR を作成する旨を記載

## マイグレーション段取り

```text
PR2 マージ → CDK デプロイで GSI が dev → stg → prod に伝播
   ↓
本 PR マージ → MigratePieceKindBackfill Lambda がデプロイされる
   ↓
1. dev: dryRun → 件数確認 → 本番 invoke → 1 件サンプリング確認
2. stg: 24h 後に同じ手順
3. prod: stg から 1 週間後に同じ手順
   ↓
全環境完了後、別 PR で Lambda を CDK から削除
```

## Test plan

- [x] `pnpm -C backend exec vitest run src/migrations/piece-kind-backfill/index.test.ts` → 6 passed
- [x] `pnpm -C backend test` → 746 passed
- [x] `pnpm run lint` → no errors
- [x] `pnpm run format:check` → all files clean
- [x] `pnpm -C cdk run build` → tsc passes
- [ ] dev デプロイ後に dryRun → 件数確認 → 本番 invoke して 1 件サンプリング


---
_Generated by [Claude Code](https://claude.ai/code/session_01TwJKBQSpFn1nk5Y5FJiSAP)_