### PR TITLE
feat(pieces): 楽曲詳細ページに楽章一覧と Movement パンくずを追加

### DIFF
--- a/app/components/molecules/MovementListItem.stories.ts
+++ b/app/components/molecules/MovementListItem.stories.ts
@@ -1,0 +1,70 @@
+import type { Meta, StoryObj } from "@storybook-vue/nuxt";
+import type { PieceMovement } from "~/types";
+import MovementListItem from "./MovementListItem.vue";
+
+const meta: Meta<typeof MovementListItem> = {
+  title: "Molecules/MovementListItem",
+  component: MovementListItem,
+};
+
+export default meta;
+type Story = StoryObj<typeof MovementListItem>;
+
+const baseMovement: PieceMovement = {
+  kind: "movement",
+  id: "movement-1",
+  parentId: "work-1",
+  index: 0,
+  title: "第1楽章 Allegro ma non troppo",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+export const Default: Story = {
+  args: { movement: baseMovement },
+};
+
+export const WithYouTubeVideo: Story = {
+  args: {
+    movement: {
+      ...baseMovement,
+      videoUrls: ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+    },
+  },
+};
+
+export const WithMultipleYouTubeVideos: Story = {
+  args: {
+    movement: {
+      ...baseMovement,
+      videoUrls: [
+        "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+        "https://www.youtube.com/watch?v=abc123",
+      ],
+    },
+  },
+};
+
+export const WithExternalUrl: Story = {
+  args: {
+    movement: {
+      ...baseMovement,
+      videoUrls: ["https://example.com/video.mp4"],
+    },
+  },
+};
+
+export const WithMixedVideoUrls: Story = {
+  args: {
+    movement: {
+      ...baseMovement,
+      videoUrls: ["https://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://example.com/video.mp4"],
+    },
+  },
+};
+
+export const TenthMovement: Story = {
+  args: {
+    movement: { ...baseMovement, id: "movement-10", index: 9, title: "第10楽章" },
+  },
+};

--- a/app/components/molecules/MovementListItem.test.ts
+++ b/app/components/molecules/MovementListItem.test.ts
@@ -1,0 +1,112 @@
+import { mountSuspended } from "@nuxt/test-utils/runtime";
+import MovementListItem from "./MovementListItem.vue";
+import type { PieceMovement } from "~/types";
+
+const baseMovement: PieceMovement = {
+  kind: "movement",
+  id: "movement-1",
+  parentId: "work-1",
+  index: 0,
+  title: "第1楽章 Allegro ma non troppo",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+describe("MovementListItem", () => {
+  describe("表示", () => {
+    it("楽章名が表示される", async () => {
+      const wrapper = await mountSuspended(MovementListItem, {
+        props: { movement: baseMovement },
+      });
+      expect(wrapper.text()).toContain("第1楽章 Allegro ma non troppo");
+    });
+
+    it("index は 1 始まりで 2 桁ゼロ埋め表示される", async () => {
+      const wrapper = await mountSuspended(MovementListItem, {
+        props: { movement: { ...baseMovement, index: 0 } },
+      });
+      expect(wrapper.find(".movement-index").text()).toContain("01");
+    });
+
+    it("index が 2 桁の値でも 2 桁表示される", async () => {
+      const wrapper = await mountSuspended(MovementListItem, {
+        props: { movement: { ...baseMovement, index: 11 } },
+      });
+      expect(wrapper.find(".movement-index").text()).toContain("12");
+    });
+  });
+
+  describe("YouTube URL の動画埋め込み", () => {
+    it("YouTube URL の場合、iframe 埋め込みが描画される", async () => {
+      const movement: PieceMovement = {
+        ...baseMovement,
+        videoUrls: ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+      };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      const iframe = wrapper.find(".movement-iframe");
+      expect(iframe.exists()).toBe(true);
+      expect(iframe.attributes("src")).toBe(
+        "https://www.youtube.com/embed/dQw4w9WgXcQ?enablejsapi=1&rel=0&fs=0",
+      );
+    });
+
+    it("短縮形式の YouTube URL でも iframe 埋め込みが描画される", async () => {
+      const movement: PieceMovement = {
+        ...baseMovement,
+        videoUrls: ["https://youtu.be/dQw4w9WgXcQ"],
+      };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      const iframe = wrapper.find(".movement-iframe");
+      expect(iframe.exists()).toBe(true);
+      expect(iframe.attributes("src")).toBe(
+        "https://www.youtube.com/embed/dQw4w9WgXcQ?enablejsapi=1&rel=0&fs=0",
+      );
+    });
+
+    it("複数の YouTube URL が含まれる場合、複数の iframe が描画される", async () => {
+      const movement: PieceMovement = {
+        ...baseMovement,
+        videoUrls: ["https://www.youtube.com/watch?v=aaa", "https://www.youtube.com/watch?v=bbb"],
+      };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      expect(wrapper.findAll(".movement-iframe")).toHaveLength(2);
+    });
+
+    it("YouTube 以外の URL は外部リンクとして描画される", async () => {
+      const movement: PieceMovement = {
+        ...baseMovement,
+        videoUrls: ["https://example.com/video.mp4"],
+      };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      expect(wrapper.find(".movement-iframe").exists()).toBe(false);
+      const link = wrapper.find(".external-link");
+      expect(link.exists()).toBe(true);
+      expect(link.attributes("href")).toBe("https://example.com/video.mp4");
+    });
+
+    it("YouTube URL と外部 URL が混在する場合、両方が描画される", async () => {
+      const movement: PieceMovement = {
+        ...baseMovement,
+        videoUrls: ["https://www.youtube.com/watch?v=aaa", "https://example.com/video.mp4"],
+      };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      expect(wrapper.findAll(".movement-iframe")).toHaveLength(1);
+      expect(wrapper.findAll(".external-link")).toHaveLength(1);
+    });
+
+    it("videoUrls が未設定の場合、iframe も外部リンクも描画されない", async () => {
+      const wrapper = await mountSuspended(MovementListItem, {
+        props: { movement: baseMovement },
+      });
+      expect(wrapper.find(".movement-iframe").exists()).toBe(false);
+      expect(wrapper.find(".external-link").exists()).toBe(false);
+    });
+
+    it("videoUrls が空配列の場合、iframe も外部リンクも描画されない", async () => {
+      const movement: PieceMovement = { ...baseMovement, videoUrls: [] };
+      const wrapper = await mountSuspended(MovementListItem, { props: { movement } });
+      expect(wrapper.find(".movement-iframe").exists()).toBe(false);
+      expect(wrapper.find(".external-link").exists()).toBe(false);
+    });
+  });
+});

--- a/app/components/molecules/MovementListItem.vue
+++ b/app/components/molecules/MovementListItem.vue
@@ -1,0 +1,121 @@
+<script setup lang="ts">
+import type { PieceMovement } from "~/types";
+import { isYouTubeUrl, toYouTubeEmbedUrl } from "~/utils/video";
+
+const props = defineProps<{
+  movement: PieceMovement;
+}>();
+
+const displayIndex = computed(() => (props.movement.index + 1).toString().padStart(2, "0"));
+
+const youtubeEmbedUrls = computed(() =>
+  (props.movement.videoUrls ?? []).filter(isYouTubeUrl).map(toYouTubeEmbedUrl),
+);
+
+const externalUrls = computed(() =>
+  (props.movement.videoUrls ?? []).filter((url) => !isYouTubeUrl(url)),
+);
+</script>
+
+<template>
+  <article class="movement-list-item">
+    <header class="movement-head">
+      <span class="movement-index smallcaps numeric">N&deg; {{ displayIndex }}</span>
+      <h3 class="movement-title">{{ movement.title }}</h3>
+    </header>
+
+    <div v-if="youtubeEmbedUrls.length > 0" class="movement-videos">
+      <div
+        v-for="(embedUrl, i) in youtubeEmbedUrls"
+        :key="`${movement.id}-yt-${i}`"
+        class="movement-video"
+      >
+        <iframe
+          :src="embedUrl"
+          class="movement-iframe"
+          title="YouTube 動画プレーヤー"
+          allowfullscreen
+        />
+      </div>
+    </div>
+
+    <ul v-if="externalUrls.length > 0" class="movement-external-links">
+      <li v-for="(url, i) in externalUrls" :key="`${movement.id}-ext-${i}`">
+        <a :href="url" target="_blank" rel="noopener noreferrer" class="external-link">
+          動画を開く（外部リンク）
+        </a>
+      </li>
+    </ul>
+  </article>
+</template>
+
+<style scoped>
+.movement-list-item {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  padding: 1.2rem 0;
+  border-bottom: 1px solid var(--color-hairline);
+}
+
+.movement-head {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.movement-index {
+  color: var(--color-text-faint);
+  flex: 0 0 auto;
+}
+
+.movement-title {
+  font-family: var(--font-display);
+  font-style: italic;
+  font-weight: 400;
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  line-height: 1.3;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 50;
+}
+
+.movement-videos {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+  margin-top: 0.4rem;
+}
+
+.movement-video {
+  width: 100%;
+}
+
+.movement-iframe {
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  border: 1px solid var(--color-hairline);
+  border-radius: 6px;
+}
+
+.movement-external-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.external-link {
+  color: var(--color-text);
+  text-decoration: underline;
+  font-size: 0.92rem;
+}
+
+.external-link:hover {
+  color: var(--color-accent);
+}
+</style>

--- a/app/components/molecules/PieceCategoryList.test.ts
+++ b/app/components/molecules/PieceCategoryList.test.ts
@@ -1,15 +1,15 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceCategoryList from "./PieceCategoryList.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
-const allCategories: Pick<Piece, "genre" | "era" | "formation" | "region"> = {
+const allCategories: Pick<PieceWork, "genre" | "era" | "formation" | "region"> = {
   genre: "交響曲",
   era: "ロマン派",
   formation: "管弦楽",
   region: "ドイツ・オーストリア",
 };
 
-const noCategories: Pick<Piece, "genre" | "era" | "formation" | "region"> = {};
+const noCategories: Pick<PieceWork, "genre" | "era" | "formation" | "region"> = {};
 
 describe("PieceCategoryList", () => {
   describe("カテゴリあり", () => {

--- a/app/components/molecules/PieceCategoryList.vue
+++ b/app/components/molecules/PieceCategoryList.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 type Kind = "genre" | "era" | "formation" | "region";
 
 const props = defineProps<{
-  piece: Pick<Piece, "genre" | "era" | "formation" | "region">;
+  piece: Pick<PieceWork, "genre" | "era" | "formation" | "region">;
 }>();
 
 const categories = computed(() =>

--- a/app/components/molecules/PieceItem.stories.ts
+++ b/app/components/molecules/PieceItem.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import PieceItem from "./PieceItem.vue";
 
 const meta: Meta<typeof PieceItem> = {
@@ -13,7 +13,8 @@ type Story = StoryObj<typeof PieceItem>;
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: "1",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: COMPOSER_ID_BEETHOVEN,

--- a/app/components/molecules/PieceItem.test.ts
+++ b/app/components/molecules/PieceItem.test.ts
@@ -2,11 +2,12 @@ import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceItem from "./PieceItem.vue";
 import ButtonSecondary from "../atoms/ButtonSecondary.vue";
 import ButtonDanger from "../atoms/ButtonDanger.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: "1",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: COMPOSER_ID,
@@ -14,7 +15,7 @@ const samplePiece: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const samplePieceWithCategories: Piece = {
+const samplePieceWithCategories: PieceWork = {
   ...samplePiece,
   genre: "交響曲",
   era: "ロマン派",
@@ -22,22 +23,22 @@ const samplePieceWithCategories: Piece = {
   region: "ドイツ・オーストリア",
 };
 
-const samplePieceWithYouTubeUrl: Piece = {
+const samplePieceWithYouTubeUrl: PieceWork = {
   ...samplePiece,
   videoUrls: ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
 };
 
-const samplePieceWithShortYouTubeUrl: Piece = {
+const samplePieceWithShortYouTubeUrl: PieceWork = {
   ...samplePiece,
   videoUrls: ["https://youtu.be/dQw4w9WgXcQ"],
 };
 
-const samplePieceWithNonYouTubeUrl: Piece = {
+const samplePieceWithNonYouTubeUrl: PieceWork = {
   ...samplePiece,
   videoUrls: ["https://example.com/video.mp4"],
 };
 
-const samplePieceWithMultipleYouTubeUrls: Piece = {
+const samplePieceWithMultipleYouTubeUrls: PieceWork = {
   ...samplePiece,
   videoUrls: [
     "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
@@ -171,7 +172,7 @@ describe("PieceItem", () => {
   });
 
   describe("YouTube サムネイル表示", () => {
-    const expectThumbnailVisible = async (piece: Piece, shouldExist: boolean) => {
+    const expectThumbnailVisible = async (piece: PieceWork, shouldExist: boolean) => {
       const wrapper = await mountSuspended(PieceItem, {
         props: { piece, composerName: "ベートーヴェン" },
       });

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import { isYouTubeUrl } from "~/utils/video";
 
 const props = defineProps<{
-  piece: Piece;
+  piece: PieceWork;
   composerName: string;
 }>();
 

--- a/app/components/organisms/ConcertLogDetail.stories.ts
+++ b/app/components/organisms/ConcertLogDetail.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog, Piece } from "~/types";
+import type { ConcertLog, PieceWork } from "~/types";
 import ConcertLogDetail from "./ConcertLogDetail.vue";
 
 const meta: Meta<typeof ConcertLogDetail> = {
@@ -31,8 +31,9 @@ const baseLog: ConcertLog = {
   updatedAt: "2024-01-15T20:00:00.000Z",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -40,6 +41,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "piece-2",
     title: "ピアノ協奏曲第1番",
     composerId: COMPOSER_ID_TCHAIKOVSKY,

--- a/app/components/organisms/ConcertLogDetail.test.ts
+++ b/app/components/organisms/ConcertLogDetail.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ConcertLogDetail from "./ConcertLogDetail.vue";
-import type { ConcertLog, Piece } from "~/types";
+import type { ConcertLog, PieceWork } from "~/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000002";
@@ -23,8 +23,9 @@ const sampleLog: ConcertLog = {
   updatedAt: "2024-01-15T20:00:00.000Z",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -32,6 +33,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "piece-2",
     title: "ピアノ協奏曲第1番",
     composerId: COMPOSER_ID_TCHAIKOVSKY,

--- a/app/components/organisms/ConcertLogDetail.vue
+++ b/app/components/organisms/ConcertLogDetail.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { formatDatetime } from "~/utils/date";
-import type { ConcertLog, Piece } from "~/types";
+import type { ConcertLog, PieceWork } from "~/types";
 
 const props = defineProps<{
   log: ConcertLog;
-  pieces: Piece[];
+  pieces: PieceWork[];
   composerNameById: Record<string, string>;
 }>();
 
@@ -14,7 +14,7 @@ const programPieces = computed(() => {
   }
   return props.log.pieceIds
     .map((id) => props.pieces.find((p) => p.id === id))
-    .filter((p): p is Piece => p !== undefined);
+    .filter((p): p is PieceWork => p !== undefined);
 });
 
 const shortId = computed(() => props.log.id.slice(0, 6).toUpperCase());

--- a/app/components/organisms/ConcertLogForm.test.ts
+++ b/app/components/organisms/ConcertLogForm.test.ts
@@ -1,19 +1,21 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ConcertLogForm from "./ConcertLogForm.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
-const mockPieces: Piece[] = [
+const mockPieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
-    composer: "ベートーヴェン",
+    composerId: "00000000-0000-4000-8000-000000000001",
     createdAt: "2024-01-01T00:00:00.000Z",
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "piece-2",
     title: "ピアノ協奏曲第1番",
-    composer: "チャイコフスキー",
+    composerId: "00000000-0000-4000-8000-000000000002",
     createdAt: "2024-01-01T00:00:00.000Z",
     updatedAt: "2024-01-01T00:00:00.000Z",
   },

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import draggable from "vuedraggable";
 import { nowAsDatetimeLocal, toDatetimeLocal } from "~/utils/date";
-import type { CreateConcertLogInput, Piece } from "~/types";
+import type { CreateConcertLogInput, PieceWork } from "~/types";
 
 const props = defineProps<{
   initialValues?: Partial<CreateConcertLogInput>;
@@ -38,15 +38,15 @@ const form = reactive({
 });
 
 const selectedPieceId = ref("");
-const selectedPieces = ref<Piece[]>(resolveInitialPieces());
+const selectedPieces = ref<PieceWork[]>(resolveInitialPieces());
 
-function resolveInitialPieces(): Piece[] {
+function resolveInitialPieces(): PieceWork[] {
   if (props.initialValues?.pieceIds === undefined || pieces.value === null) {
     return [];
   }
   return props.initialValues.pieceIds
     .map((id) => pieces.value!.find((p) => p.id === id))
-    .filter((p): p is Piece => p !== undefined);
+    .filter((p): p is PieceWork => p !== undefined);
 }
 
 watch(

--- a/app/components/organisms/FeaturedPiece.stories.ts
+++ b/app/components/organisms/FeaturedPiece.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
 import FeaturedPiece from "./FeaturedPiece.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000002";
@@ -12,7 +12,8 @@ const composerNameById = {
   [COMPOSER_ID_BRAHMS]: "ブラームス",
 };
 
-const makePiece = (overrides: Partial<Piece> = {}): Piece => ({
+const makePiece = (overrides: Partial<PieceWork> = {}): PieceWork => ({
+  kind: "work",
   id: "piece-1",
   title: "ピアノ協奏曲第1番 変ロ短調 Op.23",
   composerId: COMPOSER_ID_TCHAIKOVSKY,

--- a/app/components/organisms/FeaturedPiece.test.ts
+++ b/app/components/organisms/FeaturedPiece.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import FeaturedPiece from "./FeaturedPiece.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000002";
@@ -12,7 +12,8 @@ const composerNameById = {
   [COMPOSER_ID_BRAHMS]: "ブラームス",
 };
 
-const makePiece = (overrides: Partial<Piece> = {}): Piece => ({
+const makePiece = (overrides: Partial<PieceWork> = {}): PieceWork => ({
+  kind: "work",
   id: "piece-1",
   title: "ピアノ協奏曲第1番 変ロ短調 Op.23",
   composerId: COMPOSER_ID_TCHAIKOVSKY,

--- a/app/components/organisms/FeaturedPiece.vue
+++ b/app/components/organisms/FeaturedPiece.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const props = defineProps<{
-  pieces: Piece[];
+  pieces: PieceWork[];
   loading: boolean;
   composerNameById: Record<string, string>;
 }>();

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import ListeningLogForm from "./ListeningLogForm.vue";
 import ButtonPrimary from "../atoms/ButtonPrimary.vue";
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";
@@ -13,8 +13,9 @@ const { mockPieces, mockComposers } = vi.hoisted(() => {
   const MOZART = "00000000-0000-4000-8000-000000000002";
   const MUSSORGSKY = "00000000-0000-4000-8000-000000000003";
   const STRAVINSKY = "00000000-0000-4000-8000-000000000004";
-  const mockPieces: Piece[] = [
+  const mockPieces: PieceWork[] = [
     {
+      kind: "work",
       id: "piece-1",
       title: "交響曲第9番",
       composerId: BEETHOVEN,
@@ -22,6 +23,7 @@ const { mockPieces, mockComposers } = vi.hoisted(() => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     },
     {
+      kind: "work",
       id: "piece-2",
       title: "魔笛",
       composerId: MOZART,
@@ -29,6 +31,7 @@ const { mockPieces, mockComposers } = vi.hoisted(() => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     },
     {
+      kind: "work",
       id: "piece-3",
       title: "展覧会の絵",
       composerId: MUSSORGSKY,
@@ -37,6 +40,7 @@ const { mockPieces, mockComposers } = vi.hoisted(() => {
       updatedAt: "2024-01-01T00:00:00.000Z",
     },
     {
+      kind: "work",
       id: "piece-4",
       title: "春の祭典",
       composerId: STRAVINSKY,

--- a/app/components/organisms/PieceList.stories.ts
+++ b/app/components/organisms/PieceList.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import PieceList from "./PieceList.vue";
 
 const meta: Meta<typeof PieceList> = {
@@ -18,8 +18,9 @@ const composerNameById = {
   [COMPOSER_ID_MOZART]: "モーツァルト",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "1",
     title: "交響曲第9番 ニ短調 Op.125",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -27,6 +28,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "2",
     title: "ピアノ協奏曲第21番 ハ長調 K.467",
     composerId: COMPOSER_ID_MOZART,

--- a/app/components/organisms/PieceList.test.ts
+++ b/app/components/organisms/PieceList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceList from "./PieceList.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";
@@ -10,8 +10,9 @@ const composerNameById = {
   [COMPOSER_ID_MOZART]: "モーツァルト",
 };
 
-const makePieces = (): Piece[] => [
+const makePieces = (): PieceWork[] => [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -20,6 +21,7 @@ const makePieces = (): Piece[] => [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "piece-2",
     title: "魔笛",
     composerId: COMPOSER_ID_MOZART,
@@ -104,7 +106,7 @@ describe("PieceList", () => {
         props: { pieces: makePieces(), error: null, composerNameById },
       });
       await wrapper.findAll(".btn-danger")[0].trigger("click");
-      const emitted = wrapper.emitted("delete") as [Piece][];
+      const emitted = wrapper.emitted("delete") as [PieceWork][];
       expect(emitted[0][0].id).toBe("piece-1");
     });
 

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -1,14 +1,14 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 defineProps<{
-  pieces: Piece[];
+  pieces: PieceWork[];
   error: Error | null;
   composerNameById: Record<string, string>;
 }>();
 
 const emit = defineEmits<{
-  delete: [piece: Piece];
+  delete: [piece: PieceWork];
 }>();
 
 const router = useRouter();

--- a/app/components/organisms/PieceListInfinite.stories.ts
+++ b/app/components/organisms/PieceListInfinite.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
 import PieceListInfinite from "./PieceListInfinite.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000002";
@@ -10,8 +10,9 @@ const composerNameById = {
   [COMPOSER_ID_TCHAIKOVSKY]: "チャイコフスキー",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番 ニ短調 Op.125「合唱」",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -23,6 +24,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "piece-2",
     title: "ピアノ協奏曲第1番 変ロ短調 Op.23",
     composerId: COMPOSER_ID_TCHAIKOVSKY,

--- a/app/components/organisms/PieceListInfinite.test.ts
+++ b/app/components/organisms/PieceListInfinite.test.ts
@@ -1,13 +1,14 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
 import PieceListInfinite from "./PieceListInfinite.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const composerNameById = { [COMPOSER_ID]: "ベートーヴェン" };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
     composerId: COMPOSER_ID,

--- a/app/components/organisms/PieceListInfinite.vue
+++ b/app/components/organisms/PieceListInfinite.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const props = defineProps<{
-  pieces: Piece[];
+  pieces: PieceWork[];
   error: Error | null;
   pending: boolean;
   hasMore: boolean;
@@ -10,7 +10,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  delete: [piece: Piece];
+  delete: [piece: PieceWork];
   loadMore: [];
   retry: [];
 }>();

--- a/app/components/templates/ComposerDetailTemplate.stories.ts
+++ b/app/components/templates/ComposerDetailTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
 import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 
 const meta: Meta<typeof ComposerDetailTemplate> = {
   title: "Templates/ComposerDetailTemplate",
@@ -19,8 +19,9 @@ const sample: Composer = {
   updatedAt: "2024-06-01T00:00:00.000Z",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "p1",
     title: "交響曲第9番 ニ短調 作品125「合唱」",
     composerId: "1",
@@ -32,6 +33,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-06-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "p2",
     title: "ピアノソナタ第14番 嬰ハ短調 作品27-2「月光」",
     composerId: "1",
@@ -43,6 +45,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-06-02T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "p3",
     title: "ヴァイオリン協奏曲 ニ長調 作品61",
     composerId: "1",

--- a/app/components/templates/ComposerDetailTemplate.test.ts
+++ b/app/components/templates/ComposerDetailTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 
 const sample: Composer = {
   id: "1",
@@ -11,8 +11,9 @@ const sample: Composer = {
   updatedAt: "2024-06-01T00:00:00.000Z",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "p1",
     title: "交響曲第9番",
     composerId: "1",
@@ -24,6 +25,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-06-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "p2",
     title: "ピアノソナタ第14番「月光」",
     composerId: "1",

--- a/app/components/templates/ComposerDetailTemplate.vue
+++ b/app/components/templates/ComposerDetailTemplate.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 import { formatLifespan } from "~/utils/lifespan";
 
 const props = defineProps<{
   composer: Composer | null;
   error: Error | null;
   isAdmin: boolean;
-  pieces: Piece[];
+  pieces: PieceWork[];
   piecesError: Error | null;
   piecesPending: boolean;
 }>();

--- a/app/components/templates/ConcertLogDetailTemplate.test.ts
+++ b/app/components/templates/ConcertLogDetailTemplate.test.ts
@@ -3,7 +3,7 @@ import { flushPromises } from "@vue/test-utils";
 import ConcertLogDetailTemplate from "./ConcertLogDetailTemplate.vue";
 import ButtonDanger from "~/components/atoms/ButtonDanger.vue";
 import ButtonSecondary from "~/components/atoms/ButtonSecondary.vue";
-import type { ConcertLog, Piece } from "~/types";
+import type { ConcertLog, PieceWork } from "~/types";
 
 const mockDeleteLog = vi.fn();
 
@@ -19,11 +19,12 @@ vi.mock("~/composables/useConcertLogs", () => ({
   }),
 }));
 
-const mockPieces: Piece[] = [
+const mockPieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
-    composer: "ベートーヴェン",
+    composerId: "00000000-0000-4000-8000-000000000001",
     createdAt: "2024-01-01T00:00:00.000Z",
     updatedAt: "2024-01-01T00:00:00.000Z",
   },

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import FeaturedPiece from "~/components/organisms/FeaturedPiece.vue";
 
 defineProps<{
-  pieces: Piece[];
+  pieces: PieceWork[];
   loading: boolean;
   isAdmin: boolean;
   composerNameById: Record<string, string>;

--- a/app/components/templates/PieceDetailTemplate.stories.ts
+++ b/app/components/templates/PieceDetailTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog, Piece } from "~/types";
+import type { ListeningLog, PieceMovement, PieceWork } from "~/types";
 import PieceDetailTemplate from "./PieceDetailTemplate.vue";
 
 const meta: Meta<typeof PieceDetailTemplate> = {
@@ -13,7 +13,8 @@ type Story = StoryObj<typeof PieceDetailTemplate>;
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";
 
-const pieceWithVideo: Piece = {
+const pieceWithVideo: PieceWork = {
+  kind: "work",
   id: "1",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: COMPOSER_ID_BEETHOVEN,
@@ -22,7 +23,8 @@ const pieceWithVideo: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const pieceWithMultipleVideos: Piece = {
+const pieceWithMultipleVideos: PieceWork = {
+  kind: "work",
   id: "5",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: COMPOSER_ID_BEETHOVEN,
@@ -35,13 +37,36 @@ const pieceWithMultipleVideos: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const pieceWithoutVideo: Piece = {
+const pieceWithoutVideo: PieceWork = {
+  kind: "work",
   id: "2",
   title: "魔笛",
   composerId: COMPOSER_ID_MOZART,
   createdAt: "2024-01-01T00:00:00.000Z",
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
+
+const sampleMovements: PieceMovement[] = [
+  {
+    kind: "movement",
+    id: "movement-1",
+    parentId: "1",
+    index: 0,
+    title: "第1楽章 Allegro ma non troppo",
+    videoUrls: ["https://www.youtube.com/watch?v=dQw4w9WgXcQ"],
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+  {
+    kind: "movement",
+    id: "movement-2",
+    parentId: "1",
+    index: 1,
+    title: "第2楽章 Molto vivace",
+    createdAt: "2024-01-01T00:00:00.000Z",
+    updatedAt: "2024-01-01T00:00:00.000Z",
+  },
+];
 
 export const WithVideo: Story = {
   args: {
@@ -151,5 +176,26 @@ export const WithListeningLogs: Story = {
     isAdmin: false,
     composerName: "モーツァルト",
     listeningLogs: sampleListeningLogs,
+  },
+};
+
+export const WorkWithMovements: Story = {
+  args: {
+    piece: pieceWithoutVideo,
+    error: null,
+    isAdmin: false,
+    composerName: "モーツァルト",
+    movements: sampleMovements,
+  },
+};
+
+export const MovementWithBreadcrumb: Story = {
+  args: {
+    piece: sampleMovements[0],
+    error: null,
+    isAdmin: false,
+    composerName: "ベートーヴェン",
+    parentWork: pieceWithVideo,
+    quickLogPieceLabel: `${pieceWithVideo.title} - ${sampleMovements[0].title}`,
   },
 };

--- a/app/components/templates/PieceDetailTemplate.test.ts
+++ b/app/components/templates/PieceDetailTemplate.test.ts
@@ -1,8 +1,9 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceDetailTemplate from "./PieceDetailTemplate.vue";
-import type { ListeningLog, Piece } from "~/types";
+import type { ListeningLog, PieceMovement, PieceWork } from "~/types";
 
-const pieceWithVideo: Piece = {
+const pieceWithVideo: PieceWork = {
+  kind: "work",
   id: "1",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: "00000000-0000-4000-8000-000000000001",
@@ -11,7 +12,8 @@ const pieceWithVideo: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const pieceWithMultipleVideos: Piece = {
+const pieceWithMultipleVideos: PieceWork = {
+  kind: "work",
   id: "4",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: "00000000-0000-4000-8000-000000000001",
@@ -24,7 +26,8 @@ const pieceWithMultipleVideos: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const pieceWithCategories: Piece = {
+const pieceWithCategories: PieceWork = {
+  kind: "work",
   id: "3",
   title: "春の祭典",
   composerId: "00000000-0000-4000-8000-000000000003",
@@ -36,10 +39,22 @@ const pieceWithCategories: Piece = {
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
 
-const pieceWithoutVideo: Piece = {
+const pieceWithoutVideo: PieceWork = {
+  kind: "work",
   id: "2",
   title: "魔笛",
   composerId: "00000000-0000-4000-8000-000000000002",
+  createdAt: "2024-01-01T00:00:00.000Z",
+  updatedAt: "2024-01-01T00:00:00.000Z",
+};
+
+const movementSample: PieceMovement = {
+  kind: "movement",
+  id: "movement-1",
+  parentId: "1",
+  index: 0,
+  title: "第1楽章 Allegro ma non troppo",
+  videoUrls: ["https://www.youtube.com/watch?v=mov1"],
   createdAt: "2024-01-01T00:00:00.000Z",
   updatedAt: "2024-01-01T00:00:00.000Z",
 };
@@ -384,6 +399,103 @@ describe("PieceDetailTemplate", () => {
         },
       });
       expect(wrapper.find(".piece-listenings").exists()).toBe(false);
+    });
+  });
+
+  describe("楽章一覧（Movements）", () => {
+    it("Work かつ movements が指定されると Movements セクションが表示される", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: pieceWithoutVideo,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+          movements: [movementSample],
+        },
+      });
+      expect(wrapper.find(".piece-movements").exists()).toBe(true);
+      expect(wrapper.text()).toContain("第1楽章 Allegro ma non troppo");
+    });
+
+    it("movements が空配列の場合 Movements セクションは表示されない", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: pieceWithoutVideo,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+          movements: [],
+        },
+      });
+      expect(wrapper.find(".piece-movements").exists()).toBe(false);
+    });
+
+    it("movements が未指定の場合 Movements セクションは表示されない", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: pieceWithoutVideo,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+        },
+      });
+      expect(wrapper.find(".piece-movements").exists()).toBe(false);
+    });
+
+    it("Movement を直接開いた場合は Movements セクションは表示されない", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: movementSample,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+          movements: [movementSample],
+        },
+      });
+      expect(wrapper.find(".piece-movements").exists()).toBe(false);
+    });
+  });
+
+  describe("Movement 詳細とパンくず", () => {
+    it("Movement かつ parentWork が渡されると親 Work へのパンくずが表示される", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: movementSample,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+          parentWork: pieceWithoutVideo,
+        },
+      });
+      const link = wrapper.find(".breadcrumb-link");
+      expect(link.exists()).toBe(true);
+      expect(link.attributes("href")).toBe("/pieces/2");
+      expect(link.text()).toContain("魔笛");
+    });
+
+    it("Work の場合パンくずは表示されない", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: pieceWithoutVideo,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+        },
+      });
+      expect(wrapper.find(".breadcrumb-link").exists()).toBe(false);
+    });
+
+    it("Movement の場合 PieceCategoryList は表示されない（カテゴリは Work に紐付くため）", async () => {
+      const wrapper = await mountSuspended(PieceDetailTemplate, {
+        props: {
+          piece: movementSample,
+          error: null,
+          isAdmin: false,
+          composerName: "ベートーヴェン",
+          parentWork: pieceWithCategories,
+        },
+      });
+      expect(wrapper.find(".piece-category-list").exists()).toBe(false);
     });
   });
 });

--- a/app/components/templates/PieceDetailTemplate.vue
+++ b/app/components/templates/PieceDetailTemplate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { formatDate } from "~/utils/date";
-import type { ListeningLog, Piece, Rating } from "~/types";
+import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "~/types";
 
 const props = defineProps<{
   piece: Piece | null;
@@ -8,6 +8,9 @@ const props = defineProps<{
   isAdmin: boolean;
   composerName: string;
   listeningLogs?: ListeningLog[];
+  movements?: PieceMovement[];
+  parentWork?: PieceWork | null;
+  quickLogPieceLabel?: string;
 }>();
 
 const emit = defineEmits<{
@@ -24,6 +27,17 @@ const shortId = computed(() => {
 
 const logs = computed<ListeningLog[]>(() => props.listeningLogs ?? []);
 const logCount = computed(() => logs.value.length);
+
+const movementsList = computed<PieceMovement[]>(() => props.movements ?? []);
+const isWork = computed(() => props.piece?.kind === "work");
+const isMovement = computed(() => props.piece?.kind === "movement");
+
+const quickLogPieceTitle = computed(() => {
+  if (props.quickLogPieceLabel !== undefined) {
+    return props.quickLogPieceLabel;
+  }
+  return props.piece?.title ?? "";
+});
 </script>
 
 <template>
@@ -40,6 +54,13 @@ const logCount = computed(() => logs.value.length);
     />
 
     <template v-else-if="piece">
+      <nav v-if="isMovement && parentWork" class="movement-breadcrumb" aria-label="親楽曲">
+        <NuxtLink :to="`/pieces/${parentWork.id}`" class="breadcrumb-link">
+          <span aria-hidden="true">&larr;</span>
+          <span class="smallcaps">{{ parentWork.title }}</span>
+        </NuxtLink>
+      </nav>
+
       <header class="piece-masthead">
         <div class="piece-meta">
           <span class="meta-tag smallcaps">II / Repertoire</span>
@@ -51,7 +72,7 @@ const logCount = computed(() => logs.value.length);
 
         <h1 class="piece-title">{{ piece.title }}</h1>
 
-        <div class="piece-category-wrapper">
+        <div v-if="isWork" class="piece-category-wrapper">
           <PieceCategoryList :piece="piece" />
         </div>
 
@@ -91,11 +112,33 @@ const logCount = computed(() => logs.value.length);
           </header>
           <QuickLogForm
             :composer="composerName"
-            :piece="piece.title"
+            :piece="quickLogPieceTitle"
             @submit="emit('save', $event)"
           />
         </section>
       </template>
+
+      <section v-if="isWork && movementsList.length > 0" class="piece-movements">
+        <header class="movements-masthead">
+          <span class="movements-tag smallcaps">Movements</span>
+          <span class="movements-rule" aria-hidden="true" />
+          <span class="movements-count smallcaps numeric">
+            {{ movementsList.length.toString().padStart(2, "0") }}
+            {{ movementsList.length === 1 ? "movement" : "movements" }}
+          </span>
+        </header>
+
+        <h2 class="movements-title">
+          <span class="movements-title-jp">楽章</span>
+          <span class="movements-title-en"><em>Mouvements</em></span>
+        </h2>
+
+        <ol class="movements-list stagger-children">
+          <li v-for="movement in movementsList" :key="movement.id" class="movements-item">
+            <MovementListItem :movement="movement" />
+          </li>
+        </ol>
+      </section>
 
       <section v-if="logCount > 0" class="piece-listenings" aria-labelledby="listenings-heading">
         <header class="listenings-masthead">
@@ -153,6 +196,26 @@ const logCount = computed(() => logs.value.length);
 }
 
 .back-link:hover {
+  color: var(--color-accent);
+  gap: 0.65rem;
+}
+
+.movement-breadcrumb {
+  margin: -1rem 0 1.5rem;
+}
+
+.breadcrumb-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition:
+    color 0.25s ease,
+    gap 0.25s ease;
+}
+
+.breadcrumb-link:hover {
   color: var(--color-accent);
   gap: 0.65rem;
 }
@@ -353,6 +416,75 @@ const logCount = computed(() => logs.value.length);
 
 .quicklog-meta {
   color: var(--color-text-muted);
+}
+
+.piece-movements {
+  margin-top: 3rem;
+}
+
+.movements-masthead {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  margin-bottom: 0.6rem;
+}
+
+.movements-tag {
+  color: var(--color-bordeaux);
+}
+:root.dark .movements-tag {
+  color: var(--color-accent);
+}
+
+.movements-rule {
+  flex: 1;
+  height: 1px;
+  background: var(--color-hairline);
+}
+
+.movements-count {
+  color: var(--color-text-muted);
+}
+
+.movements-title {
+  display: flex;
+  align-items: baseline;
+  gap: 1rem;
+  flex-wrap: wrap;
+  font-family: var(--font-display);
+  font-weight: 300;
+  font-size: clamp(1.6rem, 4vw, 2.6rem);
+  line-height: 1;
+  letter-spacing: var(--tracking-tight);
+  color: var(--color-text);
+  margin: 0 0 1.5rem;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 30;
+}
+
+.movements-title-jp {
+  font-style: normal;
+  font-weight: 400;
+}
+
+.movements-title-en {
+  color: var(--color-accent);
+  font-style: italic;
+  font-size: 0.7em;
+  font-variation-settings:
+    "opsz" 144,
+    "SOFT" 100,
+    "WONK" 1;
+}
+
+.movements-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border-top: 1px solid var(--color-hairline);
 }
 
 .piece-listenings {

--- a/app/components/templates/PieceEditTemplate.stories.ts
+++ b/app/components/templates/PieceEditTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 import PieceEditTemplate from "./PieceEditTemplate.vue";
 
 const meta: Meta<typeof PieceEditTemplate> = {
@@ -21,7 +21,8 @@ const composers: Composer[] = [
   },
 ];
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: "1",
   title: "交響曲第9番 ニ短調 Op.125",
   composerId: COMPOSER_ID_BEETHOVEN,

--- a/app/components/templates/PieceEditTemplate.test.ts
+++ b/app/components/templates/PieceEditTemplate.test.ts
@@ -1,10 +1,11 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PieceEditTemplate from "./PieceEditTemplate.vue";
-import type { Composer, Piece } from "~/types";
+import type { Composer, PieceWork } from "~/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: "piece-1",
   title: "交響曲第9番",
   composerId: COMPOSER_ID,

--- a/app/components/templates/PieceEditTemplate.vue
+++ b/app/components/templates/PieceEditTemplate.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { Composer, Piece, UpdatePieceInput } from "~/types";
+import type { Composer, PieceWork, UpdatePieceInput } from "~/types";
 
 defineProps<{
-  piece: Piece | null;
+  piece: PieceWork | null;
   fetchError: Error | null;
   error: string | null;
   composers: Composer[];

--- a/app/components/templates/PiecesTemplate.stories.ts
+++ b/app/components/templates/PiecesTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import PiecesTemplate from "./PiecesTemplate.vue";
 
 const meta: Meta<typeof PiecesTemplate> = {
@@ -18,8 +18,9 @@ const composerNameById = {
   [COMPOSER_ID_MOZART]: "モーツァルト",
 };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "1",
     title: "交響曲第9番 ニ短調 Op.125",
     composerId: COMPOSER_ID_BEETHOVEN,
@@ -27,6 +28,7 @@ const samplePieces: Piece[] = [
     updatedAt: "2024-01-01T00:00:00.000Z",
   },
   {
+    kind: "work",
     id: "2",
     title: "ピアノ協奏曲第21番 ハ長調 K.467",
     composerId: COMPOSER_ID_MOZART,

--- a/app/components/templates/PiecesTemplate.test.ts
+++ b/app/components/templates/PiecesTemplate.test.ts
@@ -1,12 +1,13 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import PiecesTemplate from "./PiecesTemplate.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const composerNameById = { [COMPOSER_ID]: "ベートーヴェン" };
 
-const samplePieces: Piece[] = [
+const samplePieces: PieceWork[] = [
   {
+    kind: "work",
     id: "piece-1",
     title: "交響曲第9番",
     composerId: COMPOSER_ID,
@@ -16,7 +17,7 @@ const samplePieces: Piece[] = [
 ];
 
 const baseProps = {
-  pieces: [] as Piece[],
+  pieces: [] as PieceWork[],
   error: null as Error | null,
   pending: false,
   hasMore: false,

--- a/app/components/templates/PiecesTemplate.vue
+++ b/app/components/templates/PiecesTemplate.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const props = defineProps<{
-  pieces: Piece[];
+  pieces: PieceWork[];
   error: Error | null;
   pending: boolean;
   hasMore: boolean;
@@ -11,7 +11,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-  delete: [piece: Piece];
+  delete: [piece: PieceWork];
   loadMore: [];
   retry: [];
 }>();

--- a/app/composables/useMovements.ts
+++ b/app/composables/useMovements.ts
@@ -1,0 +1,44 @@
+import type { PieceMovement } from "~/types";
+import { useAuthenticatedApi } from "./useAuthenticatedApi";
+
+/**
+ * 親 Work 配下の楽章一覧を取得する composable。
+ *
+ * バックエンドの `GET /pieces/{id}/children` は `index` 昇順で全件返す。
+ * 認証不要（参照系）。Movement のレスポンスには `composerId` は含まれない（親 Work から継承）。
+ */
+export const useMovements = (workId: () => string) => {
+  const apiBase = useApiBase();
+  return useFetch<PieceMovement[]>(() => `${apiBase}/pieces/${workId()}/children`);
+};
+
+/**
+ * 親 Work 配下の楽章集合を一括差し替えする composable。
+ *
+ * バックエンドの `PUT /pieces/{workId}/movements` を呼び出す。admin 必須。
+ * 並び替え・追加・削除を 1 つのトランザクションで原子的に反映する。
+ */
+export const useReplaceMovements = () => {
+  const apiBase = useApiBase();
+  const { putJson } = useAuthenticatedApi();
+
+  type ReplaceMovementsItem = {
+    id?: string;
+    index: number;
+    title: string;
+    videoUrls?: string[];
+  };
+
+  const replaceMovements = async (
+    workId: string,
+    items: ReplaceMovementsItem[],
+  ): Promise<PieceMovement[]> => {
+    const response = await putJson<{ movements: PieceMovement[] }>(
+      `${apiBase}/pieces/${workId}/movements`,
+      { movements: items },
+    );
+    return response.movements;
+  };
+
+  return { replaceMovements };
+};

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -1,7 +1,7 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { usePiecesPaginated, usePiecesAll, usePiece } from "./usePieces";
 import type { PageResult } from "./usePaginatedList";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 import { ID_TOKEN_KEY } from "./useAuth";
 import {
   PIECES_PAGE_SIZE_DEFAULT,
@@ -43,7 +43,8 @@ vi.mock("./useAuth", async (importOriginal) => {
   };
 });
 
-const makePiece = (id: string, title = `title-${id}`): Piece => ({
+const makePiece = (id: string, title = `title-${id}`): PieceWork => ({
+  kind: "work",
   id,
   title,
   composerId: "00000000-0000-4000-8000-000000000001",
@@ -88,7 +89,7 @@ describe("usePiecesPaginated", () => {
       mockDollarFetch.mockResolvedValueOnce({
         items: [],
         nextCursor: null,
-      } satisfies PageResult<Piece>);
+      } satisfies PageResult<PieceWork>);
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(mockDollarFetch).toHaveBeenCalledWith("/api/pieces", {
@@ -130,9 +131,9 @@ describe("usePiecesPaginated", () => {
     });
 
     it("pending 中に loadMore を呼んでも二重発行しない", async () => {
-      let resolvePage: ((value: PageResult<Piece>) => void) | undefined;
+      let resolvePage: ((value: PageResult<PieceWork>) => void) | undefined;
       mockDollarFetch.mockReturnValueOnce(
-        new Promise<PageResult<Piece>>((resolve) => {
+        new Promise<PageResult<PieceWork>>((resolve) => {
           resolvePage = resolve;
         }),
       );
@@ -187,7 +188,11 @@ describe("usePiecesPaginated", () => {
       const p = usePiecesPaginated();
       await p.loadMore();
       expect(p.items.value).toHaveLength(1);
-      await p.createPiece({ title: "x", composerId: "00000000-0000-4000-8000-000000000001" });
+      await p.createPiece({
+        kind: "work",
+        title: "x",
+        composerId: "00000000-0000-4000-8000-000000000001",
+      });
       expect(p.items.value).toEqual([]);
       expect(p.hasMore.value).toBe(true);
     });
@@ -205,12 +210,17 @@ describe("usePiecesPaginated", () => {
       localStorage.setItem(ID_TOKEN_KEY, "test-id-token");
       mockFetch.mockResolvedValueOnce(jsonResponse(makePiece("new"), 201));
       const p = usePiecesPaginated();
-      await p.createPiece({ title: "new", composerId: "00000000-0000-4000-8000-000000000001" });
+      await p.createPiece({
+        kind: "work",
+        title: "new",
+        composerId: "00000000-0000-4000-8000-000000000001",
+      });
       expect(mockFetch).toHaveBeenCalledWith(
         "/api/pieces",
         expect.objectContaining({
           method: "POST",
           body: JSON.stringify({
+            kind: "work",
             title: "new",
             composerId: "00000000-0000-4000-8000-000000000001",
           }),
@@ -246,7 +256,11 @@ describe("usePiecesPaginated", () => {
       );
       const p = usePiecesPaginated();
       await expect(
-        p.createPiece({ title: "x", composerId: "00000000-0000-4000-8000-000000000001" }),
+        p.createPiece({
+          kind: "work",
+          title: "x",
+          composerId: "00000000-0000-4000-8000-000000000001",
+        }),
       ).rejects.toThrow();
     });
   });
@@ -310,7 +324,11 @@ describe("usePiecesAll", () => {
     const p = usePiecesAll();
     await p.refresh();
     expect(p.data.value).toHaveLength(1);
-    await p.createPiece({ title: "x", composerId: "00000000-0000-4000-8000-000000000001" });
+    await p.createPiece({
+      kind: "work",
+      title: "x",
+      composerId: "00000000-0000-4000-8000-000000000001",
+    });
     await flush();
     expect(p.data.value).toHaveLength(2);
   });

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -3,12 +3,13 @@ import {
   PIECES_ALL_MAX_TOTAL,
   PIECES_PAGE_SIZE_DEFAULT,
 } from "~/types";
-import type { CreatePieceInput, Piece, UpdatePieceInput } from "~/types";
+import type { CreatePieceInput, Piece, PieceWork, UpdatePieceInput } from "~/types";
 import { useAuthenticatedApi } from "./useAuthenticatedApi";
 import { fetchCursorPage, usePaginatedList } from "./usePaginatedList";
 
+// `GET /pieces` は root の Work のみを返す（楽章は `GET /pieces/{id}/children` 経由）。
 const fetchPiecesPage = (apiBase: string, options: { limit: number; cursor?: string }) =>
-  fetchCursorPage<Piece>(`${apiBase}/pieces`, options);
+  fetchCursorPage<PieceWork>(`${apiBase}/pieces`, options);
 
 const usePieceMutations = () => {
   const apiBase = useApiBase();
@@ -33,7 +34,7 @@ const usePieceMutations = () => {
 export const usePiecesPaginated = () => {
   const apiBase = useApiBase();
   const { postPiece, putPiece } = usePieceMutations();
-  const pagination = usePaginatedList<Piece>((cursor) =>
+  const pagination = usePaginatedList<PieceWork>((cursor) =>
     fetchPiecesPage(apiBase, { limit: PIECES_PAGE_SIZE_DEFAULT, cursor }),
   );
 
@@ -66,14 +67,14 @@ export const usePiecesPaginated = () => {
 export const usePiecesAll = () => {
   const apiBase = useApiBase();
   const { postPiece, putPiece } = usePieceMutations();
-  const data = ref<Piece[] | null>(null);
+  const data = ref<PieceWork[] | null>(null);
   const pending = ref<boolean>(false);
   const error = ref<Error | null>(null);
 
   const refresh = async () => {
     pending.value = true;
     error.value = null;
-    const acc: Piece[] = [];
+    const acc: PieceWork[] = [];
     let cursor: string | undefined;
     let consecutiveEmpty = 0;
     try {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 import type { PageResult } from "~/composables/usePaginatedList";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const apiBase = useApiBase();
-const { data, pending } = useFetch<PageResult<Piece>>(`${apiBase}/pieces`);
+const { data, pending } = useFetch<PageResult<PieceWork>>(`${apiBase}/pieces`);
 const { data: composers, refresh: refreshComposers } = useComposersAll();
 void refreshComposers();
 

--- a/app/pages/pieces/[id]/edit.test.ts
+++ b/app/pages/pieces/[id]/edit.test.ts
@@ -1,14 +1,15 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
 import PieceEditPage from "./edit.vue";
-import type { Piece, UpdatePieceInput } from "~/types";
+import type { PieceWork, UpdatePieceInput } from "~/types";
 
 const mockUpdatePiece = vi.fn();
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: "piece-1",
   title: "交響曲第9番",
-  composer: "ベートーヴェン",
+  composerId: "00000000-0000-4000-8000-000000000001",
   createdAt: "2024-01-01T00:00:00.000Z",
   updatedAt: "2024-01-01T00:00:00.000Z",
 };

--- a/app/pages/pieces/[id]/edit.vue
+++ b/app/pages/pieces/[id]/edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { UpdatePieceInput } from "~/types";
+import type { PieceWork, UpdatePieceInput } from "~/types";
 
 definePageMeta({ middleware: ["admin"] });
 
@@ -11,6 +11,12 @@ const { updatePiece } = usePiecesPaginated();
 const { data: composers, pending: composersPending, refresh: refreshComposers } = useComposersAll();
 await refreshComposers();
 
+const workPiece = computed<PieceWork | null>(() =>
+  piece.value !== null && piece.value !== undefined && piece.value.kind === "work"
+    ? piece.value
+    : null,
+);
+
 const { error, handleSubmit } = useSubmitHandler<UpdatePieceInput>({
   submit: (values) => updatePiece(id.value, values),
   redirectTo: "/pieces",
@@ -20,7 +26,7 @@ const { error, handleSubmit } = useSubmitHandler<UpdatePieceInput>({
 
 <template>
   <PieceEditTemplate
-    :piece="piece ?? null"
+    :piece="workPiece"
     :fetch-error="fetchError"
     :error="error"
     :composers="composers ?? []"

--- a/app/pages/pieces/[id]/index.test.ts
+++ b/app/pages/pieces/[id]/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
 import PieceDetailPage from "./index.vue";
-import type { Composer, ListeningLog, Piece, Rating } from "~/types";
+import type { Composer, ListeningLog, PieceWork, Rating } from "~/types";
 
 vi.mock("~/composables/useAuth", () => ({
   ACCESS_TOKEN_KEY: "accessToken",
@@ -15,7 +15,8 @@ const mockRefresh = vi.fn().mockResolvedValue(undefined);
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const PIECE_ID = "piece-1";
 
-const samplePiece: Piece = {
+const samplePiece: PieceWork = {
+  kind: "work",
   id: PIECE_ID,
   title: "交響曲第9番",
   composerId: COMPOSER_ID,
@@ -83,10 +84,12 @@ const sampleLogs: ListeningLog[] = [
   },
 ];
 
+const usePieceData = ref<PieceWork | import("~/types").PieceMovement | null>(samplePiece);
+
 vi.mock("~/composables/usePieces", () => ({
   usePiecesPaginated: vi.fn(),
   usePiecesAll: vi.fn(),
-  usePiece: () => ({ data: ref(samplePiece), error: ref(null) }),
+  usePiece: () => ({ data: usePieceData, error: ref(null) }),
 }));
 
 vi.mock("~/composables/useComposers", () => ({
@@ -116,11 +119,19 @@ vi.mock("~/composables/useListeningLogs", () => ({
   useListeningLogCreate: () => ({ create: mockCreate }),
 }));
 
+const mockDollarFetch = vi.fn();
+
 beforeEach(async () => {
   mockCreate.mockClear();
   mockExecute.mockClear();
   mockRefresh.mockClear();
   listeningLogsData.value = [];
+  mockDollarFetch.mockReset();
+  // 楽章一覧 / 親 Work の取得は空配列・null を返すデフォルトモック
+  mockDollarFetch.mockResolvedValue([]);
+  vi.stubGlobal("$fetch", mockDollarFetch);
+  // デフォルトは Work
+  usePieceData.value = samplePiece;
   const { useAuth } = await import("~/composables/useAuth");
   vi.mocked(useAuth).mockReturnValue({
     isAdmin: () => false,
@@ -209,6 +220,110 @@ describe("PieceDetailPage", () => {
       const logs = template.props("listeningLogs") as ListeningLog[];
       expect(logs).toEqual([]);
       expect(mockExecute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("楽章一覧（Work）", () => {
+    it("Work の場合 GET /pieces/{id}/children を呼んで movements にセットする", async () => {
+      const sampleMovements: import("~/types").PieceMovement[] = [
+        {
+          kind: "movement",
+          id: "movement-1",
+          parentId: PIECE_ID,
+          index: 0,
+          title: "第1楽章",
+          createdAt: "2024-01-01T00:00:00.000Z",
+          updatedAt: "2024-01-01T00:00:00.000Z",
+        },
+      ];
+      mockDollarFetch.mockImplementation((url: string) => {
+        if (url.endsWith(`/pieces/${PIECE_ID}/children`)) {
+          return Promise.resolve(sampleMovements);
+        }
+        return Promise.resolve([]);
+      });
+      const wrapper = await mountSuspended(PieceDetailPage);
+      await flushPromises();
+      const template = wrapper.findComponent({ name: "PieceDetailTemplate" });
+      const movements = template.props("movements") as import("~/types").PieceMovement[];
+      expect(movements).toHaveLength(1);
+      expect(movements[0].id).toBe("movement-1");
+    });
+  });
+
+  describe("Movement 詳細", () => {
+    const PARENT_ID = "parent-work";
+    const MOVEMENT_ID = "movement-99";
+    const movementSample: import("~/types").PieceMovement = {
+      kind: "movement",
+      id: MOVEMENT_ID,
+      parentId: PARENT_ID,
+      index: 1,
+      title: "第2楽章 Andante",
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+    const parentWorkSample: PieceWork = {
+      kind: "work",
+      id: PARENT_ID,
+      title: "ピアノ協奏曲第1番",
+      composerId: COMPOSER_ID,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: "2024-01-01T00:00:00.000Z",
+    };
+
+    beforeEach(() => {
+      usePieceData.value = movementSample;
+      mockDollarFetch.mockImplementation((url: string) => {
+        if (url.endsWith(`/pieces/${PARENT_ID}`)) {
+          return Promise.resolve(parentWorkSample);
+        }
+        return Promise.resolve([]);
+      });
+    });
+
+    it("Movement の場合 GET /pieces/{parentId} を呼んで親 Work を解決する", async () => {
+      const wrapper = await mountSuspended(PieceDetailPage);
+      await flushPromises();
+      const template = wrapper.findComponent({ name: "PieceDetailTemplate" });
+      const parentWork = template.props("parentWork") as PieceWork | null;
+      expect(parentWork?.id).toBe(PARENT_ID);
+    });
+
+    it("Movement の場合 composerName は親 Work の composerId から解決される", async () => {
+      const wrapper = await mountSuspended(PieceDetailPage);
+      await flushPromises();
+      const template = wrapper.findComponent({ name: "PieceDetailTemplate" });
+      expect(template.props("composerName")).toBe("ベートーヴェン");
+    });
+
+    it("Movement の場合 quickLogPieceLabel が「親 Work title - 楽章 title」になる", async () => {
+      const wrapper = await mountSuspended(PieceDetailPage);
+      await flushPromises();
+      const template = wrapper.findComponent({ name: "PieceDetailTemplate" });
+      expect(template.props("quickLogPieceLabel")).toBe("ピアノ協奏曲第1番 - 第2楽章 Andante");
+    });
+
+    it("Movement で handleSave を呼ぶと create の piece に親 - 楽章ラベルが渡る", async () => {
+      mockCreate.mockResolvedValue({ id: "log-new" });
+      const wrapper = await mountSuspended(PieceDetailPage);
+      await flushPromises();
+      const vm = wrapper.vm as {
+        handleSave: (values: {
+          rating: Rating;
+          isFavorite: boolean;
+          memo: string;
+        }) => Promise<void>;
+      };
+      await vm.handleSave({ rating: 4, isFavorite: false, memo: "" });
+      await flushPromises();
+      expect(mockCreate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          composer: "ベートーヴェン",
+          piece: "ピアノ協奏曲第1番 - 第2楽章 Andante",
+          pieceId: MOVEMENT_ID,
+        }),
+      );
     });
   });
 });

--- a/app/pages/pieces/[id]/index.vue
+++ b/app/pages/pieces/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLog, Piece, Rating } from "~/types";
+import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "~/types";
 
 const route = useRoute();
 const apiBase = useApiBase();
@@ -10,13 +10,71 @@ const { create } = useListeningLogCreate();
 const { isAdmin, isAuthenticated } = useAuth();
 const isAdminUser = isAdmin();
 
+// Movement を直接開いた場合、親 Work を取得して composerId・タイトルを継承解決する。
+const parentWorkId = computed<string | null>(() => {
+  if (piece.value === null || piece.value === undefined) return null;
+  return piece.value.kind === "movement" ? piece.value.parentId : null;
+});
+
+const parentWork = ref<PieceWork | null>(null);
+watch(
+  parentWorkId,
+  async (id) => {
+    if (id === null) {
+      parentWork.value = null;
+      return;
+    }
+    try {
+      const fetched = await $fetch<Piece>(`${apiBase}/pieces/${id}`);
+      parentWork.value = fetched.kind === "work" ? fetched : null;
+    } catch {
+      parentWork.value = null;
+    }
+  },
+  { immediate: true },
+);
+
+// Work の場合のみ楽章一覧を取得する。Movement の場合は不要（描画されない）。
+const movementsWorkId = computed(() => (piece.value?.kind === "work" ? piece.value.id : null));
+const movements = ref<PieceMovement[]>([]);
+watch(
+  movementsWorkId,
+  async (id) => {
+    if (id === null) {
+      movements.value = [];
+      return;
+    }
+    try {
+      const fetched = await $fetch<PieceMovement[]>(`${apiBase}/pieces/${id}/children`);
+      movements.value = fetched;
+    } catch {
+      movements.value = [];
+    }
+  },
+  { immediate: true },
+);
+
 const composerName = computed(() => {
-  const id = piece.value?.composerId;
+  let id: string | undefined;
+  if (piece.value?.kind === "work") {
+    id = piece.value.composerId;
+  } else if (piece.value?.kind === "movement") {
+    id = parentWork.value?.composerId;
+  }
   if (id === undefined) {
     return "";
   }
   const found = (composers.value ?? []).find((c) => c.id === id);
   return found?.name ?? "(不明な作曲家)";
+});
+
+const quickLogPieceLabel = computed(() => {
+  if (piece.value === null || piece.value === undefined) return "";
+  if (piece.value.kind === "movement") {
+    const parentTitle = parentWork.value?.title ?? "";
+    return parentTitle === "" ? piece.value.title : `${parentTitle} - ${piece.value.title}`;
+  }
+  return piece.value.title;
 });
 
 const authenticated: boolean = isAuthenticated();
@@ -44,7 +102,7 @@ async function handleSave(values: { rating: Rating; isFavorite: boolean; memo: s
   await create({
     listenedAt: new Date().toISOString(),
     composer: composerName.value,
-    piece: piece.value.title,
+    piece: quickLogPieceLabel.value,
     pieceId: piece.value.id,
     userId: null,
     ...values,
@@ -74,6 +132,9 @@ async function handleDelete(target: Piece) {
     :is-admin="isAdminUser"
     :composer-name="composerName"
     :listening-logs="listeningLogs"
+    :movements="movements"
+    :parent-work="parentWork"
+    :quick-log-piece-label="quickLogPieceLabel"
     @save="handleSave"
     @delete="handleDelete"
   />

--- a/app/pages/pieces/index.test.ts
+++ b/app/pages/pieces/index.test.ts
@@ -1,12 +1,13 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
 import PiecesPage from "./index.vue";
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const { samplePieces, sampleComposers, mockLoadMore, mockReset, mockRetry } = vi.hoisted(() => {
   const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
-  const samplePieces: Piece[] = [
+  const samplePieces: PieceWork[] = [
     {
+      kind: "work",
       id: "piece-1",
       title: "交響曲第9番",
       composerId: COMPOSER_ID,
@@ -31,7 +32,7 @@ const { samplePieces, sampleComposers, mockLoadMore, mockReset, mockRetry } = vi
   };
 });
 
-const piecesItems = ref<Piece[]>([]);
+const piecesItems = ref<PieceWork[]>([]);
 const piecesPending = ref<boolean>(false);
 const piecesError = ref<Error | null>(null);
 const piecesHasMore = ref<boolean>(true);

--- a/app/pages/pieces/index.vue
+++ b/app/pages/pieces/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Piece } from "~/types";
+import type { PieceWork } from "~/types";
 
 const apiBase = useApiBase();
 const { items, pending, error, hasMore, loadMore, reset, retry } = usePiecesPaginated();
@@ -19,7 +19,7 @@ const composerNameById = computed<Record<string, string>>(() => {
   return map;
 });
 
-async function handleDelete(piece: Piece) {
+async function handleDelete(piece: PieceWork) {
   if (!confirm(`「${piece.title}」を削除しますか？`)) {
     return;
   }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -12,6 +12,7 @@
 - **視聴ログの検索・統計**: クライアントサイド絞り込みと、件数・評価分布・作曲家ランキング・月別トレンドの集計表示
 - **コンサート記録管理**: 会場・指揮者・オーケストラ・ソリスト・プログラム（楽曲マスタ参照）
 - **楽曲マスタ管理**: 楽曲の登録・編集・削除（管理者のみ）。詳細ページではログイン中ユーザーの該当楽曲の鑑賞記録一覧（`pieceId` 一致でクライアントサイド絞り込み）を表示し、各鑑賞記録の詳細ページへリンクする
+- **楽章表示**: 楽曲（Work）詳細ページに楽章（Movement）の一覧をカード形式で表示し、YouTube 動画は埋め込みプレーヤーで再生する。楽章を直接 `/pieces/{movementId}` で開いた場合は親 Work へのパンくずリンクを表示し、クイックログ生成時は「親 Work title - 楽章 title」で記録する
 - **作曲家マスタ管理**: 作曲家の登録・編集・削除（管理者のみ）。生没年を登録すると一覧は生年昇順（古い順）で表示され、未登録は末尾に並ぶ。詳細ページではその作曲家の楽曲一覧（クライアントサイド絞り込み）も表示
 - **ユーザー登録**: メールアドレス＋パスワード（メール確認付き）／Google OAuth（Cognito Hosted UI）
 
@@ -53,7 +54,9 @@
 | `useApiBase`                | API Gateway のベース URL を返す                                                                                                                                               |
 | `useCognitoConfig`          | Cognito Hosted UI のドメインとクライアント ID を返す                                                                                                                          |
 | `useAuth`                   | 認証処理（register・login・logout・isAuthenticated・refreshTokens・isTokenExpired・loginWithGoogle・handleOAuthCallback・isAdmin）                                            |
-| `usePieces`                 | 曲一覧を取得する                                                                                                                                                              |
+| `usePieces`                 | 曲一覧（root の `PieceWork[]`）を取得する。`usePiecesPaginated` / `usePiecesAll` / `usePiece` を提供                                                                          |
+| `useMovements`              | 親 Work 配下の楽章一覧を取得する（`GET /pieces/{id}/children`、認証不要）                                                                                                     |
+| `useReplaceMovements`       | 親 Work 配下の楽章集合を一括差し替える `replaceMovements(workId, items)` を提供（`PUT /pieces/{workId}/movements`、admin 必須）                                               |
 | `useRatingDisplay`          | 評価値（0〜5）を星文字列に変換する (`ratingStars`)                                                                                                                            |
 | `useConcertLogs`            | コンサート記録の一覧取得（`list`）・作成（`create`）・更新（`update`）・削除（`deleteLog`）。401 時にトークンリフレッシュを自動試行                                           |
 | `useConcertLog`             | 特定のコンサート記録を id で取得する（詳細ページ用）                                                                                                                          |


### PR DESCRIPTION
Closes #644

## Summary

楽章コンポジット PR5。フロントエンドで楽章 (Movement) を扱えるようにし、楽曲詳細ページに楽章一覧表示と Movement 単独詳細時のパンくずリンク・クイックログ生成を実装した。

## 主な変更点

### Composables

- `useMovements(workId)` 新規作成: `GET /pieces/{id}/children` で親 Work 配下の楽章一覧を取得 (認証不要)
- `useReplaceMovements()` 新規作成: 楽章集合の一括差し替え `replaceMovements(workId, items)` を提供 (admin 必須)
- `usePieces` 系 (`usePiecesPaginated` / `usePiecesAll`) の戻り値型を `PieceWork[]` に絞る (root の親楽曲のみ)

### コンポーネント

- `molecules/MovementListItem.vue` 新規作成 (+ test + stories): 楽章タイトル + index ゼロ埋め表示 + YouTube は埋め込み・それ以外は外部リンク
- `templates/PieceDetailTemplate.vue` に「Movements」セクションを追加 (Work かつ楽章ありの場合のみ)
- Movement を `/pieces/{movementId}` で直接開いた場合は親 Work へのパンくずリンクを表示
- `pages/pieces/[id]/index.vue` を Movement 対応に拡張: 親 Work を fetch して `composerName` を継承し、クイックログの piece 名を「親 Work title - 楽章 title」で組み立てる
- `FeaturedPiece` / `PieceItem` / `PieceList` / `PieceListInfinite` / `HomeTemplate` / `PiecesTemplate` / `ComposerDetailTemplate` / `ConcertLogDetail` / `ConcertLogForm` / `PieceCategoryList` / `PieceEditTemplate` の props を `PieceWork` (または `PieceWork[]`) に絞り、判別共用体 (`Piece = PieceWork | PieceMovement`) に追従

### テスト

- `MovementListItem` のユニットテスト (YouTube / 短縮 URL / 外部 URL / 混在 / 空配列) を追加
- `PieceDetailTemplate` に楽章ありなし両方の表示・パンくず・Movement 詳細時のカテゴリ非表示テストを追加
- `pages/pieces/[id]/index.test.ts` に Work / Movement の両分岐 (親 Work 取得・composerName 継承・クイックログラベル) を追加
- 既存テスト・stories のサンプル `Piece` データに `kind: "work"` を補完

### ドキュメント

- `docs/SPEC.md` §1.2 に楽章表示機能を追記、§2.2 の composables 表に `useMovements` / `useReplaceMovements` を追記、`usePieces` の戻り値型を明記

## Test plan

- [x] `pnpm run test:frontend` (104 files / 781 tests passed)
- [x] `pnpm run test:backend` (52 files / 746 tests passed)
- [x] `pnpm run lint`
- [x] `pnpm run format:check`

https://claude.ai/code/session_01H1qCJXBWTsLabMkrzGwowB

---
_Generated by [Claude Code](https://claude.ai/code/session_01H1qCJXBWTsLabMkrzGwowB)_