### PR TITLE
fix(cdk): デプロイ失敗の修正: Lambda追加時にCloudWatchアラームの物理名が衝突する問題を解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,30 @@ jobs:
         run: |
           aws logs delete-log-group --log-group-name "/aws/apigateway/classical-music-lake-${STAGE_NAME}" 2>/dev/null || true
 
+      # ----------------------------------------
+      # 孤立 CloudWatch アラームのクリーンアップ
+      # Lambda 関数追加によりインデックスがズレ、論理 ID が変わった際に
+      # 古い物理リソースが残って競合するケースに対処する
+      # ----------------------------------------
+      - name: Cleanup orphaned CloudWatch alarms
+        run: |
+          STACK_NAME="${{ steps.stack.outputs.name }}"
+          # CloudFormation スタックが管理していないアラームのみ削除する
+          ALL_ALARMS=$(aws cloudwatch describe-alarms \
+            --alarm-name-prefix "classical-music-lake-${STAGE_NAME}-lambda-" \
+            --query 'MetricAlarms[].AlarmName' \
+            --output text 2>/dev/null || true)
+          MANAGED=$(aws cloudformation list-stack-resources \
+            --stack-name "$STACK_NAME" \
+            --query 'StackResourceSummaries[?ResourceType==`AWS::CloudWatch::Alarm`].PhysicalResourceId' \
+            --output text 2>/dev/null || true)
+          for alarm in $ALL_ALARMS; do
+            if ! echo "$MANAGED" | grep -qF "$alarm"; then
+              echo "Deleting orphaned alarm: $alarm"
+              aws cloudwatch delete-alarms --alarm-names "$alarm" 2>/dev/null || true
+            fi
+          done
+
       - name: CDK Bootstrap (ap-northeast-1)
         run: npx cdk bootstrap
         working-directory: cdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,30 +128,6 @@ jobs:
         run: |
           aws logs delete-log-group --log-group-name "/aws/apigateway/classical-music-lake-${STAGE_NAME}" 2>/dev/null || true
 
-      # ----------------------------------------
-      # 孤立 CloudWatch アラームのクリーンアップ
-      # Lambda 関数追加によりインデックスがズレ、論理 ID が変わった際に
-      # 古い物理リソースが残って競合するケースに対処する
-      # ----------------------------------------
-      - name: Cleanup orphaned CloudWatch alarms
-        run: |
-          STACK_NAME="${{ steps.stack.outputs.name }}"
-          # CloudFormation スタックが管理していないアラームのみ削除する
-          ALL_ALARMS=$(aws cloudwatch describe-alarms \
-            --alarm-name-prefix "classical-music-lake-${STAGE_NAME}-lambda-" \
-            --query 'MetricAlarms[].AlarmName' \
-            --output text 2>/dev/null || true)
-          MANAGED=$(aws cloudformation list-stack-resources \
-            --stack-name "$STACK_NAME" \
-            --query 'StackResourceSummaries[?ResourceType==`AWS::CloudWatch::Alarm`].PhysicalResourceId' \
-            --output text 2>/dev/null || true)
-          for alarm in $ALL_ALARMS; do
-            if ! echo "$MANAGED" | grep -qF "$alarm"; then
-              echo "Deleting orphaned alarm: $alarm"
-              aws cloudwatch delete-alarms --alarm-names "$alarm" 2>/dev/null || true
-            fi
-          done
-
       - name: CDK Bootstrap (ap-northeast-1)
         run: npx cdk bootstrap
         working-directory: cdk

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -870,8 +870,8 @@ function handler(event) {
     ];
 
     // Lambda エラー監視：各関数ごとにアラームを作成
-    allFunctions.forEach((f, i) => {
-      createAlarm(`LambdaErrorAlarm${i}`, {
+    allFunctions.forEach((f) => {
+      createAlarm(`LambdaErrorAlarm${f.node.id}`, {
         alarmName: `classical-music-lake-${stageName}-lambda-${f.node.id}-errors`,
         alarmDescription: `Lambda 関数 ${f.node.id} でエラーが発生しています`,
         metric: f.metricErrors({ period: cdk.Duration.minutes(5), statistic: "Sum" }),


### PR DESCRIPTION
## Summary

- `allFunctions` 配列に Lambda 関数を追加するとインデックスがズレ、既存アラームの物理名と新規作成しようとする論理 ID が競合してデプロイが失敗していた
- `LambdaErrorAlarm${i}` → `LambdaErrorAlarm${f.node.id}` に変更し、配列順序に依存しない安定した論理 ID にした
- 今回の競合対象だった `classical-music-lake-stg-lambda-UpdateComposer-errors` / `classical-music-lake-stg-lambda-DeleteComposer-errors` は AWS コンソールで手動削除済み

## Test plan

- [ ] PR マージ後に stg へのデプロイが成功することを確認
- [ ] 今後 Lambda 関数を追加しても同様の競合が発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)