### PR TITLE
fix(cdk): 新規Lambda関数をallFunctions末尾に移動しアラーム論理ID衝突を解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,6 +128,30 @@ jobs:
         run: |
           aws logs delete-log-group --log-group-name "/aws/apigateway/classical-music-lake-${STAGE_NAME}" 2>/dev/null || true
 
+      # ----------------------------------------
+      # 孤立 CloudWatch アラームのクリーンアップ
+      # Lambda 関数追加によりインデックスがズレ、論理 ID が変わった際に
+      # 古い物理リソースが残って競合するケースに対処する
+      # ----------------------------------------
+      - name: Cleanup orphaned CloudWatch alarms
+        run: |
+          STACK_NAME="${{ steps.stack.outputs.name }}"
+          # CloudFormation スタックが管理していないアラームのみ削除する
+          ALL_ALARMS=$(aws cloudwatch describe-alarms \
+            --alarm-name-prefix "classical-music-lake-${STAGE_NAME}-lambda-" \
+            --query 'MetricAlarms[].AlarmName' \
+            --output text 2>/dev/null || true)
+          MANAGED=$(aws cloudformation list-stack-resources \
+            --stack-name "$STACK_NAME" \
+            --query 'StackResourceSummaries[?ResourceType==`AWS::CloudWatch::Alarm`].PhysicalResourceId' \
+            --output text 2>/dev/null || true)
+          for alarm in $ALL_ALARMS; do
+            if ! echo "$MANAGED" | grep -qF "$alarm"; then
+              echo "Deleting orphaned alarm: $alarm"
+              aws cloudwatch delete-alarms --alarm-names "$alarm" 2>/dev/null || true
+            fi
+          done
+
       - name: CDK Bootstrap (ap-northeast-1)
         run: npx cdk bootstrap
         working-directory: cdk

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,30 +128,6 @@ jobs:
         run: |
           aws logs delete-log-group --log-group-name "/aws/apigateway/classical-music-lake-${STAGE_NAME}" 2>/dev/null || true
 
-      # ----------------------------------------
-      # 孤立 CloudWatch アラームのクリーンアップ
-      # Lambda 関数追加によりインデックスがズレ、論理 ID が変わった際に
-      # 古い物理リソースが残って競合するケースに対処する
-      # ----------------------------------------
-      - name: Cleanup orphaned CloudWatch alarms
-        run: |
-          STACK_NAME="${{ steps.stack.outputs.name }}"
-          # CloudFormation スタックが管理していないアラームのみ削除する
-          ALL_ALARMS=$(aws cloudwatch describe-alarms \
-            --alarm-name-prefix "classical-music-lake-${STAGE_NAME}-lambda-" \
-            --query 'MetricAlarms[].AlarmName' \
-            --output text 2>/dev/null || true)
-          MANAGED=$(aws cloudformation list-stack-resources \
-            --stack-name "$STACK_NAME" \
-            --query 'StackResourceSummaries[?ResourceType==`AWS::CloudWatch::Alarm`].PhysicalResourceId' \
-            --output text 2>/dev/null || true)
-          for alarm in $ALL_ALARMS; do
-            if ! echo "$MANAGED" | grep -qF "$alarm"; then
-              echo "Deleting orphaned alarm: $alarm"
-              aws cloudwatch delete-alarms --alarm-names "$alarm" 2>/dev/null || true
-            fi
-          done
-
       - name: CDK Bootstrap (ap-northeast-1)
         run: npx cdk bootstrap
         working-directory: cdk

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -870,8 +870,8 @@ function handler(event) {
     ];
 
     // Lambda エラー監視：各関数ごとにアラームを作成
-    allFunctions.forEach((f, i) => {
-      createAlarm(`LambdaErrorAlarm${i}`, {
+    allFunctions.forEach((f) => {
+      createAlarm(`LambdaErrorAlarm${f.node.id}`, {
         alarmName: `classical-music-lake-${stageName}-lambda-${f.node.id}-errors`,
         alarmDescription: `Lambda 関数 ${f.node.id} でエラーが発生しています`,
         metric: f.metricErrors({ period: cdk.Duration.minutes(5), statistic: "Sum" }),

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -838,6 +838,9 @@ function handler(event) {
       return alarm;
     };
 
+    // 新しい Lambda 関数は必ずこの配列の末尾に追加すること。
+    // 途中に挿入するとインデックスベースの論理 ID がズレ、
+    // CloudFormation のアラームリソースが競合してデプロイが失敗する。
     const allFunctions = [
       listeningLogsList,
       listeningLogsGet,

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -849,8 +849,6 @@ function handler(event) {
       getPiece,
       updatePiece,
       deletePiece,
-      getPieceChildren,
-      replacePieceMovements,
       authRegister,
       authLogin,
       authVerifyEmail,
@@ -867,11 +865,13 @@ function handler(event) {
       getComposer,
       updateComposer,
       deleteComposer,
+      getPieceChildren,
+      replacePieceMovements,
     ];
 
     // Lambda エラー監視：各関数ごとにアラームを作成
-    allFunctions.forEach((f) => {
-      createAlarm(`LambdaErrorAlarm${f.node.id}`, {
+    allFunctions.forEach((f, i) => {
+      createAlarm(`LambdaErrorAlarm${i}`, {
         alarmName: `classical-music-lake-${stageName}-lambda-${f.node.id}-errors`,
         alarmDescription: `Lambda 関数 ${f.node.id} でエラーが発生しています`,
         metric: f.metricErrors({ period: cdk.Duration.minutes(5), statistic: "Sum" }),


### PR DESCRIPTION
## Summary

- `getPieceChildren` / `replacePieceMovements` を `allFunctions` 配列の途中に挿入したことで既存関数のインデックスがズレ、CloudFormation のアラーム論理 ID（`LambdaErrorAlarm${i}`）が競合してデプロイが失敗していた
- 両関数を配列末尾に移動し、既存インデックス 0〜25 を変えないようにした
- 今後同じ問題が起きないよう配列にコメントを追記した（新関数は必ず末尾に追加すること）

## Test plan

- [ ] マージ後に stg へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)