### PR TITLE
fix(cdk): アラーム論理IDをインデックスベースに戻しデプロイ競合を解消

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -873,8 +873,8 @@ function handler(event) {
     ];
 
     // Lambda エラー監視：各関数ごとにアラームを作成
-    allFunctions.forEach((f) => {
-      createAlarm(`LambdaErrorAlarm${f.node.id}`, {
+    allFunctions.forEach((f, i) => {
+      createAlarm(`LambdaErrorAlarm${i}`, {
         alarmName: `classical-music-lake-${stageName}-lambda-${f.node.id}-errors`,
         alarmDescription: `Lambda 関数 ${f.node.id} でエラーが発生しています`,
         metric: f.metricErrors({ period: cdk.Duration.minutes(5), statistic: "Sum" }),


### PR DESCRIPTION
## Summary

- PR #666 で `LambdaErrorAlarm${f.node.id}` に変更したが、既存スタックの論理 ID（`LambdaErrorAlarm${i}`）と競合してデプロイが失敗し続けていた
- `LambdaErrorAlarm${i}` に戻す（PR #667 で配列末尾への移動は完了済みのため、既存インデックス 0〜25 は不変）

## Test plan

- [ ] マージ後に stg へのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)