### PR TITLE
fix(pieces): 楽曲編集画面でカテゴリの現在値が初期表示されないバグを修正

### DIFF
--- a/app/components/templates/PieceEditTemplate.test.ts
+++ b/app/components/templates/PieceEditTemplate.test.ts
@@ -92,6 +92,31 @@ describe("PieceEditTemplate", () => {
     expect((composerSelect.element as HTMLSelectElement).value).toBe(COMPOSER_ID);
   });
 
+  it("カテゴリ系（genre / era / formation / region）の現在値も初期値として反映される", async () => {
+    const pieceWithCategories: PieceWork = {
+      ...samplePiece,
+      genre: "交響曲",
+      era: "古典派",
+      formation: "管弦楽",
+      region: "ドイツ・オーストリア",
+    };
+    const wrapper = await mountSuspended(PieceEditTemplate, {
+      props: {
+        piece: pieceWithCategories,
+        fetchError: null,
+        error: null,
+        composers,
+        movements: [],
+      },
+    });
+    expect((wrapper.find("#genre").element as HTMLSelectElement).value).toBe("交響曲");
+    expect((wrapper.find("#era").element as HTMLSelectElement).value).toBe("古典派");
+    expect((wrapper.find("#formation").element as HTMLSelectElement).value).toBe("管弦楽");
+    expect((wrapper.find("#region").element as HTMLSelectElement).value).toBe(
+      "ドイツ・オーストリア",
+    );
+  });
+
   it("フォーム送信時に submit イベントが emit される", async () => {
     const wrapper = await mountSuspended(PieceEditTemplate, {
       props: { piece: samplePiece, fetchError: null, error: null, composers, movements: [] },

--- a/app/components/templates/PieceEditTemplate.vue
+++ b/app/components/templates/PieceEditTemplate.vue
@@ -34,6 +34,10 @@ const emit = defineEmits<{
             title: piece?.title,
             composerId: piece?.composerId,
             videoUrls: piece?.videoUrls,
+            genre: piece?.genre,
+            era: piece?.era,
+            formation: piece?.formation,
+            region: piece?.region,
           }"
           :composers="composers"
           :composers-pending="composersPending"

--- a/app/pages/pieces/[id]/edit.vue
+++ b/app/pages/pieces/[id]/edit.vue
@@ -11,7 +11,7 @@ const { updatePiece } = usePiecesPaginated();
 const { data: composers, pending: composersPending, refresh: refreshComposers } = useComposersAll();
 await refreshComposers();
 
-const { data: movements } = useMovements(() => id.value);
+const { data: movements } = await useMovements(() => id.value);
 
 const workPiece = computed<PieceWork | null>(() =>
   piece.value !== null && piece.value !== undefined && piece.value.kind === "work"


### PR DESCRIPTION
## Summary

- `PieceEditTemplate` から `PieceForm` に渡す `:initial-values` に `genre` / `era` / `formation` / `region` が含まれておらず、楽曲編集画面でこれらのカテゴリ系フィールドが常に空のまま表示されていたバグを修正
- そのまま「更新する」を押すと `undefined` として送信され、既存値が削除される副作用があった
- `PieceEditTemplate.test.ts` に「カテゴリ系フィールドが初期値として反映される」回帰テストを追加

closes #672

## Test plan

- [x] `pnpm run test:frontend` がグリーン（786 件 / 105 ファイル）
- [x] `pnpm run lint`（ESLint + Stylelint）通過
- [x] `pre-push` フック（`format:check` + `test:frontend` + `test:backend`）通過
- [ ] 手動確認: 管理者ログイン → ジャンル等を設定済みの楽曲を `/pieces/{id}/edit` で開き、各カテゴリセレクトに現在値が表示されること

## 補足

データモデル・API 仕様は変わらないため `docs/SPEC.md` の更新は不要。


---
_Generated by [Claude Code](https://claude.ai/code/session_01JFpYn5uZtBD2Q8esTmtMWN)_