### PR TITLE
refactor(backend): コンサート記録の title を ConcertTitle 値オブジェクト化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,8 @@ type(scope): 日本語の説明
 
 - `scope` は省略可能
 - 説明（subject）は日本語で記述する
-- subject の先頭を英大文字にしない（`subject-case` ルール）。英単語やファイル名を先頭に置きたい場合は日本語から始める形に言い換える
+- subject の先頭を英大文字にしない（`subject-case` ルール）。英単語・ファイル名・クラス名（`PieceTitle` のような PascalCase）を先頭に置きたい場合は日本語から始める形に言い換える
+- このルールは **PR タイトル** にも同じく適用される（PR タイトル＝マージ後の commit message になるため）。クラス名や型名を頭に置く形式（例: `refactor(backend): ConcertTitle 値オブジェクトを導入`）は `subject must not be ... pascal-case` で弾かれるので避ける
 - 末尾にピリオド（`.`・`。`）を付けない
 - ヘッダー全体は100文字以内
 
@@ -160,11 +161,12 @@ type(scope): 日本語の説明
 ✅ feat: 視聴ログ統計ダッシュボードを追加
 ✅ fix(auth): リフレッシュトークン失効時のリダイレクトを修正
 ✅ docs: SPEC.md にコンサート記録 API を追記
-✅ refactor(backend): PieceTitle 値オブジェクトを導入
+✅ refactor(backend): 楽曲の title を PieceTitle 値オブジェクト化
 
-❌ Add stats dashboard               （subject-case 違反 + 英語）
-❌ feat: Update README.md             （subject の先頭が英大文字）
-❌ feat: 視聴ログ統計を追加。            （末尾の句点）
+❌ Add stats dashboard                          （subject-case 違反 + 英語）
+❌ feat: Update README.md                        （subject の先頭が英大文字）
+❌ refactor(backend): PieceTitle 値オブジェクトを導入  （subject 先頭が PascalCase で弾かれる）
+❌ feat: 視聴ログ統計を追加。                       （末尾の句点）
 ```
 
 ---

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,9 @@ type(scope): 日本語の説明
 
 - `scope` は省略可能
 - 説明（subject）は**日本語で記述**する
-- subject の先頭を**英大文字にしない**（`subject-case` ルール）。ファイル名等を先頭に置く場合は日本語から始める形に言い換える
+- subject の先頭を**英大文字にしない**（`subject-case` ルール）。ファイル名・クラス名（`PieceTitle` のような **PascalCase**）を先頭に置く場合は日本語から始める形に言い換える
+  - 例: ❌ `refactor(backend): ConcertTitle 値オブジェクトを導入` → ✅ `refactor(backend): コンサート記録の title を ConcertTitle 値オブジェクト化`
+  - **PR タイトル**もこの規約に従うこと（マージ時の commit message が同じく commitlint で検証される）
 - 末尾に**ピリオド（`.`・`。`）を付けない**
 - ヘッダー全体は**100 文字以内**
 

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,5 +1,6 @@
 import type { ConcertLog, CreateConcertLogInput } from "../types";
 import { Entity, type EntityProps } from "./entity";
+import { ConcertTitle } from "./value-objects/concert-title";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 import { Venue } from "./value-objects/venue";
 
@@ -13,7 +14,7 @@ export type ConcertLogRepository = {
 
 type ConcertLogProps = EntityProps<ConcertLogId> & {
   userId: UserId;
-  title: string;
+  title: ConcertTitle;
   concertDate: string;
   venue: Venue;
   conductor?: string;
@@ -33,6 +34,7 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
       ...input,
       id: ConcertLogId.generate(),
       userId,
+      title: ConcertTitle.of(input.title),
       venue: Venue.of(input.venue),
       pieceIds: input.pieceIds === undefined ? undefined : input.pieceIds.map(PieceId.from),
       createdAt: now,
@@ -45,6 +47,7 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
       ...data,
       id: ConcertLogId.from(data.id),
       userId: UserId.from(data.userId),
+      title: ConcertTitle.of(data.title),
       venue: Venue.of(data.venue),
       pieceIds: data.pieceIds === undefined ? undefined : data.pieceIds.map(PieceId.from),
     });
@@ -63,6 +66,7 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
       ...this.props,
       id: this.props.id.value,
       userId: this.props.userId.value,
+      title: this.props.title.value,
       venue: this.props.venue.value,
       pieceIds:
         this.props.pieceIds === undefined ? undefined : this.props.pieceIds.map((id) => id.value),

--- a/backend/src/domain/value-objects/concert-title.test.ts
+++ b/backend/src/domain/value-objects/concert-title.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+
+import { ConcertTitle } from "./concert-title";
+
+describe("ConcertTitle", () => {
+  describe("of", () => {
+    it("非空文字列を受理して値を保持する", () => {
+      const title = ConcertTitle.of("ベルリン・フィル来日公演");
+      expect(title.value).toBe("ベルリン・フィル来日公演");
+      expect(String(title)).toBe("ベルリン・フィル来日公演");
+    });
+
+    it("前後の空白をトリムする", () => {
+      const title = ConcertTitle.of("  N響定期公演  ");
+      expect(title.value).toBe("N響定期公演");
+    });
+
+    it("空文字を拒否する", () => {
+      expect(() => ConcertTitle.of("")).toThrow(RangeError);
+    });
+
+    it("空白のみの文字列を拒否する", () => {
+      expect(() => ConcertTitle.of("   ")).toThrow(RangeError);
+    });
+
+    it("200 文字ちょうどは受理する", () => {
+      const value = "a".repeat(200);
+      expect(ConcertTitle.of(value).value).toBe(value);
+    });
+
+    it("201 文字以上を拒否する", () => {
+      expect(() => ConcertTitle.of("a".repeat(201))).toThrow(RangeError);
+    });
+
+    it("文字列以外を拒否する", () => {
+      expect(() => ConcertTitle.of(undefined as unknown as string)).toThrow(TypeError);
+    });
+  });
+
+  describe("equals", () => {
+    it("同じ値の ConcertTitle は等しい", () => {
+      expect(ConcertTitle.of("第九演奏会").equals(ConcertTitle.of("第九演奏会"))).toBe(true);
+    });
+
+    it("異なる値の ConcertTitle は等しくない", () => {
+      expect(ConcertTitle.of("第九演奏会").equals(ConcertTitle.of("オペラ・ガラ"))).toBe(false);
+    });
+
+    it("ConcertTitle 以外のオブジェクトとは等しくない", () => {
+      const title = ConcertTitle.of("チャイコフスキーの夕べ");
+      expect(title.equals({ value: "チャイコフスキーの夕べ" } as unknown as ConcertTitle)).toBe(
+        false,
+      );
+    });
+  });
+});

--- a/backend/src/domain/value-objects/concert-title.ts
+++ b/backend/src/domain/value-objects/concert-title.ts
@@ -1,0 +1,38 @@
+/**
+ * コンサートのタイトルを表す値オブジェクト。
+ *
+ * - 前後の空白を除去して保持する。
+ * - 空文字（空白のみを含む）を拒否する。
+ * - 最大 200 文字。
+ */
+const MAX_LENGTH = 200;
+
+export class ConcertTitle {
+  public readonly value: string;
+
+  private constructor(value: string) {
+    this.value = value;
+  }
+
+  static of(value: string): ConcertTitle {
+    if (typeof value !== "string") {
+      throw new TypeError("ConcertTitle must be a string");
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new RangeError("ConcertTitle must be a non-empty string");
+    }
+    if (trimmed.length > MAX_LENGTH) {
+      throw new RangeError(`ConcertTitle must be ${MAX_LENGTH} characters or less`);
+    }
+    return new ConcertTitle(trimmed);
+  }
+
+  equals(other: ConcertTitle): boolean {
+    return other instanceof ConcertTitle && this.value === other.value;
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -610,6 +610,7 @@ ID 以外のドメイン概念も不変条件を VO で保証する。すべて 
 | `PieceTitle`    | 非空・最大 200 文字                         | `PieceWorkEntity.props.title` / `PieceMovementEntity.props.title` |
 | `MovementIndex` | 0〜999 の整数                               | `PieceMovementEntity.props.index`                                 |
 | `ComposerName`  | 非空・最大 100 文字                         | `ComposerEntity.props.name`                                       |
+| `ConcertTitle`  | 非空・最大 200 文字                         | `ConcertLogEntity.props.title`                                    |
 | `Venue`         | 非空・最大 200 文字                         | `ConcertLogEntity.props.venue`                                    |
 | `Url`           | WHATWG URL パーサーで形式検証               | `Piece.videoUrls` 各要素 / `Composer.imageUrl`                    |
 | `Year`          | -3000〜9999 の整数（西暦。BC は負数で表現） | `ComposerEntity.props.birthYear` / `props.deathYear`              |


### PR DESCRIPTION
## Summary

- `ConcertLogEntity.props.title` を primitive `string` から新設の `ConcertTitle` 値オブジェクトに置き換え（`Venue` / `PieceTitle` と同型: 非空・最大 200 文字、trim 適用）
- `docs/SPEC.md` §8.5 のドメイン VO 一覧に `ConcertTitle` を追記
- コミット規約ドキュメント（`CLAUDE.md` / `CONTRIBUTING.md`）に「subject 先頭が PascalCase（クラス名等）でも `subject-case` で弾かれる」注意と、PR タイトルにも同じ規約が適用される旨を明記。誤った例だった `refactor(backend): PieceTitle 値オブジェクトを導入` も修正

## Why

ドメインの不変条件（コンサートタイトルは非空・最大 200 文字）を Zod スキーマに加えてエンティティ側でも保証し、ドメイン外で primitive `string` のまま流通するのを防ぐ。Venue / PieceTitle と揃えることで一貫性も向上。

## Test plan

- [x] `pnpm -C backend test`（53 ファイル / 743 テスト 全通過）
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] 新規 VO の単体テスト（`concert-title.test.ts`）追加


---
_Generated by [Claude Code](https://claude.ai/code/session_014XRaReYkhm7S3AMGscBnWe)_