### PR TITLE
refactor(backend): コンサート記録の更新を集約経由のドメインパターンに統一

### DIFF
--- a/backend/src/domain/concert-log.test.ts
+++ b/backend/src/domain/concert-log.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+
+import { ConcertLogEntity } from "./concert-log";
+import { UserId } from "./value-objects/ids";
+import type { ConcertLog, CreateConcertLogInput } from "../types";
+
+const USER_ID = "cognito-sub-user-1";
+const OTHER_USER_ID = "cognito-sub-user-2";
+const PIECE_ID_1 = "00000000-0000-4000-8000-000000000001";
+const PIECE_ID_2 = "00000000-0000-4000-8000-000000000002";
+
+const makeInput = (overrides: Partial<CreateConcertLogInput> = {}): CreateConcertLogInput => ({
+  title: "定期演奏会 第100回",
+  concertDate: "2024-01-15T19:00:00.000Z",
+  venue: "サントリーホール",
+  ...overrides,
+});
+
+describe("ConcertLogEntity", () => {
+  it("create で id・createdAt・updatedAt が付与される", () => {
+    const entity = ConcertLogEntity.create(makeInput(), UserId.from(USER_ID));
+    const plain = entity.toPlain();
+    expect(plain.id).toBeDefined();
+    expect(plain.userId).toBe(USER_ID);
+    expect(plain.createdAt).toBeDefined();
+    expect(plain.updatedAt).toBeDefined();
+    expect(plain.title).toBe("定期演奏会 第100回");
+    expect(plain.venue).toBe("サントリーホール");
+  });
+
+  it("reconstruct は与えた id / createdAt / updatedAt を保持する", () => {
+    const data: ConcertLog = {
+      id: "cl-abc",
+      userId: USER_ID,
+      title: "特別演奏会",
+      concertDate: "2024-03-01T19:00:00.000Z",
+      venue: "東京文化会館",
+      createdAt: "2024-03-01T20:00:00.000Z",
+      updatedAt: "2024-03-01T20:00:00.000Z",
+    };
+    const entity = ConcertLogEntity.reconstruct(data);
+    const plain = entity.toPlain();
+    expect(plain.id).toBe("cl-abc");
+    expect(plain.createdAt).toBe(data.createdAt);
+    expect(plain.updatedAt).toBe(data.updatedAt);
+  });
+
+  describe("mergeUpdate", () => {
+    const baseData: ConcertLog = {
+      id: "cl-1",
+      userId: USER_ID,
+      title: "定期演奏会 第100回",
+      concertDate: "2024-01-15T19:00:00.000Z",
+      venue: "サントリーホール",
+      conductor: "小澤征爾",
+      createdAt: "2024-01-15T21:00:00.000Z",
+      updatedAt: "2024-01-15T21:00:00.000Z",
+    };
+
+    it("指定フィールドのみ上書きし、updatedAt を進める", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const updated = entity.mergeUpdate({ venue: "東京文化会館" }).toPlain();
+      expect(updated.venue).toBe("東京文化会館");
+      expect(updated.title).toBe(baseData.title);
+      expect(updated.concertDate).toBe(baseData.concertDate);
+      expect(updated.conductor).toBe(baseData.conductor);
+      expect(updated.updatedAt).not.toBe(baseData.updatedAt);
+    });
+
+    it("id と createdAt は不変", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const updated = entity.mergeUpdate({ venue: "東京文化会館" }).toPlain();
+      expect(updated.id).toBe(baseData.id);
+      expect(updated.createdAt).toBe(baseData.createdAt);
+    });
+
+    it("pieceIds を配列で更新できる", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const updated = entity.mergeUpdate({ pieceIds: [PIECE_ID_1, PIECE_ID_2] }).toPlain();
+      expect(updated.pieceIds).toEqual([PIECE_ID_1, PIECE_ID_2]);
+    });
+
+    it("pieceIds を空配列で送ると空配列のまま保持される（プログラムを空に）", () => {
+      const entity = ConcertLogEntity.reconstruct({
+        ...baseData,
+        pieceIds: [PIECE_ID_1],
+      });
+      const updated = entity.mergeUpdate({ pieceIds: [] }).toPlain();
+      expect(updated.pieceIds).toEqual([]);
+    });
+  });
+
+  describe("isOwnedBy", () => {
+    it("同じ userId なら true", () => {
+      const entity = ConcertLogEntity.create(makeInput(), UserId.from(USER_ID));
+      expect(entity.isOwnedBy(UserId.from(USER_ID))).toBe(true);
+    });
+
+    it("異なる userId なら false", () => {
+      const entity = ConcertLogEntity.create(makeInput(), UserId.from(USER_ID));
+      expect(entity.isOwnedBy(UserId.from(OTHER_USER_ID))).toBe(false);
+    });
+  });
+
+  describe("sortByConcertDateDesc", () => {
+    it("concertDate 降順でソートする", () => {
+      const a = ConcertLogEntity.reconstruct({
+        id: "a",
+        userId: USER_ID,
+        title: "A",
+        concertDate: "2024-01-01T00:00:00.000Z",
+        venue: "V",
+        createdAt: "x",
+        updatedAt: "x",
+      });
+      const b = ConcertLogEntity.reconstruct({
+        id: "b",
+        userId: USER_ID,
+        title: "B",
+        concertDate: "2024-12-31T00:00:00.000Z",
+        venue: "V",
+        createdAt: "x",
+        updatedAt: "x",
+      });
+      const sorted = ConcertLogEntity.sortByConcertDateDesc([a, b]);
+      expect(sorted[0]?.id.value).toBe("b");
+      expect(sorted[1]?.id.value).toBe("a");
+    });
+  });
+});

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,5 +1,6 @@
-import type { ConcertLog, CreateConcertLogInput } from "../types";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
 import { Entity, type EntityProps } from "./entity";
+import { buildUpdateProps } from "./entity-helpers";
 import { ConcertTitle } from "./value-objects/concert-title";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 import { Venue } from "./value-objects/venue";
@@ -8,7 +9,7 @@ export type ConcertLogRepository = {
   findById(id: ConcertLogId): Promise<ConcertLog | undefined>;
   findByUserId(userId: UserId): Promise<ConcertLog[]>;
   save(item: ConcertLog): Promise<void>;
-  update(id: ConcertLogId, input: Partial<ConcertLog>): Promise<ConcertLog>;
+  saveWithOptimisticLock(item: ConcertLog, prevUpdatedAt: string): Promise<void>;
   remove(id: ConcertLogId): Promise<void>;
 };
 
@@ -59,6 +60,11 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
 
   isOwnedBy(userId: UserId): boolean {
     return this.props.userId.equals(userId);
+  }
+
+  mergeUpdate(input: UpdateConcertLogInput): ConcertLogEntity {
+    const merged = buildUpdateProps(this.toPlain(), input, []);
+    return ConcertLogEntity.reconstruct(merged);
   }
 
   toPlain(): ConcertLog {

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -8,7 +8,7 @@ const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
   findById: vi.fn(),
   findByUserId: vi.fn(),
-  update: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
   remove: vi.fn(),
 }));
 

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -13,7 +13,7 @@ const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
   findById: vi.fn(),
   findByUserId: vi.fn(),
-  update: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
   remove: vi.fn(),
 }));
 

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -8,7 +8,7 @@ const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
   findById: vi.fn(),
   findByUserId: vi.fn(),
-  update: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
   remove: vi.fn(),
 }));
 

--- a/backend/src/handlers/concert-logs/list.test.ts
+++ b/backend/src/handlers/concert-logs/list.test.ts
@@ -9,7 +9,7 @@ const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
   findById: vi.fn(),
   findByUserId: vi.fn(),
-  update: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
   remove: vi.fn(),
 }));
 

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -9,7 +9,7 @@ const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),
   findById: vi.fn(),
   findByUserId: vi.fn(),
-  update: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
   remove: vi.fn(),
 }));
 
@@ -139,7 +139,7 @@ describe("PUT /concert-logs/:id (update)", () => {
       mockCallback,
     );
     expect(result?.statusCode).toBe(404);
-    expect(mockRepo.update).not.toHaveBeenCalled();
+    expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
@@ -153,13 +153,8 @@ describe("PUT /concert-logs/:id (update)", () => {
   });
 
   it("正常更新して 200 を返す", async () => {
-    const updatedLog: ConcertLog = {
-      ...existingLog,
-      venue: "東京文化会館",
-      updatedAt: new Date().toISOString(),
-    };
     mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.update.mockResolvedValueOnce(updatedLog);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
@@ -171,15 +166,15 @@ describe("PUT /concert-logs/:id (update)", () => {
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBe("abc-123");
     expect(body.venue).toBe("東京文化会館");
+    expect(mockRepo.saveWithOptimisticLock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "abc-123", venue: "東京文化会館" }),
+      existingLog.updatedAt,
+    );
   });
 
   it("venue のみ更新して concertDate はそのままであること", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.update.mockResolvedValueOnce({
-      ...existingLog,
-      venue: "東京文化会館",
-      updatedAt: new Date().toISOString(),
-    });
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
@@ -187,18 +182,24 @@ describe("PUT /concert-logs/:id (update)", () => {
       mockCallback,
     );
     expect(result?.statusCode).toBe(200);
+    const body = JSON.parse(result?.body ?? "{}");
+    expect(body.concertDate).toBe(existingLog.concertDate);
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.update.mockRejectedValueOnce(new Conflict("Item was updated by another request"));
+    mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(
+      new Conflict("Concert log was updated by another request"),
+    );
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
       mockCallback,
     );
     expect(result?.statusCode).toBe(409);
-    expect(JSON.parse(result?.body ?? "{}").message).toBe("Item was updated by another request");
+    expect(JSON.parse(result?.body ?? "{}").message).toBe(
+      "Concert log was updated by another request",
+    );
   });
 
   it("Repository エラー時に 500 を返す", async () => {
@@ -213,13 +214,8 @@ describe("PUT /concert-logs/:id (update)", () => {
 
   it("pieceIds を更新できる", async () => {
     const pieceId = "550e8400-e29b-41d4-a716-446655440000";
-    const updatedLog: ConcertLog = {
-      ...existingLog,
-      pieceIds: [pieceId],
-      updatedAt: new Date().toISOString(),
-    };
     mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.update.mockResolvedValueOnce(updatedLog);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [pieceId] }), TEST_USER_ID),
@@ -236,13 +232,8 @@ describe("PUT /concert-logs/:id (update)", () => {
       ...existingLog,
       pieceIds: ["550e8400-e29b-41d4-a716-446655440000"],
     };
-    const updatedLog: ConcertLog = {
-      ...existingLog,
-      pieceIds: [],
-      updatedAt: new Date().toISOString(),
-    };
     mockRepo.findById.mockResolvedValueOnce(existingLogWithPieces);
-    mockRepo.update.mockResolvedValueOnce(updatedLog);
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [] }), TEST_USER_ID),

--- a/backend/src/repositories/concert-log-repository.ts
+++ b/backend/src/repositories/concert-log-repository.ts
@@ -1,7 +1,12 @@
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
 import type { ConcertLogId, UserId } from "../domain/value-objects/ids";
-import { dynamo, queryItemsByUserId, updateItem, TABLE_CONCERT_LOGS } from "../utils/dynamodb";
+import {
+  dynamo,
+  putItemWithOptimisticLock,
+  queryItemsByUserId,
+  TABLE_CONCERT_LOGS,
+} from "../utils/dynamodb";
 import type { ConcertLog } from "../types";
 import type { ConcertLogRepository } from "../domain/concert-log";
 
@@ -21,8 +26,13 @@ export class DynamoDBConcertLogRepository implements ConcertLogRepository {
     await dynamo.send(new PutCommand({ TableName: TABLE_CONCERT_LOGS, Item: item }));
   }
 
-  async update(id: ConcertLogId, input: Partial<ConcertLog>): Promise<ConcertLog> {
-    return updateItem<ConcertLog>(TABLE_CONCERT_LOGS, id.value, input);
+  async saveWithOptimisticLock(item: ConcertLog, prevUpdatedAt: string): Promise<void> {
+    await putItemWithOptimisticLock({
+      tableName: TABLE_CONCERT_LOGS,
+      item,
+      prevUpdatedAt,
+      conflictMessage: "Concert log was updated by another request",
+    });
   }
 
   async remove(id: ConcertLogId): Promise<void> {

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -3,7 +3,7 @@ import type { ConcertLogRepository } from "../domain/concert-log";
 import { ConcertLogId } from "../domain/value-objects/ids";
 import type { UserId } from "../domain/value-objects/ids";
 import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
-import type { ConcertLog, CreateConcertLogInput } from "../types";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
 import { loadOwnedEntityOrNotFound } from "./helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
@@ -42,9 +42,16 @@ export class ConcertLogUsecase {
     return entity.toPlain();
   }
 
-  async update(id: ConcertLogId, input: Partial<ConcertLog>, userId: UserId): Promise<ConcertLog> {
-    await this.loadOwnedEntity(id, userId);
-    return this.repo.update(id, input);
+  async update(
+    id: ConcertLogId,
+    input: UpdateConcertLogInput,
+    userId: UserId,
+  ): Promise<ConcertLog> {
+    const current = await this.loadOwnedEntity(id, userId);
+    const updated = current.mergeUpdate(input);
+    const plain = updated.toPlain();
+    await this.repo.saveWithOptimisticLock(plain, current.updatedAt);
+    return plain;
   }
 
   async delete(id: ConcertLogId, userId: UserId): Promise<void> {

--- a/backend/src/utils/dynamodb.test.ts
+++ b/backend/src/utils/dynamodb.test.ts
@@ -1,13 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 
-import {
-  putItemWithOptimisticLock,
-  queryItemsByUserId,
-  scanAllItems,
-  scanPage,
-  updateItem,
-} from "./dynamodb";
+import { putItemWithOptimisticLock, queryItemsByUserId, scanAllItems, scanPage } from "./dynamodb";
 
 const { mockSend } = vi.hoisted(() => ({
   mockSend: vi.fn(),
@@ -28,9 +22,6 @@ vi.mock("@aws-sdk/lib-dynamodb", () => ({
   DynamoDBDocumentClient: {
     from: vi.fn().mockReturnValue({ send: mockSend }),
   },
-  GetCommand: class GetCommand {
-    constructor(public input: unknown) {}
-  },
   PutCommand: class PutCommand {
     constructor(public input: unknown) {}
   },
@@ -41,13 +32,6 @@ vi.mock("@aws-sdk/lib-dynamodb", () => ({
     constructor(public input: unknown) {}
   },
 }));
-
-type TestItem = {
-  id: string;
-  createdAt: string;
-  updatedAt: string;
-  name: string;
-};
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -226,75 +210,5 @@ describe("putItemWithOptimisticLock", () => {
         conflictMessage: "Whatever",
       }),
     ).rejects.toThrow("DynamoDB connection error");
-  });
-});
-
-describe("updateItem", () => {
-  const existing: TestItem = {
-    id: "item-1",
-    createdAt: "2024-01-01T00:00:00.000Z",
-    updatedAt: "2024-01-01T00:00:00.000Z",
-    name: "original",
-  };
-
-  it("アイテムが存在しない場合は 404 を投げる", async () => {
-    mockSend.mockResolvedValueOnce({ Item: undefined });
-
-    await expect(updateItem<TestItem>("test-table", "item-1", { name: "updated" })).rejects.toThrow(
-      "Item not found",
-    );
-  });
-
-  it("正常に更新されたアイテムを返す", async () => {
-    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
-
-    const result = await updateItem<TestItem>("test-table", "item-1", { name: "updated" });
-
-    expect(result.name).toBe("updated");
-    expect(result.id).toBe("item-1");
-    expect(result.createdAt).toBe(existing.createdAt);
-    expect(result.updatedAt).not.toBe(existing.updatedAt);
-  });
-
-  it("updatedAt が更新される", async () => {
-    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
-
-    const result = await updateItem<TestItem>("test-table", "item-1", {});
-
-    expect(result.updatedAt).not.toBe(existing.updatedAt);
-  });
-
-  it("id と createdAt は変更されない", async () => {
-    mockSend.mockResolvedValueOnce({ Item: existing }).mockResolvedValueOnce({});
-
-    const result = await updateItem<TestItem>("test-table", "item-1", {
-      id: "different-id",
-      createdAt: "2099-01-01T00:00:00.000Z",
-    } as Partial<TestItem>);
-
-    expect(result.id).toBe("item-1");
-    expect(result.createdAt).toBe(existing.createdAt);
-  });
-
-  it("ConditionalCheckFailedException が発生した場合は 409 を投げる", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: existing })
-      .mockRejectedValueOnce(
-        new ConditionalCheckFailedException({ message: "Condition failed", $metadata: {} }),
-      );
-
-    await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
-      "Item was updated by another request",
-    );
-  });
-
-  it("その他のエラーはそのまま再スローされる", async () => {
-    mockSend
-      .mockResolvedValueOnce({ Item: existing })
-      .mockRejectedValueOnce(new Error("DynamoDB connection error"));
-
-    await expect(updateItem("test-table", "item-1", {})).rejects.toThrow(
-      "DynamoDB connection error",
-    );
   });
 });

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -1,7 +1,6 @@
 import { ConditionalCheckFailedException, DynamoDBClient } from "@aws-sdk/client-dynamodb";
 import {
   DynamoDBDocumentClient,
-  GetCommand,
   PutCommand,
   QueryCommand,
   ScanCommand,
@@ -117,31 +116,4 @@ export async function putItemWithOptimisticLock<T>(options: {
     }
     throw err;
   }
-}
-
-export async function updateItem<T extends { id: string; createdAt: string; updatedAt: string }>(
-  tableName: string,
-  id: string,
-  input: Partial<T>,
-): Promise<T> {
-  const existing = await dynamo.send(new GetCommand({ TableName: tableName, Key: { id } }));
-  if (existing.Item === undefined) {
-    throw new createError.NotFound("Item not found");
-  }
-
-  const current = existing.Item as T;
-  const updated: T = {
-    ...current,
-    ...input,
-    id,
-    createdAt: current.createdAt,
-    updatedAt: new Date().toISOString(),
-  };
-  await putItemWithOptimisticLock({
-    tableName,
-    item: updated,
-    prevUpdatedAt: current.updatedAt,
-    conflictMessage: "Item was updated by another request",
-  });
-  return updated;
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,7 +339,9 @@ classical-music-lake/
   → API Gateway + Cognito Authorizer
   → Lambda (update.ts)
   → 既存レコード取得 + userId 検証（不一致は 404）
-  → updateItem でフィールドを部分更新（楽観的ロック）
+  → ConcertLogEntity.mergeUpdate(input) で新エンティティを生成
+  → DynamoDBConcertLogRepository.saveWithOptimisticLock(plain, prevUpdatedAt)
+    （競合時は 409 Conflict + "Concert log was updated by another request"）
   → 200 OK + 更新済みオブジェクト
   → ブラウザに返却 → /concert-logs/{id} へ遷移
 ```

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -317,6 +317,7 @@ interface ConcertLog {
 - **CRUD**: `GET /concert-logs` / `GET /concert-logs/{id}` / `POST /concert-logs` / `PUT /concert-logs/{id}` / `DELETE /concert-logs/{id}`
 - **ソート順**: `concertDate` 降順
 - **アクセス制御**: GSI1（`userId` + `createdAt`）でユーザースコープに絞り込み
+- **楽観的ロック**: `PUT /concert-logs/{id}` は `updatedAt` を ifMatch 条件にした条件付き Put で更新する。競合時は `409 Conflict` + `{ "message": "Concert log was updated by another request" }`
 - 認可・自動生成・更新ルールは視聴ログと同様
 
 ### 4.5 楽曲マスタ API（`/pieces`）


### PR DESCRIPTION
## 背景

`ConcertLogRepository.update(id, Partial<ConcertLog>)` がリポジトリ層で部分更新ロジックを担っており、`ConcertLogUsecase.update` はそこへ丸投げしていた。視聴ログ（ListeningLog）・作曲家マスタ（Composer）が `load → mergeUpdate → saveWithOptimisticLock` の標準パターンで書き込みを行っているのに対し、コンサート記録だけが**ドメインを通らずに更新**される状態になっていた。

DDD のレイヤー境界（handlers → usecases → domain / repositories）に沿わせ、書き込みパスを必ずエンティティ経由にすることで、3 エンティティで書き込みパターンを揃える。

## 変更内容

- **ドメイン層**: `ConcertLogEntity.mergeUpdate(input: UpdateConcertLogInput)` を追加（`ListeningLogEntity` と同じく `buildUpdateProps` を利用、`clearableFields=[]`）。`ConcertLogRepository` I/F を `update(Partial)` から `saveWithOptimisticLock(item, prevUpdatedAt)` に差し替え
- **リポジトリ層**: `DynamoDBConcertLogRepository` を `putItemWithOptimisticLock` ベースに書き換え。競合メッセージは `Concert log was updated by another request`
- **ユースケース層**: `ConcertLogUsecase.update` を標準パターンに書き換え
- **utils**: 唯一の利用元が消えた `dynamodb.ts:updateItem` と関連テストを削除
- **テスト**: `concert-log.test.ts` を新設して `mergeUpdate` / `isOwnedBy` / `sortByConcertDateDesc` を検証。handler テスト群（create / get / list / delete / update）の repo モックを新 I/F へ揃え、`update.test.ts` の正常系・楽観的ロック競合・pieceIds 更新ケースを `saveWithOptimisticLock` ベースに書き換え
- **ドキュメント**: `docs/SPEC.md` §4.4 にコンサート記録の楽観的ロック仕様を追記、`docs/ARCHITECTURE.md` のコンサート記録更新フローをドメイン経由表現に更新

## 互換性

API・HTTP 挙動は完全互換。Zod の `updateConcertLogSchema = createConcertLogSchema.partial()` が undefined キーを除去するため、新パターンの `mergeUpdate` シャローマージは `updateItem` の `{...current, ...input}` と等価。`pieceIds: []` を送って空配列で保存する既存挙動も維持される。

## Test plan

- [x] `pnpm run test:backend`（738 件 green）
- [x] `pnpm run lint`（ESLint + Stylelint）
- [x] `pnpm run format:check`
- [x] pre-push フック（format:check + フロント 786 件 + バック 738 件 全 green）
- [ ] CI 上の deploy / E2E

https://claude.ai/code/session_01MqUEmhrff3xg2Yo4xF6o1R

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUEmhrff3xg2Yo4xF6o1R)_