### PR TITLE
refactor(backend): コンサート記録の更新を集約意図メソッド revise に書き直す

### DIFF
--- a/backend/src/domain/concert-log.test.ts
+++ b/backend/src/domain/concert-log.test.ts
@@ -1,9 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import { ConcertLogEntity } from "./concert-log";
-import { ConcertTitle } from "./value-objects/concert-title";
-import { PieceId, UserId } from "./value-objects/ids";
-import { Venue } from "./value-objects/venue";
+import { UserId } from "./value-objects/ids";
 import type { ConcertLog, CreateConcertLogInput } from "../types";
 
 const USER_ID = "cognito-sub-user-1";
@@ -49,73 +47,54 @@ describe("ConcertLogEntity", () => {
     expect(plain.updatedAt).toBe(baseData.updatedAt);
   });
 
-  describe("意図メソッドは新エンティティを返し updatedAt を進める", () => {
-    it("rename はタイトルだけを置き換える", () => {
+  describe("revise（鑑賞記録の訂正）", () => {
+    it("指定したフィールドのみ書き換え、updatedAt を進める", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      const renamed = entity.rename(ConcertTitle.of("特別演奏会")).toPlain();
-      expect(renamed.title).toBe("特別演奏会");
-      expect(renamed.venue).toBe(baseData.venue);
-      expect(renamed.concertDate).toBe(baseData.concertDate);
-      expect(renamed.id).toBe(baseData.id);
-      expect(renamed.createdAt).toBe(baseData.createdAt);
-      expect(renamed.updatedAt).not.toBe(baseData.updatedAt);
+      const revised = entity.revise({ venue: "東京文化会館" }).toPlain();
+      expect(revised.venue).toBe("東京文化会館");
+      expect(revised.title).toBe(baseData.title);
+      expect(revised.concertDate).toBe(baseData.concertDate);
+      expect(revised.conductor).toBe(baseData.conductor);
+      expect(revised.updatedAt).not.toBe(baseData.updatedAt);
     });
 
-    it("relocate は会場だけを置き換える", () => {
+    it("複数フィールドをまとめて書き換えられる", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      const moved = entity.relocate(Venue.of("東京文化会館")).toPlain();
-      expect(moved.venue).toBe("東京文化会館");
-      expect(moved.title).toBe(baseData.title);
-      expect(moved.updatedAt).not.toBe(baseData.updatedAt);
-    });
-
-    it("reschedule は開催日時だけを置き換える", () => {
-      const entity = ConcertLogEntity.reconstruct(baseData);
-      const rescheduled = entity.reschedule("2024-03-01T19:00:00.000Z").toPlain();
-      expect(rescheduled.concertDate).toBe("2024-03-01T19:00:00.000Z");
-      expect(rescheduled.title).toBe(baseData.title);
-      expect(rescheduled.updatedAt).not.toBe(baseData.updatedAt);
-    });
-
-    it("assignConductor は指揮者だけを置き換える", () => {
-      const entity = ConcertLogEntity.reconstruct(baseData);
-      const reassigned = entity.assignConductor("カラヤン").toPlain();
-      expect(reassigned.conductor).toBe("カラヤン");
-      expect(reassigned.orchestra).toBeUndefined();
-      expect(reassigned.updatedAt).not.toBe(baseData.updatedAt);
-    });
-
-    it("assignOrchestra はオーケストラだけを置き換える", () => {
-      const entity = ConcertLogEntity.reconstruct(baseData);
-      const reassigned = entity.assignOrchestra("ベルリン・フィル").toPlain();
-      expect(reassigned.orchestra).toBe("ベルリン・フィル");
-      expect(reassigned.conductor).toBe(baseData.conductor);
-    });
-
-    it("assignSoloist はソリストだけを置き換える", () => {
-      const entity = ConcertLogEntity.reconstruct(baseData);
-      const reassigned = entity.assignSoloist("内田光子").toPlain();
-      expect(reassigned.soloist).toBe("内田光子");
-    });
-
-    it("setProgram はプログラム配列を置き換える", () => {
-      const entity = ConcertLogEntity.reconstruct(baseData);
-      const programmed = entity
-        .setProgram([PieceId.from(PIECE_ID_1), PieceId.from(PIECE_ID_2)])
+      const revised = entity
+        .revise({
+          title: "特別演奏会",
+          venue: "東京文化会館",
+          conductor: "カラヤン",
+        })
         .toPlain();
-      expect(programmed.pieceIds).toEqual([PIECE_ID_1, PIECE_ID_2]);
+      expect(revised.title).toBe("特別演奏会");
+      expect(revised.venue).toBe("東京文化会館");
+      expect(revised.conductor).toBe("カラヤン");
     });
 
-    it("setProgram に空配列を渡すとプログラムが空になる", () => {
-      const entity = ConcertLogEntity.reconstruct({ ...baseData, pieceIds: [PIECE_ID_1] });
-      const cleared = entity.setProgram([]).toPlain();
-      expect(cleared.pieceIds).toEqual([]);
-    });
-
-    it("意図メソッドはイミュータブル（元エンティティは変化しない）", () => {
+    it("id と createdAt は不変", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      entity.rename(ConcertTitle.of("別の名前"));
-      expect(entity.toPlain().title).toBe(baseData.title);
+      const revised = entity.revise({ venue: "東京文化会館" }).toPlain();
+      expect(revised.id).toBe(baseData.id);
+      expect(revised.createdAt).toBe(baseData.createdAt);
+    });
+
+    it("pieceIds を配列で書き換えられる", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const revised = entity.revise({ pieceIds: [PIECE_ID_1, PIECE_ID_2] }).toPlain();
+      expect(revised.pieceIds).toEqual([PIECE_ID_1, PIECE_ID_2]);
+    });
+
+    it("pieceIds に空配列を渡すとプログラムが空になる", () => {
+      const entity = ConcertLogEntity.reconstruct({ ...baseData, pieceIds: [PIECE_ID_1] });
+      const revised = entity.revise({ pieceIds: [] }).toPlain();
+      expect(revised.pieceIds).toEqual([]);
+    });
+
+    it("イミュータブル（元エンティティは変化しない）", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      entity.revise({ venue: "東京文化会館" });
+      expect(entity.toPlain().venue).toBe(baseData.venue);
     });
   });
 
@@ -126,8 +105,8 @@ describe("ConcertLogEntity", () => {
     });
 
     it("異なる userId なら false", () => {
-      const entity = ConcertLogEntity.create(makeInput(), UserId.from(USER_ID));
-      expect(entity.isOwnedBy(UserId.from(OTHER_USER_ID))).toBe(false);
+      const entity = ConcertLogEntity.create(makeInput(), UserId.from(OTHER_USER_ID));
+      expect(entity.isOwnedBy(UserId.from(USER_ID))).toBe(false);
     });
   });
 

--- a/backend/src/domain/concert-log.test.ts
+++ b/backend/src/domain/concert-log.test.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect } from "vitest";
 
 import { ConcertLogEntity } from "./concert-log";
-import { UserId } from "./value-objects/ids";
+import { ConcertTitle } from "./value-objects/concert-title";
+import { PieceId, UserId } from "./value-objects/ids";
+import { Venue } from "./value-objects/venue";
 import type { ConcertLog, CreateConcertLogInput } from "../types";
 
 const USER_ID = "cognito-sub-user-1";
@@ -16,6 +18,17 @@ const makeInput = (overrides: Partial<CreateConcertLogInput> = {}): CreateConcer
   ...overrides,
 });
 
+const baseData: ConcertLog = {
+  id: "cl-1",
+  userId: USER_ID,
+  title: "定期演奏会 第100回",
+  concertDate: "2024-01-15T19:00:00.000Z",
+  venue: "サントリーホール",
+  conductor: "小澤征爾",
+  createdAt: "2024-01-15T21:00:00.000Z",
+  updatedAt: "2024-01-15T21:00:00.000Z",
+};
+
 describe("ConcertLogEntity", () => {
   it("create で id・createdAt・updatedAt が付与される", () => {
     const entity = ConcertLogEntity.create(makeInput(), UserId.from(USER_ID));
@@ -29,64 +42,80 @@ describe("ConcertLogEntity", () => {
   });
 
   it("reconstruct は与えた id / createdAt / updatedAt を保持する", () => {
-    const data: ConcertLog = {
-      id: "cl-abc",
-      userId: USER_ID,
-      title: "特別演奏会",
-      concertDate: "2024-03-01T19:00:00.000Z",
-      venue: "東京文化会館",
-      createdAt: "2024-03-01T20:00:00.000Z",
-      updatedAt: "2024-03-01T20:00:00.000Z",
-    };
-    const entity = ConcertLogEntity.reconstruct(data);
+    const entity = ConcertLogEntity.reconstruct(baseData);
     const plain = entity.toPlain();
-    expect(plain.id).toBe("cl-abc");
-    expect(plain.createdAt).toBe(data.createdAt);
-    expect(plain.updatedAt).toBe(data.updatedAt);
+    expect(plain.id).toBe("cl-1");
+    expect(plain.createdAt).toBe(baseData.createdAt);
+    expect(plain.updatedAt).toBe(baseData.updatedAt);
   });
 
-  describe("mergeUpdate", () => {
-    const baseData: ConcertLog = {
-      id: "cl-1",
-      userId: USER_ID,
-      title: "定期演奏会 第100回",
-      concertDate: "2024-01-15T19:00:00.000Z",
-      venue: "サントリーホール",
-      conductor: "小澤征爾",
-      createdAt: "2024-01-15T21:00:00.000Z",
-      updatedAt: "2024-01-15T21:00:00.000Z",
-    };
-
-    it("指定フィールドのみ上書きし、updatedAt を進める", () => {
+  describe("意図メソッドは新エンティティを返し updatedAt を進める", () => {
+    it("rename はタイトルだけを置き換える", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      const updated = entity.mergeUpdate({ venue: "東京文化会館" }).toPlain();
-      expect(updated.venue).toBe("東京文化会館");
-      expect(updated.title).toBe(baseData.title);
-      expect(updated.concertDate).toBe(baseData.concertDate);
-      expect(updated.conductor).toBe(baseData.conductor);
-      expect(updated.updatedAt).not.toBe(baseData.updatedAt);
+      const renamed = entity.rename(ConcertTitle.of("特別演奏会")).toPlain();
+      expect(renamed.title).toBe("特別演奏会");
+      expect(renamed.venue).toBe(baseData.venue);
+      expect(renamed.concertDate).toBe(baseData.concertDate);
+      expect(renamed.id).toBe(baseData.id);
+      expect(renamed.createdAt).toBe(baseData.createdAt);
+      expect(renamed.updatedAt).not.toBe(baseData.updatedAt);
     });
 
-    it("id と createdAt は不変", () => {
+    it("relocate は会場だけを置き換える", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      const updated = entity.mergeUpdate({ venue: "東京文化会館" }).toPlain();
-      expect(updated.id).toBe(baseData.id);
-      expect(updated.createdAt).toBe(baseData.createdAt);
+      const moved = entity.relocate(Venue.of("東京文化会館")).toPlain();
+      expect(moved.venue).toBe("東京文化会館");
+      expect(moved.title).toBe(baseData.title);
+      expect(moved.updatedAt).not.toBe(baseData.updatedAt);
     });
 
-    it("pieceIds を配列で更新できる", () => {
+    it("reschedule は開催日時だけを置き換える", () => {
       const entity = ConcertLogEntity.reconstruct(baseData);
-      const updated = entity.mergeUpdate({ pieceIds: [PIECE_ID_1, PIECE_ID_2] }).toPlain();
-      expect(updated.pieceIds).toEqual([PIECE_ID_1, PIECE_ID_2]);
+      const rescheduled = entity.reschedule("2024-03-01T19:00:00.000Z").toPlain();
+      expect(rescheduled.concertDate).toBe("2024-03-01T19:00:00.000Z");
+      expect(rescheduled.title).toBe(baseData.title);
+      expect(rescheduled.updatedAt).not.toBe(baseData.updatedAt);
     });
 
-    it("pieceIds を空配列で送ると空配列のまま保持される（プログラムを空に）", () => {
-      const entity = ConcertLogEntity.reconstruct({
-        ...baseData,
-        pieceIds: [PIECE_ID_1],
-      });
-      const updated = entity.mergeUpdate({ pieceIds: [] }).toPlain();
-      expect(updated.pieceIds).toEqual([]);
+    it("assignConductor は指揮者だけを置き換える", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const reassigned = entity.assignConductor("カラヤン").toPlain();
+      expect(reassigned.conductor).toBe("カラヤン");
+      expect(reassigned.orchestra).toBeUndefined();
+      expect(reassigned.updatedAt).not.toBe(baseData.updatedAt);
+    });
+
+    it("assignOrchestra はオーケストラだけを置き換える", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const reassigned = entity.assignOrchestra("ベルリン・フィル").toPlain();
+      expect(reassigned.orchestra).toBe("ベルリン・フィル");
+      expect(reassigned.conductor).toBe(baseData.conductor);
+    });
+
+    it("assignSoloist はソリストだけを置き換える", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const reassigned = entity.assignSoloist("内田光子").toPlain();
+      expect(reassigned.soloist).toBe("内田光子");
+    });
+
+    it("setProgram はプログラム配列を置き換える", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      const programmed = entity
+        .setProgram([PieceId.from(PIECE_ID_1), PieceId.from(PIECE_ID_2)])
+        .toPlain();
+      expect(programmed.pieceIds).toEqual([PIECE_ID_1, PIECE_ID_2]);
+    });
+
+    it("setProgram に空配列を渡すとプログラムが空になる", () => {
+      const entity = ConcertLogEntity.reconstruct({ ...baseData, pieceIds: [PIECE_ID_1] });
+      const cleared = entity.setProgram([]).toPlain();
+      expect(cleared.pieceIds).toEqual([]);
+    });
+
+    it("意図メソッドはイミュータブル（元エンティティは変化しない）", () => {
+      const entity = ConcertLogEntity.reconstruct(baseData);
+      entity.rename(ConcertTitle.of("別の名前"));
+      expect(entity.toPlain().title).toBe(baseData.title);
     });
   });
 

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,5 +1,6 @@
-import type { ConcertLog, CreateConcertLogInput } from "../types";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
 import { Entity, type EntityProps } from "./entity";
+import { buildUpdateProps } from "./entity-helpers";
 import { ConcertTitle } from "./value-objects/concert-title";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 import { Venue } from "./value-objects/venue";
@@ -11,6 +12,14 @@ export type ConcertLogRepository = {
   saveWithOptimisticLock(item: ConcertLog, prevUpdatedAt: string): Promise<void>;
   remove(id: ConcertLogId): Promise<void>;
 };
+
+/**
+ * 鑑賞記録の訂正内容を表す型。フィールド単位の差分を 1 つのオブジェクトで表現する。
+ * このアプリは鑑賞者の個人ノートであり、コンサートを「主催・運営」しているわけではないため、
+ * フィールドごとの意図メソッド（rename / relocate / reschedule …）には実体が伴わない。
+ * 操作はすべて「過去に観測した事実の記録を訂正・追記する」という単一のドメイン操作に帰着する。
+ */
+export type ConcertLogRevision = UpdateConcertLogInput;
 
 type ConcertLogProps = EntityProps<ConcertLogId> & {
   userId: UserId;
@@ -61,60 +70,13 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
     return this.props.userId.equals(userId);
   }
 
-  rename(title: ConcertTitle): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      title,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  relocate(venue: Venue): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      venue,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  reschedule(concertDate: string): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      concertDate,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  assignConductor(name: string): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      conductor: name,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  assignOrchestra(name: string): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      orchestra: name,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  assignSoloist(name: string): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      soloist: name,
-      updatedAt: new Date().toISOString(),
-    });
-  }
-
-  setProgram(pieceIds: PieceId[]): ConcertLogEntity {
-    return new ConcertLogEntity({
-      ...this.props,
-      pieceIds,
-      updatedAt: new Date().toISOString(),
-    });
+  /**
+   * 鑑賞記録を訂正する。フィールドごとの意図メソッドを生やす代わりに、
+   * 「観測した事実の記録を後から書き直す」という単一の意図を 1 メソッドで表す。
+   */
+  revise(revision: ConcertLogRevision): ConcertLogEntity {
+    const merged = buildUpdateProps(this.toPlain(), revision, []);
+    return ConcertLogEntity.reconstruct(merged);
   }
 
   toPlain(): ConcertLog {

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,6 +1,5 @@
-import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
+import type { ConcertLog, CreateConcertLogInput } from "../types";
 import { Entity, type EntityProps } from "./entity";
-import { buildUpdateProps } from "./entity-helpers";
 import { ConcertTitle } from "./value-objects/concert-title";
 import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
 import { Venue } from "./value-objects/venue";
@@ -62,9 +61,60 @@ export class ConcertLogEntity extends Entity<ConcertLogId, ConcertLogProps> {
     return this.props.userId.equals(userId);
   }
 
-  mergeUpdate(input: UpdateConcertLogInput): ConcertLogEntity {
-    const merged = buildUpdateProps(this.toPlain(), input, []);
-    return ConcertLogEntity.reconstruct(merged);
+  rename(title: ConcertTitle): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      title,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  relocate(venue: Venue): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      venue,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  reschedule(concertDate: string): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      concertDate,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  assignConductor(name: string): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      conductor: name,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  assignOrchestra(name: string): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      orchestra: name,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  assignSoloist(name: string): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      soloist: name,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  setProgram(pieceIds: PieceId[]): ConcertLogEntity {
+    return new ConcertLogEntity({
+      ...this.props,
+      pieceIds,
+      updatedAt: new Date().toISOString(),
+    });
   }
 
   toPlain(): ConcertLog {

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -1,9 +1,7 @@
 import { ConcertLogEntity } from "../domain/concert-log";
 import type { ConcertLogRepository } from "../domain/concert-log";
-import { ConcertTitle } from "../domain/value-objects/concert-title";
-import { ConcertLogId, PieceId } from "../domain/value-objects/ids";
+import { ConcertLogId } from "../domain/value-objects/ids";
 import type { UserId } from "../domain/value-objects/ids";
-import { Venue } from "../domain/value-objects/venue";
 import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
 import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
 import { loadOwnedEntityOrNotFound } from "./helpers";
@@ -50,32 +48,8 @@ export class ConcertLogUsecase {
     userId: UserId,
   ): Promise<ConcertLog> {
     const current = await this.loadOwnedEntity(id, userId);
-    let next = current;
-    if (input.title !== undefined) {
-      next = next.rename(ConcertTitle.of(input.title));
-    }
-    if (input.venue !== undefined) {
-      next = next.relocate(Venue.of(input.venue));
-    }
-    if (input.concertDate !== undefined) {
-      next = next.reschedule(input.concertDate);
-    }
-    if (input.conductor !== undefined) {
-      next = next.assignConductor(input.conductor);
-    }
-    if (input.orchestra !== undefined) {
-      next = next.assignOrchestra(input.orchestra);
-    }
-    if (input.soloist !== undefined) {
-      next = next.assignSoloist(input.soloist);
-    }
-    if (input.pieceIds !== undefined) {
-      next = next.setProgram(input.pieceIds.map(PieceId.from));
-    }
-    const plain = next.toPlain();
-    if (next === current) {
-      return plain;
-    }
+    const revised = current.revise(input);
+    const plain = revised.toPlain();
     await this.repo.saveWithOptimisticLock(plain, current.updatedAt);
     return plain;
   }

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -1,7 +1,9 @@
 import { ConcertLogEntity } from "../domain/concert-log";
 import type { ConcertLogRepository } from "../domain/concert-log";
-import { ConcertLogId } from "../domain/value-objects/ids";
+import { ConcertTitle } from "../domain/value-objects/concert-title";
+import { ConcertLogId, PieceId } from "../domain/value-objects/ids";
 import type { UserId } from "../domain/value-objects/ids";
+import { Venue } from "../domain/value-objects/venue";
 import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
 import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
 import { loadOwnedEntityOrNotFound } from "./helpers";
@@ -48,8 +50,32 @@ export class ConcertLogUsecase {
     userId: UserId,
   ): Promise<ConcertLog> {
     const current = await this.loadOwnedEntity(id, userId);
-    const updated = current.mergeUpdate(input);
-    const plain = updated.toPlain();
+    let next = current;
+    if (input.title !== undefined) {
+      next = next.rename(ConcertTitle.of(input.title));
+    }
+    if (input.venue !== undefined) {
+      next = next.relocate(Venue.of(input.venue));
+    }
+    if (input.concertDate !== undefined) {
+      next = next.reschedule(input.concertDate);
+    }
+    if (input.conductor !== undefined) {
+      next = next.assignConductor(input.conductor);
+    }
+    if (input.orchestra !== undefined) {
+      next = next.assignOrchestra(input.orchestra);
+    }
+    if (input.soloist !== undefined) {
+      next = next.assignSoloist(input.soloist);
+    }
+    if (input.pieceIds !== undefined) {
+      next = next.setProgram(input.pieceIds.map(PieceId.from));
+    }
+    const plain = next.toPlain();
+    if (next === current) {
+      return plain;
+    }
     await this.repo.saveWithOptimisticLock(plain, current.updatedAt);
     return plain;
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -339,7 +339,7 @@ classical-music-lake/
   → API Gateway + Cognito Authorizer
   → Lambda (update.ts)
   → 既存レコード取得 + userId 検証（不一致は 404）
-  → ConcertLogEntity.mergeUpdate(input) で新エンティティを生成
+  → ConcertLogEntity の意図メソッド (rename / relocate / reschedule / assignConductor / assignOrchestra / assignSoloist / setProgram) を入力フィールドに応じて呼び分ける
   → DynamoDBConcertLogRepository.saveWithOptimisticLock(plain, prevUpdatedAt)
     （競合時は 409 Conflict + "Concert log was updated by another request"）
   → 200 OK + 更新済みオブジェクト

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,7 +243,7 @@ classical-music-lake/
   → / へナビゲート
 ```
 
-### ユーザー登録〜メール確認〜自動ログイン
+### ユーザー登録～メール確認～自動ログイン
 
 ```text
 ブラウザ (/auth/user-register)
@@ -339,7 +339,7 @@ classical-music-lake/
   → API Gateway + Cognito Authorizer
   → Lambda (update.ts)
   → 既存レコード取得 + userId 検証（不一致は 404）
-  → ConcertLogEntity の意図メソッド (rename / relocate / reschedule / assignConductor / assignOrchestra / assignSoloist / setProgram) を入力フィールドに応じて呼び分ける
+  → ConcertLogEntity.revise(input) で訂正後のエンティティを生成（鑑賞記録のドメイン操作は「訂正・追記」の 1 種に集約）
   → DynamoDBConcertLogRepository.saveWithOptimisticLock(plain, prevUpdatedAt)
     （競合時は 409 Conflict + "Concert log was updated by another request"）
   → 200 OK + 更新済みオブジェクト

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -590,8 +590,8 @@ cd cdk && pnpm install && cdk bootstrap && cdk deploy
 - `equals(other: unknown)`: 「同じ具象クラス」かつ「同じ ID」のとき `true`。異なる派生クラス同士は `false`
 - 派生クラスの規約: `private constructor(props)` で `super(props)` を呼ぶ。`static create()` / `static reconstruct()` ファクトリは個別実装。`toPlain()` / `isOwnedBy()` は派生クラスで実装
 - 更新方法は派生クラスごとに 2 系統:
-  - **意図メソッド系**（`ConcertLogEntity`）: `rename` / `relocate` / `reschedule` / `assignConductor` / `assignOrchestra` / `assignSoloist` / `setProgram` のようにユビキタス言語を反映したメソッドを公開する。usecase 層が HTTP partial input を読んでフィールドの有無に応じてメソッドを呼び分ける
-  - **`mergeUpdate(input)` 系**（`ListeningLogEntity` / `ComposerEntity` / `PieceWorkEntity` / `PieceMovementEntity`）: `entity-helpers.ts:buildUpdateProps` を介して `Update*Input` をシャローマージする汎用更新メソッド。意図メソッド系への移行は段階的に進める（参照: 貧血ドメインモデル解消方針）
+  - **集約意図メソッド系**（`ConcertLogEntity`）: 鑑賞記録のドメイン操作は「過去に観測した事実の記録を訂正・追記する」という単一の意図に帰着する（コンサート運営者ではなく鑑賞者の語彙）。そのためフィールド単位の意図メソッドは生やさず、`revise(revision: ConcertLogRevision)` 1 メソッドに集約する。実装は内部で `entity-helpers.ts:buildUpdateProps` を呼ぶ
+  - **`mergeUpdate(input)` 系**（`ListeningLogEntity` / `ComposerEntity` / `PieceWorkEntity` / `PieceMovementEntity`）: `entity-helpers.ts:buildUpdateProps` を介して `Update*Input` をシャローマージする汎用更新メソッド。命名がドメイン語彙を反映していない貧血状態。意図メソッド化（`markAsFavorite` / `recordLifeSpan` 等）への移行は段階的に進める
 
 ### 8.4 読み取り専用集約（ListeningLogDetail）
 
@@ -599,7 +599,7 @@ cd cdk && pnpm install && cdk bootstrap && cdk deploy
 
 - `ListeningLogEntity` は `pieceId` のみを保持し、楽曲名・作曲家名は持たない（DDD の集約境界に従い、関連集約は ID で参照）
 - 派生値の解決責任は `ListeningLogDetail` に閉じる:
-  - `pieceTitle`: Work なら `piece.title`、Movement なら「親 Work title - 楽章 title」
+  - `pieceTitle`: Work なら `piece.title`、Movement なら「親 Work title - 楽章 title」に整形
   - `composerId` / `composerName`: Work なら自身の `composerId`、Movement なら親 Work から継承
 - ドメイン層は `repositories/` に依存しないため、必要な `Piece` / `Composer` は usecase 層が事前に取得して `ListeningLogDetail.from(log, piece, parentWork, composer)` に渡す
 - 一覧 API では同一 `pieceId` / 同一 `composerId` の重複取得を排除し、N+1 を抑制する（`ListeningLogUsecase.toDetailDtoList`）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -588,7 +588,10 @@ cd cdk && pnpm install && cdk bootstrap && cdk deploy
 - `protected readonly props: TProps`: 派生クラスの内部状態。`TProps extends EntityProps<TId> = { id: TId; createdAt: string; updatedAt: string }`
 - `get id(): TId` / `get createdAt(): string` / `get updatedAt(): string`: 共通アクセサ
 - `equals(other: unknown)`: 「同じ具象クラス」かつ「同じ ID」のとき `true`。異なる派生クラス同士は `false`
-- 派生クラスの規約: `private constructor(props)` で `super(props)` を呼ぶ。`static create()` / `static reconstruct()` ファクトリは個別実装。`toPlain()` / `isOwnedBy()` / `mergeUpdate()` は派生クラスで実装
+- 派生クラスの規約: `private constructor(props)` で `super(props)` を呼ぶ。`static create()` / `static reconstruct()` ファクトリは個別実装。`toPlain()` / `isOwnedBy()` は派生クラスで実装
+- 更新方法は派生クラスごとに 2 系統:
+  - **意図メソッド系**（`ConcertLogEntity`）: `rename` / `relocate` / `reschedule` / `assignConductor` / `assignOrchestra` / `assignSoloist` / `setProgram` のようにユビキタス言語を反映したメソッドを公開する。usecase 層が HTTP partial input を読んでフィールドの有無に応じてメソッドを呼び分ける
+  - **`mergeUpdate(input)` 系**（`ListeningLogEntity` / `ComposerEntity` / `PieceWorkEntity` / `PieceMovementEntity`）: `entity-helpers.ts:buildUpdateProps` を介して `Update*Input` をシャローマージする汎用更新メソッド。意図メソッド系への移行は段階的に進める（参照: 貧血ドメインモデル解消方針）
 
 ### 8.4 読み取り専用集約（ListeningLogDetail）
 


### PR DESCRIPTION
## 背景

PR #680 で `ConcertLog` の更新を集約経由のドメインパターンに揃えた。本 PR ではその上で、エンティティを **CRUD 用語ではなくユビキタス言語で語らせる** 段階へ進める。

ただし、当初の試案でフィールド単位の意図メソッド（`rename` / `relocate` / `reschedule` / `assignConductor` / …）を入れたところ、それが**コンサート運営者の語彙**になっており、このアプリの**鑑賞記録ドメイン**（鑑賞者の個人ノート）に合っていないことが判明（[INCEPTION_DECK.md](docs/INCEPTION_DECK.md) の「クラシック音楽の鑑賞体験を記録するWebアプリ」）。鑑賞者は「日程を組み直し」も「指揮者を任命」もしておらず、ただ過去に観測した事実を後から書き留めているだけ。

加えて `ConcertLog` のフィールド（タイトル・会場・日程・指揮者・オーケストラ・ソリスト・プログラム）はすべて**観測した事実の書き留め**で、ユーザー操作の意図は実質 1 種類「過去の記録を訂正・追記する」に帰着する。フィールド単位の意図メソッドは語彙の細分化で、ドメインの実態には合っていない。

そこでフィールド単位ではなく**集約意図メソッド `revise(revision)` 1 つ**に集約する。命名は鑑賞者の語彙（「鑑賞記録を訂正する」）を反映する。

## 変更内容

- **`ConcertLogEntity.revise(revision: ConcertLogRevision)` を追加**
  - 内部で `entity-helpers.ts:buildUpdateProps` を呼び、`Update*Input` をシャローマージ
  - 命名が「観測した事実の記録を後から書き直す」というドメイン操作を反映
- **`ConcertLogRevision` 型を追加**（実体は `UpdateConcertLogInput` と同一の型エイリアス。コードを読む人に「これは訂正内容」と伝えるための命名）
- **`ConcertLogEntity.mergeUpdate` を撤去**
- **`ConcertLogUsecase.update` を `revise` 経由に簡素化**: `load → revise → saveWithOptimisticLock` の最小パターン
- **`concert-log.test.ts` を `revise` ベースに刷新**: 単一/複数フィールド更新・id/createdAt 不変・pieceIds の配列・空配列・イミュータブル性を検証
- **`docs/SPEC.md` §8.3 / `docs/ARCHITECTURE.md`**: エンティティの更新方法を「集約意図メソッド系（ConcertLog）」と「`mergeUpdate` 系（ListeningLog / Composer / Piece）」の 2 系統として整理。「鑑賞者ではなくコンサート運営者の語彙にならないように」という設計意図も明記

## 互換性

API・HTTP 挙動は完全互換。Zod の `updateConcertLogSchema = createConcertLogSchema.partial()` で undefined キーが除去されるので、`revise` で受けたあとは `buildUpdateProps` のシャローマージで現行挙動を再現できる。空文字・空配列で上書きされる現在の挙動も維持。

## 設計上の判断（議論ログ）

PR 着手後に「`rename` / `relocate` / `reschedule` / `assignConductor` は鑑賞者ドメインで違和感がある」という指摘を受け、フィールド単位の意図メソッド 7 種を撤去して `revise` 1 つに集約する形へ舵を切った。コミット履歴に経緯が残っている。

ListeningLog（PR2 想定）の `markAsFavorite` / `rerate` / `rewriteMemo` のように**操作ごとに意図がはっきり違う**ケースは引き続きフィールド単位の意図メソッド化が有効。ConcertLog で `revise` に集約したのは「フィールド単位の操作意図に違いが無い」という個別判断であり、すべてのエンティティで集約意図メソッドにすべきという主張ではない。

## 残作業

- PR2: `ListeningLogEntity` に意図メソッド導入（`markAsFavorite` / `rerate` / `rewriteMemo` 等）
- PR4: `ComposerEntity` に意図メソッド導入（必要なら `LifeSpan` VO 化）
- PR5: 全エンティティから `mergeUpdate` が消えたら `entity-helpers.ts` を削除

## Test plan

- [x] `pnpm run test:backend`（740 件 green）
- [x] `pnpm run lint` / `pnpm run format:check`
- [x] pre-push フック（フロント 786 件 + バック 740 件 全 green）
- [ ] CI 上の deploy / E2E

https://claude.ai/code/session_01MqUEmhrff3xg2Yo4xF6o1R