### PR TITLE
chore: vitest EnvironmentTeardownError workaround の検証履歴を更新

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -13,7 +13,9 @@
  * TODO: vitest の上流修正が入ったらこのファイルごと削除する。
  *   - 上流 issue: https://github.com/vitest-dev/vitest/issues/9872
  *   - トラッキング: https://github.com/konabe/classical-music-lake/issues/574
- *   検証履歴: vitest 4.1.5 + @nuxt/test-utils 4.0.3 の組み合わせでも未解消（2026-04-29 時点）。
+ *   検証履歴:
+ *     - 2026-04-29: vitest 4.1.5 + @nuxt/test-utils 4.0.3 → 未解消
+ *     - 2026-05-11: vitest 4.1.5 + @nuxt/test-utils 4.0.3 → 未解消（786/786 pass、unhandled rejection 2 件で exit 1）
  */
 process.on("unhandledRejection", (reason: unknown) => {
   if (


### PR DESCRIPTION
## Summary

Issue #574 / #590 の現状を確認し、両者とも上流の修正待ちで解消できないことを確認した。

### Issue #574: vitest EnvironmentTeardownError workaround

検証手順（`vitest.setup.ts` を `setupFiles` から外して `pnpm run test:frontend` を実行）を実施。

- 結果: 786/786 tests passed だが unhandled rejection 2 件で exit code 1（前回 2026-04-29 と同症状）
- 上流 issue [vitest-dev/vitest#9872](https://github.com/vitest-dev/vitest/issues/9872) は引き続き pending triage
- 対応: workaround 維持。`vitest.setup.ts` のコメント内検証履歴に 2026-05-11 の再確認結果を追記

### Issue #590: @nuxtjs/storybook 復帰

- `@nuxtjs/storybook` の latest タグはまだ `9.0.1`（`storybook: ~9.0.5` 要求）
- 本プロジェクトは `storybook@10.3.5` のため非互換のまま
- Storybook 10 対応版は nightly（`9.1.0-...`、`storybook: ~10.0.2`）のみで stable 未リリース
- 上流 PR [nuxt-modules/storybook#994](https://github.com/nuxt-modules/storybook/pull/994) の状況は変わらず
- 対応: 暫定対応（`nuxt.config.ts` から除外）のまま維持。コード変更不要

## Test plan

- [x] `pnpm run test:frontend` 全件 pass（pre-push フックで実行済み）
- [x] `pnpm run test:backend` 全件 pass（pre-push フックで実行済み）
- [x] `pnpm run format:check` pass（pre-push フックで実行済み）

refs #574 #590

---
_Generated by [Claude Code](https://claude.ai/code/session_01VUuNwzn6a2twDRV7gyfzZS)_