### PR TITLE
refactor(backend): 楽曲マスタの編集を editMetadata + updateVideos に分解する

### DIFF
--- a/backend/src/domain/piece.test.ts
+++ b/backend/src/domain/piece.test.ts
@@ -50,16 +50,95 @@ describe("PieceWorkEntity", () => {
     expect(plain.updatedAt).toBe(data.updatedAt);
   });
 
-  it("mergeUpdate で title を更新できる", () => {
-    const entity = PieceWorkEntity.create(makeWorkInput());
-    const updated = entity.mergeUpdate({ kind: "work", title: "交響曲第5番" });
-    expect(updated.toPlain().title).toBe("交響曲第5番");
+  describe("editMetadata", () => {
+    it("title を訂正できる", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput());
+      const updated = entity.editMetadata({ title: "交響曲第5番" });
+      expect(updated.toPlain().title).toBe("交響曲第5番");
+    });
+
+    it("era に空文字を渡すとフィールドが削除される", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput({ era: "古典派" }));
+      const updated = entity.editMetadata({ era: "" });
+      expect(updated.toPlain().era).toBeUndefined();
+    });
+
+    it("genre / formation / region も空文字でクリアできる", () => {
+      const entity = PieceWorkEntity.create(
+        makeWorkInput({ genre: "交響曲", formation: "管弦楽", region: "ドイツ・オーストリア" }),
+      );
+      const updated = entity.editMetadata({ genre: "", formation: "", region: "" });
+      const plain = updated.toPlain();
+      expect(plain.genre).toBeUndefined();
+      expect(plain.formation).toBeUndefined();
+      expect(plain.region).toBeUndefined();
+    });
+
+    it("videoUrls は editMetadata の責務外（変更されない）", () => {
+      const entity = PieceWorkEntity.create(
+        makeWorkInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.editMetadata({ title: "別名" });
+      expect(updated.toPlain().videoUrls).toEqual(["https://example.com/v"]);
+    });
   });
 
-  it("mergeUpdate で era に空文字を渡すとフィールドが削除される", () => {
-    const entity = PieceWorkEntity.create(makeWorkInput({ era: "古典派" }));
-    const updated = entity.mergeUpdate({ kind: "work", era: "" });
-    expect(updated.toPlain().era).toBeUndefined();
+  describe("updateVideos", () => {
+    it("URL 配列で動画を貼り替える", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput());
+      const updated = entity.updateVideos(["https://example.com/a", "https://example.com/b"]);
+      expect(updated.toPlain().videoUrls).toEqual([
+        "https://example.com/a",
+        "https://example.com/b",
+      ]);
+    });
+
+    it("空配列を渡すと videoUrls フィールドが消える", () => {
+      const entity = PieceWorkEntity.create(
+        makeWorkInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.updateVideos([]);
+      expect(updated.toPlain().videoUrls).toBeUndefined();
+    });
+
+    it("undefined を渡すと videoUrls フィールドが消える", () => {
+      const entity = PieceWorkEntity.create(
+        makeWorkInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.updateVideos(undefined);
+      expect(updated.toPlain().videoUrls).toBeUndefined();
+    });
+  });
+
+  describe("applyRevisions", () => {
+    it("editMetadata と updateVideos の両方へ dispatch する", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput());
+      const next = PieceWorkEntity.applyRevisions(entity, {
+        kind: "work",
+        title: "別名",
+        era: "ロマン派",
+        videoUrls: ["https://example.com/a"],
+      }).toPlain();
+      expect(next.title).toBe("別名");
+      expect(next.era).toBe("ロマン派");
+      expect(next.videoUrls).toEqual(["https://example.com/a"]);
+    });
+
+    it("videoUrls だけが渡された場合は editMetadata に行かず updateVideos だけ走る", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput({ title: "保持" }));
+      const next = PieceWorkEntity.applyRevisions(entity, {
+        kind: "work",
+        videoUrls: ["https://example.com/only"],
+      }).toPlain();
+      expect(next.title).toBe("保持");
+      expect(next.videoUrls).toEqual(["https://example.com/only"]);
+    });
+
+    it("空の input（kind のみ）なら entity をそのまま返す", () => {
+      const entity = PieceWorkEntity.create(makeWorkInput());
+      const next = PieceWorkEntity.applyRevisions(entity, { kind: "work" });
+      expect(next).toBe(entity);
+    });
   });
 });
 
@@ -90,18 +169,69 @@ describe("PieceMovementEntity", () => {
     expect(plain.title).toBe("第3楽章");
   });
 
-  it("mergeUpdate で title を更新できる", () => {
-    const entity = PieceMovementEntity.create(makeMovementInput());
-    const updated = entity.mergeUpdate({ kind: "movement", title: "Allegro" });
-    expect(updated.toPlain().title).toBe("Allegro");
+  describe("editMetadata", () => {
+    it("title を訂正できる", () => {
+      const entity = PieceMovementEntity.create(makeMovementInput());
+      const updated = entity.editMetadata({ title: "Allegro" });
+      expect(updated.toPlain().title).toBe("Allegro");
+    });
+
+    it("index を更新できる", () => {
+      const entity = PieceMovementEntity.create(makeMovementInput({ index: 0 }));
+      const updated = entity.editMetadata({ index: 3 });
+      expect(updated.toPlain().index).toBe(3);
+    });
+
+    it("videoUrls は editMetadata の責務外（変更されない）", () => {
+      const entity = PieceMovementEntity.create(
+        makeMovementInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.editMetadata({ title: "別名" });
+      expect(updated.toPlain().videoUrls).toEqual(["https://example.com/v"]);
+    });
   });
 
-  it("mergeUpdate で videoUrls を空配列で送るとフィールドが削除される", () => {
-    const entity = PieceMovementEntity.create(
-      makeMovementInput({ videoUrls: ["https://example.com/v"] }),
-    );
-    const updated = entity.mergeUpdate({ kind: "movement", videoUrls: [] });
-    expect(updated.toPlain().videoUrls).toBeUndefined();
+  describe("updateVideos", () => {
+    it("URL 配列で動画を貼り替える", () => {
+      const entity = PieceMovementEntity.create(makeMovementInput());
+      const updated = entity.updateVideos(["https://example.com/m"]);
+      expect(updated.toPlain().videoUrls).toEqual(["https://example.com/m"]);
+    });
+
+    it("空配列を渡すと videoUrls フィールドが消える", () => {
+      const entity = PieceMovementEntity.create(
+        makeMovementInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.updateVideos([]);
+      expect(updated.toPlain().videoUrls).toBeUndefined();
+    });
+
+    it("undefined を渡すと videoUrls フィールドが消える", () => {
+      const entity = PieceMovementEntity.create(
+        makeMovementInput({ videoUrls: ["https://example.com/v"] }),
+      );
+      const updated = entity.updateVideos(undefined);
+      expect(updated.toPlain().videoUrls).toBeUndefined();
+    });
+  });
+
+  describe("applyRevisions", () => {
+    it("editMetadata と updateVideos の両方へ dispatch する", () => {
+      const entity = PieceMovementEntity.create(makeMovementInput());
+      const next = PieceMovementEntity.applyRevisions(entity, {
+        kind: "movement",
+        title: "Allegro",
+        videoUrls: ["https://example.com/m"],
+      }).toPlain();
+      expect(next.title).toBe("Allegro");
+      expect(next.videoUrls).toEqual(["https://example.com/m"]);
+    });
+
+    it("空の input（kind のみ）なら entity をそのまま返す", () => {
+      const entity = PieceMovementEntity.create(makeMovementInput());
+      const next = PieceMovementEntity.applyRevisions(entity, { kind: "movement" });
+      expect(next).toBe(entity);
+    });
   });
 
   it("index に範囲外の値（-1）を渡すと例外", () => {

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -131,6 +131,29 @@ export abstract class PieceComponent<
   abstract toPlain(): Piece;
 
   /**
+   * 派生クラスが自身の具象型でインスタンスを再生成するためのフック。
+   * `updateVideos` 等、props を貼り替えるだけの操作を基底クラスで共通実装するために使う。
+   */
+  protected abstract cloneWithProps(props: TProps): this;
+
+  /**
+   * 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。
+   * Work / Movement で実装が同一なので基底クラスに集約する。
+   */
+  updateVideos(videoUrls: readonly string[] | undefined): this {
+    const now = new Date().toISOString();
+    if (videoUrls === undefined || videoUrls.length === 0) {
+      const { videoUrls: _omit, ...rest } = this.props;
+      return this.cloneWithProps({ ...(rest as TProps), updatedAt: now });
+    }
+    return this.cloneWithProps({
+      ...this.props,
+      videoUrls: videoUrls.map((u) => Url.of(u)),
+      updatedAt: now,
+    });
+  }
+
+  /**
    * `CreatePieceInput` から適切な Entity を生成するファクトリ。
    * 判別共用体の `kind` で分岐する。`default` 節は `never` 型で網羅性をコンパイル時検証し、
    * 想定外の `kind` が渡された場合は例外を投げる。
@@ -195,6 +218,10 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
     return "work";
   }
 
+  protected override cloneWithProps(props: PieceWorkProps): this {
+    return new PieceWorkEntity(props) as this;
+  }
+
   static create(input: CreateWorkInput): PieceWorkEntity {
     const now = new Date().toISOString();
     return new PieceWorkEntity({
@@ -228,23 +255,10 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
     return PieceWorkEntity.reconstruct(merged);
   }
 
-  /** 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。 */
-  updateVideos(videoUrls: readonly string[] | undefined): PieceWorkEntity {
-    const now = new Date().toISOString();
-    if (videoUrls === undefined || videoUrls.length === 0) {
-      const { videoUrls: _omit, ...rest } = this.props;
-      return new PieceWorkEntity({ ...rest, updatedAt: now });
-    }
-    return new PieceWorkEntity({
-      ...this.props,
-      videoUrls: videoUrls.map((u) => Url.of(u)),
-      updatedAt: now,
-    });
-  }
-
   /**
    * `UpdateWorkInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
    * 動画 URL だけが意図として独立しており、それ以外は編集業務に集約する。
+   * `updateVideos` は基底 `PieceComponent` の共通実装を使う。
    */
   static applyRevisions(entity: PieceWorkEntity, input: UpdateWorkInput): PieceWorkEntity {
     let next = entity;
@@ -278,6 +292,10 @@ export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
 
   override get kind(): "movement" {
     return "movement";
+  }
+
+  protected override cloneWithProps(props: PieceMovementProps): this {
+    return new PieceMovementEntity(props) as this;
   }
 
   get parentId(): PieceId {
@@ -322,22 +340,9 @@ export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
     return PieceMovementEntity.reconstruct(merged);
   }
 
-  /** 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。 */
-  updateVideos(videoUrls: readonly string[] | undefined): PieceMovementEntity {
-    const now = new Date().toISOString();
-    if (videoUrls === undefined || videoUrls.length === 0) {
-      const { videoUrls: _omit, ...rest } = this.props;
-      return new PieceMovementEntity({ ...rest, updatedAt: now });
-    }
-    return new PieceMovementEntity({
-      ...this.props,
-      videoUrls: videoUrls.map((u) => Url.of(u)),
-      updatedAt: now,
-    });
-  }
-
   /**
    * `UpdateMovementInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
+   * `updateVideos` は基底 `PieceComponent` の共通実装を使う。
    */
   static applyRevisions(
     entity: PieceMovementEntity,

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -20,7 +20,8 @@ import { MovementIndex } from "./value-objects/movement-index";
 import { PieceTitle } from "./value-objects/piece-title";
 import { Url } from "./value-objects/url";
 
-const WORK_METADATA_CLEARABLE_FIELDS = ["genre", "era", "formation", "region"] as const;
+const WORK_METADATA_CLEARABLE_FIELDS: readonly string[] = ["genre", "era", "formation", "region"];
+const MOVEMENT_METADATA_CLEARABLE_FIELDS: readonly string[] = [];
 
 /**
  * 楽曲（Work）のメタデータを編集する差分。
@@ -111,12 +112,17 @@ type PieceMovementProps = EntityProps<PieceId> & {
  * - `kind` は具象クラスで literal 型として実装する（判別共用体のタグ）。
  * - `title` / `videoUrls` は両方が共通で持つ。
  * - `toPlain()` は派生クラスで実装する（戻り値の判別共用体型を保つため）。
+ * - 編集系メソッド（`updateVideos` / `editMetadata` / `applyRevisions`）の実装本体は基底に集約し、
+ *   具象クラスは差分点（`clearableMetadataFields` / `cloneWithProps` / `reconstructFromPlain`）
+ *   だけを宣言する。
  * - `kind` に基づいて Work / Movement を振り分けるファクトリ（`create` / `reconstruct` /
  *   `applyUpdate`）を static メソッドとして集約する。トップレベル関数を増やさず、
  *   コンポジット階層のエントリポイントを Component 自身に閉じ込める。
  */
 export abstract class PieceComponent<
   TProps extends EntityProps<PieceId> & { title: PieceTitle; videoUrls?: Url[] },
+  TPlain extends Piece,
+  TUpdateInput extends UpdatePieceInput,
 > extends Entity<PieceId, TProps> {
   abstract get kind(): "work" | "movement";
 
@@ -128,13 +134,26 @@ export abstract class PieceComponent<
     return this.props.videoUrls;
   }
 
-  abstract toPlain(): Piece;
+  abstract toPlain(): TPlain;
 
   /**
    * 派生クラスが自身の具象型でインスタンスを再生成するためのフック。
    * `updateVideos` 等、props を貼り替えるだけの操作を基底クラスで共通実装するために使う。
    */
   protected abstract cloneWithProps(props: TProps): this;
+
+  /**
+   * `editMetadata` で「空文字 / null / 空配列」がクリア指示として扱われるフィールド集合。
+   * 派生クラスごとに API 仕様（空文字で削除可能なフィールド）に合わせて宣言する。
+   */
+  protected abstract readonly clearableMetadataFields: readonly string[];
+
+  /**
+   * plain DTO から自身の具象型で Entity を再構築するフック。
+   * `editMetadata` 内で `buildUpdateProps` がマージした plain を派生クラスの
+   * `reconstruct` に流し込むために使う。
+   */
+  protected abstract reconstructFromPlain(plain: TPlain): this;
 
   /**
    * 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。
@@ -151,6 +170,38 @@ export abstract class PieceComponent<
       videoUrls: videoUrls.map((u) => Url.of(u)),
       updatedAt: now,
     });
+  }
+
+  /**
+   * メタデータを編集する。Work / Movement 共通の編集処理を基底に集約。
+   * 差分は `clearableMetadataFields`（派生クラスで宣言）のみ。
+   * 動画 URL はここでは扱わず `updateVideos` を使う。
+   */
+  editMetadata(revision: Omit<TUpdateInput, "kind" | "videoUrls">): this {
+    const merged = buildUpdateProps(this.toPlain(), revision, this.clearableMetadataFields);
+    return this.reconstructFromPlain(merged as TPlain);
+  }
+
+  /**
+   * `UpdateXxxInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
+   * 各派生クラスの `static applyRevisions(entity, input)` は本メソッドへの薄いラッパーとして
+   * 残し、usecase 層が呼ぶ static API を Composer / ListeningLog と一貫させる。
+   */
+  applyRevisions(input: TUpdateInput): this {
+    const { kind: _kind, videoUrls, ...metadata } = input;
+    const revision = metadata as Omit<TUpdateInput, "kind" | "videoUrls">;
+    const hasMetadata = Object.keys(revision).length > 0;
+
+    if (hasMetadata && videoUrls !== undefined) {
+      return this.editMetadata(revision).updateVideos(videoUrls);
+    }
+    if (hasMetadata) {
+      return this.editMetadata(revision);
+    }
+    if (videoUrls !== undefined) {
+      return this.updateVideos(videoUrls);
+    }
+    return this;
   }
 
   /**
@@ -209,7 +260,9 @@ export abstract class PieceComponent<
   }
 }
 
-export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
+export class PieceWorkEntity extends PieceComponent<PieceWorkProps, PieceWork, UpdateWorkInput> {
+  protected readonly clearableMetadataFields = WORK_METADATA_CLEARABLE_FIELDS;
+
   private constructor(props: PieceWorkProps) {
     super(props);
   }
@@ -220,6 +273,10 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
 
   protected override cloneWithProps(props: PieceWorkProps): this {
     return new PieceWorkEntity(props) as this;
+  }
+
+  protected override reconstructFromPlain(plain: PieceWork): this {
+    return PieceWorkEntity.reconstruct(plain) as this;
   }
 
   static create(input: CreateWorkInput): PieceWorkEntity {
@@ -246,31 +303,12 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
   }
 
   /**
-   * Work のメタデータを編集する。曲名・作曲家・カテゴリ系の訂正を 1 つの編集操作として扱う。
-   * `genre` / `era` / `formation` / `region` は空文字を渡すと当該フィールドが削除される
-   * （API 仕様と一致）。動画 URL はここでは扱わず `updateVideos` を使う。
-   */
-  editMetadata(revision: PieceWorkMetadataRevision): PieceWorkEntity {
-    const merged = buildUpdateProps(this.toPlain(), revision, WORK_METADATA_CLEARABLE_FIELDS);
-    return PieceWorkEntity.reconstruct(merged);
-  }
-
-  /**
-   * `UpdateWorkInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
-   * 動画 URL だけが意図として独立しており、それ以外は編集業務に集約する。
-   * `updateVideos` は基底 `PieceComponent` の共通実装を使う。
+   * usecase 層・テストが使う static API。`ComposerEntity` / `ListeningLogEntity` と
+   * 一貫した `XxxEntity.applyRevisions(current, input)` 形式を保つための薄いラッパー。
+   * 実装本体は基底クラスの instance method に集約している。
    */
   static applyRevisions(entity: PieceWorkEntity, input: UpdateWorkInput): PieceWorkEntity {
-    let next = entity;
-    const { kind: _kind, videoUrls, ...metadata } = input;
-
-    if (Object.keys(metadata).length > 0) {
-      next = next.editMetadata(metadata);
-    }
-    if (videoUrls !== undefined) {
-      next = next.updateVideos(videoUrls);
-    }
-    return next;
+    return entity.applyRevisions(input);
   }
 
   override toPlain(): PieceWork {
@@ -285,7 +323,13 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
   }
 }
 
-export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
+export class PieceMovementEntity extends PieceComponent<
+  PieceMovementProps,
+  PieceMovement,
+  UpdateMovementInput
+> {
+  protected readonly clearableMetadataFields = MOVEMENT_METADATA_CLEARABLE_FIELDS;
+
   private constructor(props: PieceMovementProps) {
     super(props);
   }
@@ -296,6 +340,10 @@ export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
 
   protected override cloneWithProps(props: PieceMovementProps): this {
     return new PieceMovementEntity(props) as this;
+  }
+
+  protected override reconstructFromPlain(plain: PieceMovement): this {
+    return PieceMovementEntity.reconstruct(plain) as this;
   }
 
   get parentId(): PieceId {
@@ -332,32 +380,13 @@ export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
   }
 
   /**
-   * Movement のメタデータを編集する。楽章名・親 Work 参照・演奏順 index の訂正を
-   * 1 つの編集操作として扱う。動画 URL はここでは扱わず `updateVideos` を使う。
-   */
-  editMetadata(revision: PieceMovementMetadataRevision): PieceMovementEntity {
-    const merged = buildUpdateProps(this.toPlain(), revision, []);
-    return PieceMovementEntity.reconstruct(merged);
-  }
-
-  /**
-   * `UpdateMovementInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
-   * `updateVideos` は基底 `PieceComponent` の共通実装を使う。
+   * usecase 層・テストが使う static API。基底クラスの instance method への薄いラッパー。
    */
   static applyRevisions(
     entity: PieceMovementEntity,
     input: UpdateMovementInput,
   ): PieceMovementEntity {
-    let next = entity;
-    const { kind: _kind, videoUrls, ...metadata } = input;
-
-    if (Object.keys(metadata).length > 0) {
-      next = next.editMetadata(metadata);
-    }
-    if (videoUrls !== undefined) {
-      next = next.updateVideos(videoUrls);
-    }
-    return next;
+    return entity.applyRevisions(input);
   }
 
   override toPlain(): PieceMovement {

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -20,8 +20,23 @@ import { MovementIndex } from "./value-objects/movement-index";
 import { PieceTitle } from "./value-objects/piece-title";
 import { Url } from "./value-objects/url";
 
-const WORK_CLEARABLE_FIELDS = ["videoUrls", "genre", "era", "formation", "region"] as const;
-const MOVEMENT_CLEARABLE_FIELDS = ["videoUrls"] as const;
+const WORK_METADATA_CLEARABLE_FIELDS = ["genre", "era", "formation", "region"] as const;
+
+/**
+ * 楽曲（Work）のメタデータを編集する差分。
+ * 曲名・作曲家・カテゴリ系（genre / era / formation / region）の訂正は
+ * 「マスタ管理者がメタデータを編集する」という単一の意図に帰着するため、
+ * フィールドごとに意図メソッドを生やさず 1 つの `editMetadata` に集約する。
+ * 動画 URL は外部リソース参照を貼り替える独立した意図なので、ここには含めない。
+ */
+export type PieceWorkMetadataRevision = Omit<UpdateWorkInput, "kind" | "videoUrls">;
+
+/**
+ * 楽章（Movement）のメタデータを編集する差分。
+ * 楽章名・親 Work 参照・演奏順 index の訂正は単一の編集意図に集約する。
+ * 動画 URL は外部リソース参照なので別メソッドで扱う。
+ */
+export type PieceMovementMetadataRevision = Omit<UpdateMovementInput, "kind" | "videoUrls">;
 
 /**
  * リポジトリ I/F。Composite 構造に合わせて root（Work）操作と子（Movement）操作を明確に分ける。
@@ -160,10 +175,10 @@ export abstract class PieceComponent<
     input: UpdatePieceInput,
   ): PieceWorkEntity | PieceMovementEntity {
     if (current instanceof PieceWorkEntity && input.kind === "work") {
-      return current.mergeUpdate(input);
+      return PieceWorkEntity.applyRevisions(current, input);
     }
     if (current instanceof PieceMovementEntity && input.kind === "movement") {
-      return current.mergeUpdate(input);
+      return PieceMovementEntity.applyRevisions(current, input);
     }
     throw new TypeError(
       `Piece kind mismatch: cannot update ${current.kind} with input of kind=${input.kind}`,
@@ -203,10 +218,45 @@ export class PieceWorkEntity extends PieceComponent<PieceWorkProps> {
     });
   }
 
-  mergeUpdate(input: UpdateWorkInput): PieceWorkEntity {
-    const { kind: _kind, ...rest } = input;
-    const merged = buildUpdateProps(this.toPlain(), rest, WORK_CLEARABLE_FIELDS);
+  /**
+   * Work のメタデータを編集する。曲名・作曲家・カテゴリ系の訂正を 1 つの編集操作として扱う。
+   * `genre` / `era` / `formation` / `region` は空文字を渡すと当該フィールドが削除される
+   * （API 仕様と一致）。動画 URL はここでは扱わず `updateVideos` を使う。
+   */
+  editMetadata(revision: PieceWorkMetadataRevision): PieceWorkEntity {
+    const merged = buildUpdateProps(this.toPlain(), revision, WORK_METADATA_CLEARABLE_FIELDS);
     return PieceWorkEntity.reconstruct(merged);
+  }
+
+  /** 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。 */
+  updateVideos(videoUrls: readonly string[] | undefined): PieceWorkEntity {
+    const now = new Date().toISOString();
+    if (videoUrls === undefined || videoUrls.length === 0) {
+      const { videoUrls: _omit, ...rest } = this.props;
+      return new PieceWorkEntity({ ...rest, updatedAt: now });
+    }
+    return new PieceWorkEntity({
+      ...this.props,
+      videoUrls: videoUrls.map((u) => Url.of(u)),
+      updatedAt: now,
+    });
+  }
+
+  /**
+   * `UpdateWorkInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
+   * 動画 URL だけが意図として独立しており、それ以外は編集業務に集約する。
+   */
+  static applyRevisions(entity: PieceWorkEntity, input: UpdateWorkInput): PieceWorkEntity {
+    let next = entity;
+    const { kind: _kind, videoUrls, ...metadata } = input;
+
+    if (Object.keys(metadata).length > 0) {
+      next = next.editMetadata(metadata);
+    }
+    if (videoUrls !== undefined) {
+      next = next.updateVideos(videoUrls);
+    }
+    return next;
   }
 
   override toPlain(): PieceWork {
@@ -263,10 +313,46 @@ export class PieceMovementEntity extends PieceComponent<PieceMovementProps> {
     });
   }
 
-  mergeUpdate(input: UpdateMovementInput): PieceMovementEntity {
-    const { kind: _kind, ...rest } = input;
-    const merged = buildUpdateProps(this.toPlain(), rest, MOVEMENT_CLEARABLE_FIELDS);
+  /**
+   * Movement のメタデータを編集する。楽章名・親 Work 参照・演奏順 index の訂正を
+   * 1 つの編集操作として扱う。動画 URL はここでは扱わず `updateVideos` を使う。
+   */
+  editMetadata(revision: PieceMovementMetadataRevision): PieceMovementEntity {
+    const merged = buildUpdateProps(this.toPlain(), revision, []);
     return PieceMovementEntity.reconstruct(merged);
+  }
+
+  /** 動画 URL の集合を貼り替える。`undefined` または空配列で動画を取り外す。 */
+  updateVideos(videoUrls: readonly string[] | undefined): PieceMovementEntity {
+    const now = new Date().toISOString();
+    if (videoUrls === undefined || videoUrls.length === 0) {
+      const { videoUrls: _omit, ...rest } = this.props;
+      return new PieceMovementEntity({ ...rest, updatedAt: now });
+    }
+    return new PieceMovementEntity({
+      ...this.props,
+      videoUrls: videoUrls.map((u) => Url.of(u)),
+      updatedAt: now,
+    });
+  }
+
+  /**
+   * `UpdateMovementInput` を `editMetadata` と `updateVideos` の 2 系統に dispatch する。
+   */
+  static applyRevisions(
+    entity: PieceMovementEntity,
+    input: UpdateMovementInput,
+  ): PieceMovementEntity {
+    let next = entity;
+    const { kind: _kind, videoUrls, ...metadata } = input;
+
+    if (Object.keys(metadata).length > 0) {
+      next = next.editMetadata(metadata);
+    }
+    if (videoUrls !== undefined) {
+      next = next.updateVideos(videoUrls);
+    }
+    return next;
   }
 
   override toPlain(): PieceMovement {

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -68,7 +68,7 @@ export class WorkUsecase {
   async update(id: PieceId, input: UpdateWorkInput): Promise<PieceWork> {
     const current = await findByIdOrNotFound((id) => this.repo.findRootById(id), id, ENTITY_NAME);
     const entity = PieceWorkEntity.reconstruct(current);
-    const updated = entity.mergeUpdate(input);
+    const updated = PieceWorkEntity.applyRevisions(entity, input);
     const plain = updated.toPlain();
     await this.repo.saveWorkWithOptimisticLock(plain, current.updatedAt);
     return plain;
@@ -106,7 +106,7 @@ export class MovementUsecase {
   async update(id: PieceId, input: UpdateMovementInput): Promise<PieceMovement> {
     const current = await this.get(id);
     const entity = PieceMovementEntity.reconstruct(current);
-    const updated = entity.mergeUpdate(input);
+    const updated = PieceMovementEntity.applyRevisions(entity, input);
     const plain = updated.toPlain();
     await this.repo.saveMovementWithOptimisticLock(plain, current.updatedAt);
     return plain;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -480,12 +480,20 @@ classical-music-lake/
 - **Piece 削除時のガード**: 上記の `PieceUsecase.delete` の参照ガードと組み合わせて dangling reference を防ぐ
 - **個別意図メソッド**: 更新フローは `markAsFavorite()` / `unmarkAsFavorite()` / `rerate(rating)` / `rewriteMemo(memo)` / `correctListenedAt(listenedAt)` / `relinkPiece(pieceId)` の 6 種に分解。`Update*Input` の partial を意図メソッドへ dispatch する責務はエンティティ側の static `applyRevisions(entity, input)` に閉じ、`ListeningLogUsecase.update` は `ListeningLogEntity.applyRevisions(current, input)` を呼ぶだけ。汎用 `mergeUpdate` は持たない（フィールドごとに鑑賞者ドメインの意図がはっきり違うため、ConcertLog の `revise` 集約とは別パターンを採る）
 
-### Composer 集約の個別意図メソッド (2026-05)
+### Composer / Piece 集約のハイブリッド意図メソッド (2026-05)
 
-`ComposerEntity` も `ListeningLogEntity` と同じ「個別意図メソッド系」に揃え、汎用 `mergeUpdate` を撤去した。
+マスタ系エンティティ（`ComposerEntity` / `PieceWorkEntity` / `PieceMovementEntity`）は「マスタ情報の編集」と「外部リソース参照（画像 / 動画）の貼り替え」の 2 つのドメイン操作に分かれる。前者はマスタ管理者が事実を訂正・追記する単一の編集業務として集約意図メソッドに、後者は外部リソース参照を貼り替える独立した操作として単独メソッドに分ける。汎用 `mergeUpdate` はいずれも撤去済み。
 
-- **意図メソッド 5 種**: `rename(name)` / `reclassifyEra(era)` / `reclassifyRegion(region)` / `updateImage(imageUrl)` / `recordLifeSpan(birthYear, deathYear)`
-- **クリア表現の閉じ込め**: API 仕様の「空文字でフィールド削除」（`era` / `region` / `imageUrl`）「null でフィールド削除」（`birthYear` / `deathYear`）はドメイン層には漏らさない。`ComposerEntity.applyRevisions(entity, input)` が API 入力を読み替え、意図メソッドの引数（`undefined` = 削除）に正規化してから dispatch する
-- **`recordLifeSpan` の二項引数**: 生年と没年は鑑賞者にとってもマスタ管理者にとっても 1 セットで扱う情報のため、`recordBirthYear` / `recordDeathYear` には分けず単一メソッドに集約する。片方だけ更新したい場合はもう片方に `undefined` を渡す。`null` を渡したフィールドだけが個別に削除される
-- **`touched` ヘルパー**: 「diff を適用しつつクリア対象キーを削除する」プライベートヘルパーを `ComposerEntity` 内に閉じる。`entity-helpers.ts:buildUpdateProps` への依存は `ComposerEntity` 側からは消える（`Piece*Entity` がまだ使用中なのでヘルパー自体は残る）
-- **`ComposerUsecase.update`**: `ComposerEntity.applyRevisions(current, input)` を呼ぶだけ。usecase 層には partial 仕様の解釈ロジックを持たない
+- **`ComposerEntity`**
+  - `editProfile(revision: ComposerProfileRevision)`: 名前・時代区分・地域・生没年の編集を 1 メソッドに集約。`era` / `region` は空文字、`birthYear` / `deathYear` は `null` で当該フィールド削除
+  - `updateImage(imageUrl: string | undefined)`: 肖像画像 URL を貼り替え／取り外す
+- **`PieceWorkEntity`**
+  - `editMetadata(revision: PieceWorkMetadataRevision)`: 曲名・作曲家参照・カテゴリ系（`genre` / `era` / `formation` / `region`）の編集を集約。カテゴリ系は空文字でフィールド削除
+  - `updateVideos(videoUrls: readonly string[] | undefined)`: 動画 URL 集合を貼り替え。`undefined` または空配列で取り外し
+- **`PieceMovementEntity`**
+  - `editMetadata(revision: PieceMovementMetadataRevision)`: 楽章名・親 Work 参照・演奏順 `index` の編集を集約
+  - `updateVideos(videoUrls)`: Work と同じ動画 URL 貼り替えメソッド
+- **`applyRevisions(entity, input)`**: API 入力（`UpdateXxxInput`）を編集業務側と外部リソース側に分割し、`editProfile`／`editMetadata` と `updateImage`／`updateVideos` にそれぞれ dispatch する。API 仕様の「空文字でクリア」もここで `undefined` 等に正規化し、ドメイン層には漏らさない
+- **`*Revision` 型**: `Omit<UpdateComposerInput, "imageUrl">` / `Omit<UpdateWorkInput, "kind" | "videoUrls">` / `Omit<UpdateMovementInput, "kind" | "videoUrls">` として「編集業務」の語彙を型で表現
+- **usecase 層の役割**: `ComposerUsecase.update` / `WorkUsecase.update` / `MovementUsecase.update` は `XxxEntity.applyRevisions(current, input)` を呼ぶだけ。partial 仕様の解釈ロジックを持たない
+- **`PieceComponent.applyUpdate`**: ファサードは kind を判別して `PieceWorkEntity.applyRevisions` / `PieceMovementEntity.applyRevisions` に dispatch する（Work ↔ Movement の昇格・降格はサポートしない）

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -589,13 +589,15 @@ cd cdk && pnpm install && cdk bootstrap && cdk deploy
 - `get id(): TId` / `get createdAt(): string` / `get updatedAt(): string`: 共通アクセサ
 - `equals(other: unknown)`: 「同じ具象クラス」かつ「同じ ID」のとき `true`。異なる派生クラス同士は `false`
 - 派生クラスの規約: `private constructor(props)` で `super(props)` を呼ぶ。`static create()` / `static reconstruct()` ファクトリは個別実装。`toPlain()` / `isOwnedBy()` は派生クラスで実装
-- 更新方法は派生クラスごとに 3 系統:
+- 更新方法は派生クラスごとに 3 系統。**汎用 `mergeUpdate` は全エンティティで撤去済み**で、`entity-helpers.ts:buildUpdateProps` は各エンティティの集約意図メソッド内部から呼び出す形でのみ残る。
   - **集約意図メソッド系**（`ConcertLogEntity`）: 鑑賞記録のドメイン操作は「過去に観測した事実の記録を訂正・追記する」という単一の意図に帰着する（コンサート運営者ではなく鑑賞者の語彙）。そのためフィールド単位の意図メソッドは生やさず、`revise(revision: ConcertLogRevision)` 1 メソッドに集約する。実装は内部で `entity-helpers.ts:buildUpdateProps` を呼ぶ
-  - **個別意図メソッド系**（`ListeningLogEntity` / `ComposerEntity`）: フィールドごとにドメインの意図がはっきり違うため、`Update*Input` をそのまま受ける汎用 `mergeUpdate` は持たず、フィールド単位の意図メソッドを生やす。
-    - `ListeningLogEntity`: `markAsFavorite()` / `unmarkAsFavorite()` / `rerate(rating)` / `rewriteMemo(memo)` / `correctListenedAt(listenedAt)` / `relinkPiece(pieceId)`
-    - `ComposerEntity`: `rename(name)` / `reclassifyEra(era)` / `reclassifyRegion(region)` / `updateImage(imageUrl)` / `recordLifeSpan(birthYear, deathYear)`。`reclassify*` / `updateImage` は `undefined` で当該フィールドを削除し、`recordLifeSpan` は `null` で個別に削除する（API 仕様の「空文字 / null でフィールドを削除」は `applyRevisions` 側で意図メソッドの引数に正規化する）
-    - `Update*Input` の partial を意図メソッドへ dispatch する責務はエンティティ側の static `applyRevisions(entity, input)` に閉じ、usecase は `XxxEntity.applyRevisions(current, input)` を呼ぶだけ
-  - **`mergeUpdate(input)` 系**（`PieceWorkEntity` / `PieceMovementEntity`）: `entity-helpers.ts:buildUpdateProps` を介して `Update*Input` をシャローマージする汎用更新メソッド。命名がドメイン語彙を反映していない貧血状態。Piece 側も意図メソッド化への移行を段階的に進める
+  - **集約意図メソッド + 独立意図メソッドのハイブリッド**（`ComposerEntity` / `PieceWorkEntity` / `PieceMovementEntity`）: マスタ情報の編集は「マスタ管理者が事実を訂正・追記する」という単一の編集意図に集約しつつ、外部リソース参照（画像 URL / 動画 URL）の貼り替えは独立した意図メソッドに分ける。
+    - `ComposerEntity`: `editProfile(revision: ComposerProfileRevision)` + `updateImage(imageUrl)`
+    - `PieceWorkEntity`: `editMetadata(revision: PieceWorkMetadataRevision)` + `updateVideos(videoUrls)`
+    - `PieceMovementEntity`: `editMetadata(revision: PieceMovementMetadataRevision)` + `updateVideos(videoUrls)`
+    - 集約意図メソッド側は内部で `buildUpdateProps` を呼び、API 仕様の「空文字 / null でフィールド削除」をそのまま尊重する
+    - `Update*Input` の partial を 2 系統に dispatch する責務はエンティティ側の static `applyRevisions(entity, input)` に閉じ、usecase は `XxxEntity.applyRevisions(current, input)` を呼ぶだけ
+  - **個別意図メソッド系**（`ListeningLogEntity`）: フィールドごとに鑑賞者ドメインの意図がはっきり違うため、フィールド単位の意図メソッド（`markAsFavorite()` / `unmarkAsFavorite()` / `rerate(rating)` / `rewriteMemo(memo)` / `correctListenedAt(listenedAt)` / `relinkPiece(pieceId)`）を生やす。dispatch 責務は `applyRevisions` に閉じる
 
 ### 8.4 読み取り専用集約（ListeningLogDetail）
 


### PR DESCRIPTION
## 背景

PR #682（ListeningLog）/ #681（ConcertLog）/ #684（Composer）で順次進めてきた「`mergeUpdate` 撤去 + 意図メソッド化」シリーズの最終 PR。残っていた `PieceWorkEntity` / `PieceMovementEntity` の `mergeUpdate` を撤去し、PR #684 の `ComposerEntity` と同じ「集約意図メソッド + 独立意図メソッドのハイブリッド」パターンに揃える。

`Piece` のマスタ情報も Composer と同じく、

| 観点 | フィールド | 意図 |
| --- | --- | --- |
| メタデータ | title / composerId / genre / era / formation / region（Work）／ title / parentId / index（Movement） | マスタ管理者が事実を訂正・追記する |
| 外部リソース参照 | videoUrls | YouTube 等の動画 URL を貼り替える／取り外す |

の 2 つに分かれる。前者は「マスタ情報の編集」という単一意図に集約し、後者は独立した意図メソッドに分ける。

## 変更内容

- **`PieceWorkEntity` に意図メソッドを 2 つ追加**:
  - `editMetadata(revision: PieceWorkMetadataRevision)`: 曲名・作曲家参照・カテゴリ系の編集を集約。`genre` / `era` / `formation` / `region` は空文字でフィールド削除
  - `updateVideos(videoUrls: readonly string[] | undefined)`: 動画 URL 集合の貼り替え。`undefined` または空配列で取り外し
- **`PieceMovementEntity` に同じ 2 系統**:
  - `editMetadata(revision: PieceMovementMetadataRevision)`: 楽章名・親 Work 参照・演奏順 `index` の編集を集約
  - `updateVideos(videoUrls)`: Work と同じ動画 URL 貼り替え
- **`applyRevisions` を各 Entity の static に追加**: `UpdateXxxInput` から `videoUrls` とそれ以外を切り出し、`editMetadata` / `updateVideos` にそれぞれ dispatch する。`PieceComponent.applyUpdate` ファサードは kind 判別後にこの static を呼ぶ
- **`mergeUpdate` を撤去**: Work / Movement の両方から。`PieceComponent.applyUpdate` の中身も `applyRevisions` ベースに書き換え
- **`PieceWorkMetadataRevision` / `PieceMovementMetadataRevision` 型を導入**: `Omit<UpdateWorkInput, "kind" | "videoUrls">` / `Omit<UpdateMovementInput, "kind" | "videoUrls">` として「編集業務」の語彙を型で表現
- **`piece-usecase.ts` の `WorkUsecase.update` / `MovementUsecase.update`** を `XxxEntity.applyRevisions` ベースに書き換え
- **`piece.test.ts` を意図メソッド中心に書き直し**（799 件 green、+7 件）: 各意図メソッド単体・dispatch・空 input で entity をそのまま返す挙動を検証
- **`docs/SPEC.md` §8.3**: 全エンティティが意図メソッド化された状態（「`mergeUpdate` 系」の項目を削除）に揃える。PR #684 マージ時点で残っていた古い ComposerEntity の説明（`rename` / `reclassifyEra` 等）もハイブリッド版に訂正
- **`docs/ARCHITECTURE.md`**: 「Composer 集約の個別意図メソッド」セクションを「Composer / Piece 集約のハイブリッド意図メソッド」に書き直し、Work / Movement のメソッドを並べて記述

## 互換性

API・HTTP 挙動は完全互換。

- `updatePieceSchema` は変更なし（partial + 空文字／空配列クリア）
- `applyRevisions` は input にキーが含まれるフィールドのみ意図メソッドを適用するので、現行の partial update 挙動を再現
- 既存のハンドラレベル統合テスト（`handlers/pieces/update.test.ts` 等）はそのまま green

## 設計上の判断

**`editMetadata` の集約**: 楽曲マスタ管理者の操作は「曲名を訂正する」「作曲家を別の人に張り直す」「ジャンルを分類し直す」「カテゴリのクリア」のいずれも、対外的には「マスタ情報の編集」という単一の業務に帰着する。フィールドごとに `renameWork` / `relinkComposer` / `reclassifyGenre` … を生やすと、UI 側もフォーム送信を細切れに分解せねばならず、ConcertLog の `revise` と同じく集約意図メソッドが自然。

**`updateVideos` の独立**: 動画 URL は YouTube 等の外部リソース参照を貼る／剥がす行為で、ComposerEntity の `imageUrl` と同じ性質。テキスト情報の編集とは別の操作として扱う。

**`buildUpdateProps` の継続利用**: `editMetadata` / `editProfile` / `revise` の内部実装としては引き続き使う（API の「空文字／null でクリア」の意味論をそのまま尊重する）。Entity 側の公開 API としての `mergeUpdate` は全撤去された。

## 残作業

- なし。`mergeUpdate` 撤去 + 意図メソッド化シリーズはこれで完了

## Test plan

- [x] `pnpm run test:backend`（799 件 green、+7 件）
- [x] `pnpm run test:frontend`（786 件 green、無関係）
- [x] `pnpm run lint` / `pnpm run format:check`
- [ ] CI 上の deploy / E2E

---
_Generated by [Claude Code](https://claude.ai/code/session_01MqUEmhrff3xg2Yo4xF6o1R)_