### PR TITLE
refactor: import エイリアスを @/ と @shared/ に統一

### DIFF
--- a/app/components/atoms/ButtonDanger.test.ts
+++ b/app/components/atoms/ButtonDanger.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ButtonDanger from "./ButtonDanger.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
 
 describe("ButtonDanger", () => {
   describe("表示", () => {

--- a/app/components/atoms/ButtonDanger.vue
+++ b/app/components/atoms/ButtonDanger.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CommonButtonProps, ButtonSlots } from "./button-props";
+import type { CommonButtonProps, ButtonSlots } from "@/components/atoms/button-props";
 
 defineProps<CommonButtonProps>();
 defineSlots<ButtonSlots>();

--- a/app/components/atoms/ButtonPrimary.test.ts
+++ b/app/components/atoms/ButtonPrimary.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ButtonPrimary from "./ButtonPrimary.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
 
 describe("ButtonPrimary", () => {
   describe("表示", () => {

--- a/app/components/atoms/ButtonPrimary.vue
+++ b/app/components/atoms/ButtonPrimary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { SubmittableButtonProps, ButtonSlots } from "./button-props";
+import type { SubmittableButtonProps, ButtonSlots } from "@/components/atoms/button-props";
 
 defineProps<SubmittableButtonProps>();
 defineSlots<ButtonSlots>();

--- a/app/components/atoms/ButtonSecondary.test.ts
+++ b/app/components/atoms/ButtonSecondary.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ButtonSecondary from "./ButtonSecondary.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
 
 describe("ButtonSecondary", () => {
   describe("表示", () => {

--- a/app/components/atoms/ButtonSecondary.vue
+++ b/app/components/atoms/ButtonSecondary.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CommonButtonProps, ButtonSlots } from "./button-props";
+import type { CommonButtonProps, ButtonSlots } from "@/components/atoms/button-props";
 
 defineProps<CommonButtonProps>();
 defineSlots<ButtonSlots>();

--- a/app/components/atoms/CategoryBadge.stories.ts
+++ b/app/components/atoms/CategoryBadge.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import CategoryBadge from "./CategoryBadge.vue";
+import CategoryBadge from "@/components/atoms/CategoryBadge.vue";
 
 const meta: Meta<typeof CategoryBadge> = {
   title: "Atoms/CategoryBadge",

--- a/app/components/atoms/CategoryBadge.test.ts
+++ b/app/components/atoms/CategoryBadge.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import CategoryBadge from "./CategoryBadge.vue";
+import CategoryBadge from "@/components/atoms/CategoryBadge.vue";
 
 describe("CategoryBadge", () => {
   describe("表示", () => {

--- a/app/components/atoms/EmptyState.stories.ts
+++ b/app/components/atoms/EmptyState.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import EmptyState from "./EmptyState.vue";
+import EmptyState from "@/components/atoms/EmptyState.vue";
 
 const meta: Meta<typeof EmptyState> = {
   title: "Atoms/EmptyState",

--- a/app/components/atoms/EmptyState.test.ts
+++ b/app/components/atoms/EmptyState.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import EmptyState from "./EmptyState.vue";
+import EmptyState from "@/components/atoms/EmptyState.vue";
 
 describe("EmptyState", () => {
   it("スロットのテキストが表示される", async () => {

--- a/app/components/atoms/ErrorMessage.stories.ts
+++ b/app/components/atoms/ErrorMessage.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ErrorMessage from "./ErrorMessage.vue";
+import ErrorMessage from "@/components/atoms/ErrorMessage.vue";
 
 const meta: Meta<typeof ErrorMessage> = {
   title: "Atoms/ErrorMessage",

--- a/app/components/atoms/ErrorMessage.test.ts
+++ b/app/components/atoms/ErrorMessage.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ErrorMessage from "./ErrorMessage.vue";
+import ErrorMessage from "@/components/atoms/ErrorMessage.vue";
 
 describe("ErrorMessage", () => {
   it("メッセージが表示される", async () => {

--- a/app/components/atoms/FormGroup.test.ts
+++ b/app/components/atoms/FormGroup.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import FormGroup from "./FormGroup.vue";
+import FormGroup from "@/components/atoms/FormGroup.vue";
 
 describe("FormGroup", () => {
   describe("表示", () => {

--- a/app/components/atoms/PageTitle.stories.ts
+++ b/app/components/atoms/PageTitle.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PageTitle from "./PageTitle.vue";
+import PageTitle from "@/components/atoms/PageTitle.vue";
 
 const meta: Meta<typeof PageTitle> = {
   title: "Atoms/PageTitle",

--- a/app/components/atoms/PageTitle.test.ts
+++ b/app/components/atoms/PageTitle.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PageTitle from "./PageTitle.vue";
+import PageTitle from "@/components/atoms/PageTitle.vue";
 
 describe("PageTitle", () => {
   it("スロットのテキストが表示される", async () => {

--- a/app/components/atoms/RequiredMark.stories.ts
+++ b/app/components/atoms/RequiredMark.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import RequiredMark from "./RequiredMark.vue";
+import RequiredMark from "@/components/atoms/RequiredMark.vue";
 
 const meta: Meta<typeof RequiredMark> = {
   title: "Atoms/RequiredMark",

--- a/app/components/atoms/RequiredMark.test.ts
+++ b/app/components/atoms/RequiredMark.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import RequiredMark from "./RequiredMark.vue";
+import RequiredMark from "@/components/atoms/RequiredMark.vue";
 
 describe("RequiredMark", () => {
   it("「required」テキストが表示される", async () => {

--- a/app/components/atoms/SelectInput.stories.ts
+++ b/app/components/atoms/SelectInput.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import SelectInput from "./SelectInput.vue";
-import { PIECE_GENRES } from "~/types";
+import SelectInput from "@/components/atoms/SelectInput.vue";
+import { PIECE_GENRES } from "@/types";
 
 const genreOptions = PIECE_GENRES.map((v) => ({ value: v, label: v }));
 

--- a/app/components/atoms/SelectInput.test.ts
+++ b/app/components/atoms/SelectInput.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import SelectInput from "./SelectInput.vue";
+import SelectInput from "@/components/atoms/SelectInput.vue";
 
 const options = [
   { value: "交響曲", label: "交響曲" },

--- a/app/components/atoms/TextInput.stories.ts
+++ b/app/components/atoms/TextInput.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import TextInput from "./TextInput.vue";
+import TextInput from "@/components/atoms/TextInput.vue";
 
 const meta: Meta<typeof TextInput> = {
   title: "Atoms/TextInput",

--- a/app/components/atoms/TextInput.test.ts
+++ b/app/components/atoms/TextInput.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import TextInput from "./TextInput.vue";
+import TextInput from "@/components/atoms/TextInput.vue";
 
 describe("TextInput", () => {
   it("デフォルトの type は text", async () => {

--- a/app/components/atoms/ThemeToggle.stories.ts
+++ b/app/components/atoms/ThemeToggle.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ThemeToggle from "./ThemeToggle.vue";
+import ThemeToggle from "@/components/atoms/ThemeToggle.vue";
 
 const meta: Meta<typeof ThemeToggle> = {
   title: "Atoms/ThemeToggle",

--- a/app/components/atoms/ThemeToggle.test.ts
+++ b/app/components/atoms/ThemeToggle.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import ThemeToggle from "./ThemeToggle.vue";
+import ThemeToggle from "@/components/atoms/ThemeToggle.vue";
 
 const colorModeState = reactive({
   preference: "light",

--- a/app/components/atoms/YouTubeThumbnail.stories.ts
+++ b/app/components/atoms/YouTubeThumbnail.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import YouTubeThumbnail from "./YouTubeThumbnail.vue";
+import YouTubeThumbnail from "@/components/atoms/YouTubeThumbnail.vue";
 
 const meta: Meta<typeof YouTubeThumbnail> = {
   title: "Atoms/YouTubeThumbnail",

--- a/app/components/atoms/YouTubeThumbnail.test.ts
+++ b/app/components/atoms/YouTubeThumbnail.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import YouTubeThumbnail from "./YouTubeThumbnail.vue";
+import YouTubeThumbnail from "@/components/atoms/YouTubeThumbnail.vue";
 
 const VIDEO_ID = "dQw4w9WgXcQ";
 const STANDARD_URL = `https://www.youtube.com/watch?v=${VIDEO_ID}`;

--- a/app/components/atoms/YouTubeThumbnail.vue
+++ b/app/components/atoms/YouTubeThumbnail.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { extractYouTubeVideoId, isYouTubeUrl } from "~/utils/video";
+import { extractYouTubeVideoId, isYouTubeUrl } from "@/utils/video";
 
 const props = defineProps<{
   videoUrl: string | undefined;

--- a/app/components/molecules/AuthFormContainer.stories.ts
+++ b/app/components/molecules/AuthFormContainer.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import AuthFormContainer from "./AuthFormContainer.vue";
+import AuthFormContainer from "@/components/molecules/AuthFormContainer.vue";
 
 const meta: Meta<typeof AuthFormContainer> = {
   title: "Molecules/AuthFormContainer",

--- a/app/components/molecules/AuthFormContainer.test.ts
+++ b/app/components/molecules/AuthFormContainer.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import AuthFormContainer from "./AuthFormContainer.vue";
+import AuthFormContainer from "@/components/molecules/AuthFormContainer.vue";
 
 describe("AuthFormContainer", () => {
   it("title が h1 に表示される", async () => {

--- a/app/components/molecules/ComposerCategoryList.stories.ts
+++ b/app/components/molecules/ComposerCategoryList.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerCategoryList from "./ComposerCategoryList.vue";
+import ComposerCategoryList from "@/components/molecules/ComposerCategoryList.vue";
 
 const meta: Meta<typeof ComposerCategoryList> = {
   title: "Molecules/ComposerCategoryList",

--- a/app/components/molecules/ComposerCategoryList.test.ts
+++ b/app/components/molecules/ComposerCategoryList.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerCategoryList from "./ComposerCategoryList.vue";
+import ComposerCategoryList from "@/components/molecules/ComposerCategoryList.vue";
 
 describe("ComposerCategoryList", () => {
   describe("表示", () => {

--- a/app/components/molecules/ComposerCategoryList.vue
+++ b/app/components/molecules/ComposerCategoryList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
+import type { Composer } from "@/types";
 
 type Kind = "era" | "region";
 

--- a/app/components/molecules/ComposerItem.stories.ts
+++ b/app/components/molecules/ComposerItem.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerItem from "./ComposerItem.vue";
+import ComposerItem from "@/components/molecules/ComposerItem.vue";
 
 const meta: Meta<typeof ComposerItem> = {
   title: "Molecules/ComposerItem",

--- a/app/components/molecules/ComposerItem.test.ts
+++ b/app/components/molecules/ComposerItem.test.ts
@@ -1,8 +1,8 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerItem from "./ComposerItem.vue";
-import ButtonSecondary from "../atoms/ButtonSecondary.vue";
-import ButtonDanger from "../atoms/ButtonDanger.vue";
-import type { Composer } from "~/types";
+import ComposerItem from "@/components/molecules/ComposerItem.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
+import type { Composer } from "@/types";
 
 const sampleComposer: Composer = {
   id: "1",

--- a/app/components/molecules/ComposerItem.vue
+++ b/app/components/molecules/ComposerItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
-import { formatLifespan } from "~/utils/lifespan";
+import type { Composer } from "@/types";
+import { formatLifespan } from "@/utils/lifespan";
 
 const props = defineProps<{
   composer: Composer;

--- a/app/components/molecules/ConcertLogItem.stories.ts
+++ b/app/components/molecules/ConcertLogItem.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog } from "~/types";
-import ConcertLogItem from "./ConcertLogItem.vue";
+import type { ConcertLog } from "@/types";
+import ConcertLogItem from "@/components/molecules/ConcertLogItem.vue";
 
 const meta: Meta<typeof ConcertLogItem> = {
   title: "Molecules/ConcertLogItem",

--- a/app/components/molecules/ConcertLogItem.test.ts
+++ b/app/components/molecules/ConcertLogItem.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogItem from "./ConcertLogItem.vue";
-import ButtonSecondary from "../atoms/ButtonSecondary.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogItem from "@/components/molecules/ConcertLogItem.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLog: ConcertLog = {
   id: "1",

--- a/app/components/molecules/ConcertLogItem.vue
+++ b/app/components/molecules/ConcertLogItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { formatDate } from "~/utils/date";
-import type { ConcertLog } from "~/types";
+import { formatDate } from "@/utils/date";
+import type { ConcertLog } from "@/types";
 
 defineProps<{
   concertLog: ConcertLog;

--- a/app/components/molecules/FavoriteIndicator.stories.ts
+++ b/app/components/molecules/FavoriteIndicator.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import FavoriteIndicator from "./FavoriteIndicator.vue";
+import FavoriteIndicator from "@/components/molecules/FavoriteIndicator.vue";
 
 const meta: Meta<typeof FavoriteIndicator> = {
   title: "Molecules/FavoriteIndicator",

--- a/app/components/molecules/FavoriteIndicator.test.ts
+++ b/app/components/molecules/FavoriteIndicator.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import FavoriteIndicator from "./FavoriteIndicator.vue";
+import FavoriteIndicator from "@/components/molecules/FavoriteIndicator.vue";
 
 describe("FavoriteIndicator", () => {
   it("isFavorite が true のとき ♥ が表示される", async () => {

--- a/app/components/molecules/FormActions.stories.ts
+++ b/app/components/molecules/FormActions.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import FormActions from "./FormActions.vue";
+import FormActions from "@/components/molecules/FormActions.vue";
 
 const meta: Meta<typeof FormActions> = {
   title: "Molecules/FormActions",

--- a/app/components/molecules/FormActions.test.ts
+++ b/app/components/molecules/FormActions.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import FormActions from "./FormActions.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
-import ButtonSecondary from "../atoms/ButtonSecondary.vue";
+import FormActions from "@/components/molecules/FormActions.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
 
 const globalComponents = { global: { components: { ButtonPrimary, ButtonSecondary } } };
 

--- a/app/components/molecules/ListeningLogFilter.stories.ts
+++ b/app/components/molecules/ListeningLogFilter.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ListeningLogFilter from "./ListeningLogFilter.vue";
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
+import ListeningLogFilter from "@/components/molecules/ListeningLogFilter.vue";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
 
 const meta: Meta<typeof ListeningLogFilter> = {
   title: "Molecules/ListeningLogFilter",

--- a/app/components/molecules/ListeningLogFilter.test.ts
+++ b/app/components/molecules/ListeningLogFilter.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogFilter from "./ListeningLogFilter.vue";
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
+import ListeningLogFilter from "@/components/molecules/ListeningLogFilter.vue";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
 
 const initialState: ListeningLogFilterState = {
   keyword: "",

--- a/app/components/molecules/ListeningLogFilter.vue
+++ b/app/components/molecules/ListeningLogFilter.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
 
 defineProps<{
   modelValue: ListeningLogFilterState;

--- a/app/components/molecules/ListeningLogItem.stories.ts
+++ b/app/components/molecules/ListeningLogItem.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import ListeningLogItem from "./ListeningLogItem.vue";
+import type { ListeningLog } from "@/types";
+import ListeningLogItem from "@/components/molecules/ListeningLogItem.vue";
 
 const meta: Meta<typeof ListeningLogItem> = {
   title: "Molecules/ListeningLogItem",

--- a/app/components/molecules/ListeningLogItem.test.ts
+++ b/app/components/molecules/ListeningLogItem.test.ts
@@ -1,8 +1,8 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogItem from "./ListeningLogItem.vue";
-import ButtonSecondary from "../atoms/ButtonSecondary.vue";
-import ButtonDanger from "../atoms/ButtonDanger.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogItem from "@/components/molecules/ListeningLogItem.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
+import type { ListeningLog } from "@/types";
 
 const sampleLog: ListeningLog = {
   id: "1",

--- a/app/components/molecules/ListeningLogItem.vue
+++ b/app/components/molecules/ListeningLogItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { formatDate } from "~/utils/date";
-import type { ListeningLog } from "~/types";
+import { formatDate } from "@/utils/date";
+import type { ListeningLog } from "@/types";
 
 defineProps<{
   listeningLog: ListeningLog;

--- a/app/components/molecules/MovementListItem.stories.ts
+++ b/app/components/molecules/MovementListItem.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { PieceMovement } from "~/types";
-import MovementListItem from "./MovementListItem.vue";
+import type { PieceMovement } from "@/types";
+import MovementListItem from "@/components/molecules/MovementListItem.vue";
 
 const meta: Meta<typeof MovementListItem> = {
   title: "Molecules/MovementListItem",

--- a/app/components/molecules/MovementListItem.test.ts
+++ b/app/components/molecules/MovementListItem.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import MovementListItem from "./MovementListItem.vue";
-import type { PieceMovement } from "~/types";
+import MovementListItem from "@/components/molecules/MovementListItem.vue";
+import type { PieceMovement } from "@/types";
 
 const baseMovement: PieceMovement = {
   kind: "movement",

--- a/app/components/molecules/MovementListItem.vue
+++ b/app/components/molecules/MovementListItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { PieceMovement } from "~/types";
-import { isYouTubeUrl, toYouTubeEmbedUrl } from "~/utils/video";
+import type { PieceMovement } from "@/types";
+import { isYouTubeUrl, toYouTubeEmbedUrl } from "@/utils/video";
 
 const props = defineProps<{
   movement: PieceMovement;

--- a/app/components/molecules/PageHeader.stories.ts
+++ b/app/components/molecules/PageHeader.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PageHeader from "./PageHeader.vue";
+import PageHeader from "@/components/molecules/PageHeader.vue";
 
 const meta: Meta<typeof PageHeader> = {
   title: "Molecules/PageHeader",

--- a/app/components/molecules/PageHeader.test.ts
+++ b/app/components/molecules/PageHeader.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PageHeader from "./PageHeader.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
+import PageHeader from "@/components/molecules/PageHeader.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
 
 vi.mock("~/composables/useAuth", () => ({
   ACCESS_TOKEN_KEY: "accessToken",

--- a/app/components/molecules/PasswordInput.stories.ts
+++ b/app/components/molecules/PasswordInput.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PasswordInput from "./PasswordInput.vue";
+import PasswordInput from "@/components/molecules/PasswordInput.vue";
 
 const meta: Meta<typeof PasswordInput> = {
   title: "Molecules/PasswordInput",

--- a/app/components/molecules/PasswordInput.test.ts
+++ b/app/components/molecules/PasswordInput.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PasswordInput from "./PasswordInput.vue";
+import PasswordInput from "@/components/molecules/PasswordInput.vue";
 
 describe("PasswordInput", () => {
   describe("表示", () => {

--- a/app/components/molecules/PieceCategoryList.stories.ts
+++ b/app/components/molecules/PieceCategoryList.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PieceCategoryList from "./PieceCategoryList.vue";
+import PieceCategoryList from "@/components/molecules/PieceCategoryList.vue";
 
 const meta: Meta<typeof PieceCategoryList> = {
   title: "Molecules/PieceCategoryList",

--- a/app/components/molecules/PieceCategoryList.test.ts
+++ b/app/components/molecules/PieceCategoryList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceCategoryList from "./PieceCategoryList.vue";
-import type { PieceWork } from "~/types";
+import PieceCategoryList from "@/components/molecules/PieceCategoryList.vue";
+import type { PieceWork } from "@/types";
 
 const allCategories: Pick<PieceWork, "genre" | "era" | "formation" | "region"> = {
   genre: "交響曲",

--- a/app/components/molecules/PieceCategoryList.vue
+++ b/app/components/molecules/PieceCategoryList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 type Kind = "genre" | "era" | "formation" | "region";
 

--- a/app/components/molecules/PieceItem.stories.ts
+++ b/app/components/molecules/PieceItem.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { PieceWork } from "~/types";
-import PieceItem from "./PieceItem.vue";
+import type { PieceWork } from "@/types";
+import PieceItem from "@/components/molecules/PieceItem.vue";
 
 const meta: Meta<typeof PieceItem> = {
   title: "Molecules/PieceItem",

--- a/app/components/molecules/PieceItem.test.ts
+++ b/app/components/molecules/PieceItem.test.ts
@@ -1,8 +1,8 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceItem from "./PieceItem.vue";
-import ButtonSecondary from "../atoms/ButtonSecondary.vue";
-import ButtonDanger from "../atoms/ButtonDanger.vue";
-import type { PieceWork } from "~/types";
+import PieceItem from "@/components/molecules/PieceItem.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 

--- a/app/components/molecules/PieceItem.vue
+++ b/app/components/molecules/PieceItem.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
-import { isYouTubeUrl } from "~/utils/video";
+import type { PieceWork } from "@/types";
+import { isYouTubeUrl } from "@/utils/video";
 
 const props = defineProps<{
   piece: PieceWork;

--- a/app/components/molecules/RatingDisplay.stories.ts
+++ b/app/components/molecules/RatingDisplay.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import RatingDisplay from "./RatingDisplay.vue";
+import RatingDisplay from "@/components/molecules/RatingDisplay.vue";
 
 const meta: Meta<typeof RatingDisplay> = {
   title: "Molecules/RatingDisplay",

--- a/app/components/molecules/RatingDisplay.test.ts
+++ b/app/components/molecules/RatingDisplay.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import RatingDisplay from "./RatingDisplay.vue";
+import RatingDisplay from "@/components/molecules/RatingDisplay.vue";
 
 describe("RatingDisplay", () => {
   it("評価5のとき★5つが表示される", async () => {

--- a/app/components/molecules/RatingSelector.stories.ts
+++ b/app/components/molecules/RatingSelector.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import RatingSelector from "./RatingSelector.vue";
+import RatingSelector from "@/components/molecules/RatingSelector.vue";
 
 const meta: Meta<typeof RatingSelector> = {
   title: "Molecules/RatingSelector",

--- a/app/components/molecules/RatingSelector.test.ts
+++ b/app/components/molecules/RatingSelector.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import RatingSelector from "./RatingSelector.vue";
+import RatingSelector from "@/components/molecules/RatingSelector.vue";
 
 describe("RatingSelector", () => {
   it("星ボタンが5つ表示される", async () => {

--- a/app/components/molecules/RatingSelector.vue
+++ b/app/components/molecules/RatingSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Rating } from "~/types";
+import type { Rating } from "@/types";
 
 defineProps<{
   modelValue: Rating;

--- a/app/components/molecules/VideoPlayer.stories.ts
+++ b/app/components/molecules/VideoPlayer.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import VideoPlayer from "./VideoPlayer.vue";
+import VideoPlayer from "@/components/molecules/VideoPlayer.vue";
 
 const meta: Meta<typeof VideoPlayer> = {
   title: "Molecules/VideoPlayer",

--- a/app/components/molecules/VideoPlayer.test.ts
+++ b/app/components/molecules/VideoPlayer.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import VideoPlayer from "./VideoPlayer.vue";
+import VideoPlayer from "@/components/molecules/VideoPlayer.vue";
 
 const youtubeUrl = "https://www.youtube.com/watch?v=abc123";
 const nonYoutubeUrl = "https://example.com/video";

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { isYouTubeUrl, toYouTubeEmbedUrl } from "~/utils/video";
+import { isYouTubeUrl, toYouTubeEmbedUrl } from "@/utils/video";
 
 const props = defineProps<{
   videoUrl: string;

--- a/app/components/organisms/ComposerForm.stories.ts
+++ b/app/components/organisms/ComposerForm.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerForm from "./ComposerForm.vue";
+import ComposerForm from "@/components/organisms/ComposerForm.vue";
 
 const meta: Meta<typeof ComposerForm> = {
   title: "Organisms/ComposerForm",

--- a/app/components/organisms/ComposerForm.test.ts
+++ b/app/components/organisms/ComposerForm.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerForm from "./ComposerForm.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
+import ComposerForm from "@/components/organisms/ComposerForm.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
 
 describe("ComposerForm", () => {
   describe("デフォルト値でのレンダリング", () => {

--- a/app/components/organisms/ComposerForm.vue
+++ b/app/components/organisms/ComposerForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { CreateComposerInput } from "~/types";
-import { PIECE_ERAS, PIECE_REGIONS } from "~/types";
-import { toSelectOptions } from "~/utils/select-options";
+import type { CreateComposerInput } from "@/types";
+import { PIECE_ERAS, PIECE_REGIONS } from "@/types";
+import { toSelectOptions } from "@/utils/select-options";
 
 const eraOptions = toSelectOptions(PIECE_ERAS);
 const regionOptions = toSelectOptions(PIECE_REGIONS);

--- a/app/components/organisms/ComposerList.stories.ts
+++ b/app/components/organisms/ComposerList.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerList from "./ComposerList.vue";
-import type { Composer } from "~/types";
+import ComposerList from "@/components/organisms/ComposerList.vue";
+import type { Composer } from "@/types";
 
 const meta: Meta<typeof ComposerList> = {
   title: "Organisms/ComposerList",

--- a/app/components/organisms/ComposerList.test.ts
+++ b/app/components/organisms/ComposerList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerList from "./ComposerList.vue";
-import type { Composer } from "~/types";
+import ComposerList from "@/components/organisms/ComposerList.vue";
+import type { Composer } from "@/types";
 
 const sampleComposers: Composer[] = [
   {

--- a/app/components/organisms/ComposerList.vue
+++ b/app/components/organisms/ComposerList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
+import type { Composer } from "@/types";
 
 defineProps<{
   composers: Composer[];

--- a/app/components/organisms/ConcertLogDetail.stories.ts
+++ b/app/components/organisms/ConcertLogDetail.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog, PieceWork } from "~/types";
-import ConcertLogDetail from "./ConcertLogDetail.vue";
+import type { ConcertLog, PieceWork } from "@/types";
+import ConcertLogDetail from "@/components/organisms/ConcertLogDetail.vue";
 
 const meta: Meta<typeof ConcertLogDetail> = {
   title: "Organisms/ConcertLogDetail",

--- a/app/components/organisms/ConcertLogDetail.test.ts
+++ b/app/components/organisms/ConcertLogDetail.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogDetail from "./ConcertLogDetail.vue";
-import type { ConcertLog, PieceWork } from "~/types";
+import ConcertLogDetail from "@/components/organisms/ConcertLogDetail.vue";
+import type { ConcertLog, PieceWork } from "@/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/ConcertLogDetail.vue
+++ b/app/components/organisms/ConcertLogDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { formatDatetime } from "~/utils/date";
-import type { ConcertLog, PieceWork } from "~/types";
+import { formatDatetime } from "@/utils/date";
+import type { ConcertLog, PieceWork } from "@/types";
 
 const props = defineProps<{
   log: ConcertLog;

--- a/app/components/organisms/ConcertLogForm.stories.ts
+++ b/app/components/organisms/ConcertLogForm.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ConcertLogForm from "./ConcertLogForm.vue";
+import ConcertLogForm from "@/components/organisms/ConcertLogForm.vue";
 
 const meta: Meta<typeof ConcertLogForm> = {
   title: "Organisms/ConcertLogForm",

--- a/app/components/organisms/ConcertLogForm.test.ts
+++ b/app/components/organisms/ConcertLogForm.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogForm from "./ConcertLogForm.vue";
-import type { PieceWork } from "~/types";
+import ConcertLogForm from "@/components/organisms/ConcertLogForm.vue";
+import type { PieceWork } from "@/types";
 
 const mockPieces: PieceWork[] = [
   {

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import draggable from "vuedraggable";
-import { nowAsDatetimeLocal, toDatetimeLocal } from "~/utils/date";
-import type { CreateConcertLogInput, PieceWork } from "~/types";
+import { nowAsDatetimeLocal, toDatetimeLocal } from "@/utils/date";
+import type { CreateConcertLogInput, PieceWork } from "@/types";
 
 const props = defineProps<{
   initialValues?: Partial<CreateConcertLogInput>;

--- a/app/components/organisms/ConcertLogList.stories.ts
+++ b/app/components/organisms/ConcertLogList.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog } from "~/types";
-import ConcertLogList from "./ConcertLogList.vue";
+import type { ConcertLog } from "@/types";
+import ConcertLogList from "@/components/organisms/ConcertLogList.vue";
 
 const meta: Meta<typeof ConcertLogList> = {
   title: "Organisms/ConcertLogList",

--- a/app/components/organisms/ConcertLogList.test.ts
+++ b/app/components/organisms/ConcertLogList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogList from "./ConcertLogList.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogList from "@/components/organisms/ConcertLogList.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLogs: ConcertLog[] = [
   {

--- a/app/components/organisms/ConcertLogList.vue
+++ b/app/components/organisms/ConcertLogList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ConcertLog } from "~/types";
+import type { ConcertLog } from "@/types";
 
 defineProps<{
   logs: ConcertLog[];

--- a/app/components/organisms/FeaturedPiece.stories.ts
+++ b/app/components/organisms/FeaturedPiece.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import FeaturedPiece from "./FeaturedPiece.vue";
-import type { PieceWork } from "~/types";
+import FeaturedPiece from "@/components/organisms/FeaturedPiece.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/FeaturedPiece.test.ts
+++ b/app/components/organisms/FeaturedPiece.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import FeaturedPiece from "./FeaturedPiece.vue";
-import type { PieceWork } from "~/types";
+import FeaturedPiece from "@/components/organisms/FeaturedPiece.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/FeaturedPiece.vue
+++ b/app/components/organisms/FeaturedPiece.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 const props = defineProps<{
   pieces: PieceWork[];

--- a/app/components/organisms/ListeningLogDetail.stories.ts
+++ b/app/components/organisms/ListeningLogDetail.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import ListeningLogDetail from "./ListeningLogDetail.vue";
+import type { ListeningLog } from "@/types";
+import ListeningLogDetail from "@/components/organisms/ListeningLogDetail.vue";
 
 const meta: Meta<typeof ListeningLogDetail> = {
   title: "Organisms/ListeningLogDetail",

--- a/app/components/organisms/ListeningLogDetail.test.ts
+++ b/app/components/organisms/ListeningLogDetail.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogDetail from "./ListeningLogDetail.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogDetail from "@/components/organisms/ListeningLogDetail.vue";
+import type { ListeningLog } from "@/types";
 
 const sampleLog: ListeningLog = {
   id: "log-1",

--- a/app/components/organisms/ListeningLogDetail.vue
+++ b/app/components/organisms/ListeningLogDetail.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { formatDatetime } from "~/utils/date";
-import type { ListeningLog } from "~/types";
+import { formatDatetime } from "@/utils/date";
+import type { ListeningLog } from "@/types";
 
 const props = defineProps<{
   log: ListeningLog;

--- a/app/components/organisms/ListeningLogForm.test.ts
+++ b/app/components/organisms/ListeningLogForm.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import ListeningLogForm from "./ListeningLogForm.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
-import type { Composer, PieceWork } from "~/types";
+import ListeningLogForm from "@/components/organisms/ListeningLogForm.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
+import type { Composer, PieceWork } from "@/types";
 
 const { mockPieces, mockComposers } = vi.hoisted(() => {
   const BEETHOVEN = "00000000-0000-4000-8000-000000000001";

--- a/app/components/organisms/ListeningLogForm.vue
+++ b/app/components/organisms/ListeningLogForm.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { nowAsDatetimeLocal, toDatetimeLocal } from "~/utils/date";
-import type { CreateListeningLogInput } from "~/types";
+import { nowAsDatetimeLocal, toDatetimeLocal } from "@/utils/date";
+import type { CreateListeningLogInput } from "@/types";
 
 const props = defineProps<{
   initialValues?: Partial<CreateListeningLogInput>;

--- a/app/components/organisms/ListeningLogList.stories.ts
+++ b/app/components/organisms/ListeningLogList.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import ListeningLogList from "./ListeningLogList.vue";
+import type { ListeningLog } from "@/types";
+import ListeningLogList from "@/components/organisms/ListeningLogList.vue";
 
 const meta: Meta<typeof ListeningLogList> = {
   title: "Organisms/ListeningLogList",

--- a/app/components/organisms/ListeningLogList.test.ts
+++ b/app/components/organisms/ListeningLogList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogList from "./ListeningLogList.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogList from "@/components/organisms/ListeningLogList.vue";
+import type { ListeningLog } from "@/types";
 
 const makeLogs = (): ListeningLog[] => [
   {

--- a/app/components/organisms/ListeningLogList.vue
+++ b/app/components/organisms/ListeningLogList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLog } from "~/types";
+import type { ListeningLog } from "@/types";
 
 defineProps<{
   logs: ListeningLog[];

--- a/app/components/organisms/ListeningLogStatistics.stories.ts
+++ b/app/components/organisms/ListeningLogStatistics.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ListeningLogStatistics from "./ListeningLogStatistics.vue";
-import type { ListeningLogStatistics as Stats } from "~/composables/useListeningLogStatistics";
+import ListeningLogStatistics from "@/components/organisms/ListeningLogStatistics.vue";
+import type { ListeningLogStatistics as Stats } from "@/composables/useListeningLogStatistics";
 
 const meta: Meta<typeof ListeningLogStatistics> = {
   title: "Organisms/ListeningLogStatistics",

--- a/app/components/organisms/ListeningLogStatistics.test.ts
+++ b/app/components/organisms/ListeningLogStatistics.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogStatistics from "./ListeningLogStatistics.vue";
-import type { ListeningLogStatistics as Stats } from "~/composables/useListeningLogStatistics";
+import ListeningLogStatistics from "@/components/organisms/ListeningLogStatistics.vue";
+import type { ListeningLogStatistics as Stats } from "@/composables/useListeningLogStatistics";
 
 const emptyStats: Stats = {
   total: 0,

--- a/app/components/organisms/ListeningLogStatistics.vue
+++ b/app/components/organisms/ListeningLogStatistics.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLogStatistics } from "~/composables/useListeningLogStatistics";
+import type { ListeningLogStatistics } from "@/composables/useListeningLogStatistics";
 
 const props = defineProps<{
   statistics: ListeningLogStatistics;

--- a/app/components/organisms/LoginForm.stories.ts
+++ b/app/components/organisms/LoginForm.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import LoginForm from "./LoginForm.vue";
+import LoginForm from "@/components/organisms/LoginForm.vue";
 
 const meta: Meta<typeof LoginForm> = {
   title: "Organisms/LoginForm",

--- a/app/components/organisms/LoginForm.test.ts
+++ b/app/components/organisms/LoginForm.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import LoginForm from "./LoginForm.vue";
+import LoginForm from "@/components/organisms/LoginForm.vue";
 
 const defaultErrors = { email: "", password: "", general: "" };
 

--- a/app/components/organisms/MovementListEditor.stories.ts
+++ b/app/components/organisms/MovementListEditor.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { PieceMovement } from "~/types";
-import MovementListEditor from "./MovementListEditor.vue";
+import type { PieceMovement } from "@/types";
+import MovementListEditor from "@/components/organisms/MovementListEditor.vue";
 
 const meta: Meta<typeof MovementListEditor> = {
   title: "Organisms/MovementListEditor",

--- a/app/components/organisms/MovementListEditor.test.ts
+++ b/app/components/organisms/MovementListEditor.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import MovementListEditor from "./MovementListEditor.vue";
-import type { PieceMovement } from "~/types";
+import MovementListEditor from "@/components/organisms/MovementListEditor.vue";
+import type { PieceMovement } from "@/types";
 
 const mockReplaceMovements = vi.fn();
 

--- a/app/components/organisms/MovementListEditor.vue
+++ b/app/components/organisms/MovementListEditor.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import draggable from "vuedraggable";
-import type { PieceMovement } from "~/types";
+import type { PieceMovement } from "@/types";
 
 const props = defineProps<{
   workId: string;

--- a/app/components/organisms/PieceForm.stories.ts
+++ b/app/components/organisms/PieceForm.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Composer } from "~/types";
-import PieceForm from "./PieceForm.vue";
+import type { Composer } from "@/types";
+import PieceForm from "@/components/organisms/PieceForm.vue";
 
 const meta: Meta<typeof PieceForm> = {
   title: "Organisms/PieceForm",

--- a/app/components/organisms/PieceForm.test.ts
+++ b/app/components/organisms/PieceForm.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceForm from "./PieceForm.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
-import type { Composer } from "~/types";
+import PieceForm from "@/components/organisms/PieceForm.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
+import type { Composer } from "@/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import type { Composer, CreatePieceInput, CreateWorkInput } from "~/types";
-import { PIECE_ERAS, PIECE_FORMATIONS, PIECE_GENRES, PIECE_REGIONS } from "~/types";
-import { toSelectOptions } from "~/utils/select-options";
+import type { Composer, CreatePieceInput, CreateWorkInput } from "@/types";
+import { PIECE_ERAS, PIECE_FORMATIONS, PIECE_GENRES, PIECE_REGIONS } from "@/types";
+import { toSelectOptions } from "@/utils/select-options";
 
 const genreOptions = toSelectOptions(PIECE_GENRES);
 

--- a/app/components/organisms/PieceList.stories.ts
+++ b/app/components/organisms/PieceList.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { PieceWork } from "~/types";
-import PieceList from "./PieceList.vue";
+import type { PieceWork } from "@/types";
+import PieceList from "@/components/organisms/PieceList.vue";
 
 const meta: Meta<typeof PieceList> = {
   title: "Organisms/PieceList",

--- a/app/components/organisms/PieceList.test.ts
+++ b/app/components/organisms/PieceList.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceList from "./PieceList.vue";
-import type { PieceWork } from "~/types";
+import PieceList from "@/components/organisms/PieceList.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_MOZART = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/PieceList.vue
+++ b/app/components/organisms/PieceList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 defineProps<{
   pieces: PieceWork[];

--- a/app/components/organisms/PieceListInfinite.stories.ts
+++ b/app/components/organisms/PieceListInfinite.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PieceListInfinite from "./PieceListInfinite.vue";
-import type { PieceWork } from "~/types";
+import PieceListInfinite from "@/components/organisms/PieceListInfinite.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID_BEETHOVEN = "00000000-0000-4000-8000-000000000001";
 const COMPOSER_ID_TCHAIKOVSKY = "00000000-0000-4000-8000-000000000002";

--- a/app/components/organisms/PieceListInfinite.test.ts
+++ b/app/components/organisms/PieceListInfinite.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import PieceListInfinite from "./PieceListInfinite.vue";
-import type { PieceWork } from "~/types";
+import PieceListInfinite from "@/components/organisms/PieceListInfinite.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const composerNameById = { [COMPOSER_ID]: "ベートーヴェン" };

--- a/app/components/organisms/PieceListInfinite.vue
+++ b/app/components/organisms/PieceListInfinite.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 const props = defineProps<{
   pieces: PieceWork[];

--- a/app/components/organisms/QuickLogForm.stories.ts
+++ b/app/components/organisms/QuickLogForm.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import QuickLogForm from "./QuickLogForm.vue";
+import QuickLogForm from "@/components/organisms/QuickLogForm.vue";
 
 const meta: Meta<typeof QuickLogForm> = {
   title: "Organisms/QuickLogForm",

--- a/app/components/organisms/QuickLogForm.test.ts
+++ b/app/components/organisms/QuickLogForm.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import QuickLogForm from "./QuickLogForm.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
+import QuickLogForm from "@/components/organisms/QuickLogForm.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
 
 const defaultProps = { composer: "ベートーヴェン", piece: "交響曲第9番 ニ短調" };
 

--- a/app/components/organisms/QuickLogForm.vue
+++ b/app/components/organisms/QuickLogForm.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Rating } from "~/types";
+import type { Rating } from "@/types";
 
 defineProps<{
   composer: string;

--- a/app/components/organisms/UserRegisterForm.stories.ts
+++ b/app/components/organisms/UserRegisterForm.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import UserRegisterForm from "./UserRegisterForm.vue";
+import UserRegisterForm from "@/components/organisms/UserRegisterForm.vue";
 
 const meta: Meta<typeof UserRegisterForm> = {
   title: "Organisms/UserRegisterForm",

--- a/app/components/organisms/UserRegisterForm.test.ts
+++ b/app/components/organisms/UserRegisterForm.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import UserRegisterForm from "./UserRegisterForm.vue";
+import UserRegisterForm from "@/components/organisms/UserRegisterForm.vue";
 
 const defaultErrors = { email: "", password: "" };
 

--- a/app/components/organisms/VerifyEmailForm.test.ts
+++ b/app/components/organisms/VerifyEmailForm.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import VerifyEmailForm from "./VerifyEmailForm.vue";
-import ErrorMessage from "../atoms/ErrorMessage.vue";
-import ButtonPrimary from "../atoms/ButtonPrimary.vue";
+import VerifyEmailForm from "@/components/organisms/VerifyEmailForm.vue";
+import ErrorMessage from "@/components/atoms/ErrorMessage.vue";
+import ButtonPrimary from "@/components/atoms/ButtonPrimary.vue";
 
 describe("VerifyEmailForm", () => {
   const defaultProps = {

--- a/app/components/templates/ComposerDetailTemplate.stories.ts
+++ b/app/components/templates/ComposerDetailTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
-import type { Composer, PieceWork } from "~/types";
+import ComposerDetailTemplate from "@/components/templates/ComposerDetailTemplate.vue";
+import type { Composer, PieceWork } from "@/types";
 
 const meta: Meta<typeof ComposerDetailTemplate> = {
   title: "Templates/ComposerDetailTemplate",

--- a/app/components/templates/ComposerDetailTemplate.test.ts
+++ b/app/components/templates/ComposerDetailTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerDetailTemplate from "./ComposerDetailTemplate.vue";
-import type { Composer, PieceWork } from "~/types";
+import ComposerDetailTemplate from "@/components/templates/ComposerDetailTemplate.vue";
+import type { Composer, PieceWork } from "@/types";
 
 const sample: Composer = {
   id: "1",

--- a/app/components/templates/ComposerDetailTemplate.vue
+++ b/app/components/templates/ComposerDetailTemplate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { Composer, PieceWork } from "~/types";
-import { formatLifespan } from "~/utils/lifespan";
+import type { Composer, PieceWork } from "@/types";
+import { formatLifespan } from "@/utils/lifespan";
 
 const props = defineProps<{
   composer: Composer | null;

--- a/app/components/templates/ComposerEditTemplate.stories.ts
+++ b/app/components/templates/ComposerEditTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerEditTemplate from "./ComposerEditTemplate.vue";
-import type { Composer } from "~/types";
+import ComposerEditTemplate from "@/components/templates/ComposerEditTemplate.vue";
+import type { Composer } from "@/types";
 
 const meta: Meta<typeof ComposerEditTemplate> = {
   title: "Templates/ComposerEditTemplate",

--- a/app/components/templates/ComposerEditTemplate.test.ts
+++ b/app/components/templates/ComposerEditTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerEditTemplate from "./ComposerEditTemplate.vue";
-import type { Composer } from "~/types";
+import ComposerEditTemplate from "@/components/templates/ComposerEditTemplate.vue";
+import type { Composer } from "@/types";
 
 const sample: Composer = {
   id: "1",

--- a/app/components/templates/ComposerEditTemplate.vue
+++ b/app/components/templates/ComposerEditTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer, UpdateComposerInput } from "~/types";
+import type { Composer, UpdateComposerInput } from "@/types";
 
 defineProps<{
   composer: Composer | null;

--- a/app/components/templates/ComposerNewTemplate.stories.ts
+++ b/app/components/templates/ComposerNewTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposerNewTemplate from "./ComposerNewTemplate.vue";
+import ComposerNewTemplate from "@/components/templates/ComposerNewTemplate.vue";
 
 const meta: Meta<typeof ComposerNewTemplate> = {
   title: "Templates/ComposerNewTemplate",

--- a/app/components/templates/ComposerNewTemplate.test.ts
+++ b/app/components/templates/ComposerNewTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerNewTemplate from "./ComposerNewTemplate.vue";
+import ComposerNewTemplate from "@/components/templates/ComposerNewTemplate.vue";
 
 describe("ComposerNewTemplate", () => {
   it("タイトルが表示される", async () => {

--- a/app/components/templates/ComposerNewTemplate.vue
+++ b/app/components/templates/ComposerNewTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateComposerInput } from "~/types";
+import type { CreateComposerInput } from "@/types";
 
 defineProps<{
   error: string | null;

--- a/app/components/templates/ComposersTemplate.stories.ts
+++ b/app/components/templates/ComposersTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ComposersTemplate from "./ComposersTemplate.vue";
-import type { Composer } from "~/types";
+import ComposersTemplate from "@/components/templates/ComposersTemplate.vue";
+import type { Composer } from "@/types";
 
 const meta: Meta<typeof ComposersTemplate> = {
   title: "Templates/ComposersTemplate",

--- a/app/components/templates/ComposersTemplate.test.ts
+++ b/app/components/templates/ComposersTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposersTemplate from "./ComposersTemplate.vue";
+import ComposersTemplate from "@/components/templates/ComposersTemplate.vue";
 
 describe("ComposersTemplate", () => {
   it("管理者の場合 '+ 新しい作曲家' リンクが表示される", async () => {

--- a/app/components/templates/ComposersTemplate.vue
+++ b/app/components/templates/ComposersTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
+import type { Composer } from "@/types";
 
 const props = defineProps<{
   composers: Composer[];

--- a/app/components/templates/ConcertLogDetailTemplate.stories.ts
+++ b/app/components/templates/ConcertLogDetailTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog } from "~/types";
-import ConcertLogDetailTemplate from "./ConcertLogDetailTemplate.vue";
+import type { ConcertLog } from "@/types";
+import ConcertLogDetailTemplate from "@/components/templates/ConcertLogDetailTemplate.vue";
 
 const meta: Meta<typeof ConcertLogDetailTemplate> = {
   title: "Templates/ConcertLogDetailTemplate",

--- a/app/components/templates/ConcertLogDetailTemplate.test.ts
+++ b/app/components/templates/ConcertLogDetailTemplate.test.ts
@@ -1,9 +1,9 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ConcertLogDetailTemplate from "./ConcertLogDetailTemplate.vue";
-import ButtonDanger from "~/components/atoms/ButtonDanger.vue";
-import ButtonSecondary from "~/components/atoms/ButtonSecondary.vue";
-import type { ConcertLog, PieceWork } from "~/types";
+import ConcertLogDetailTemplate from "@/components/templates/ConcertLogDetailTemplate.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import type { ConcertLog, PieceWork } from "@/types";
 
 const mockDeleteLog = vi.fn();
 

--- a/app/components/templates/ConcertLogDetailTemplate.vue
+++ b/app/components/templates/ConcertLogDetailTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ConcertLog } from "~/types";
+import type { ConcertLog } from "@/types";
 
 const props = defineProps<{
   log: ConcertLog;

--- a/app/components/templates/ConcertLogEditTemplate.stories.ts
+++ b/app/components/templates/ConcertLogEditTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog } from "~/types";
-import ConcertLogEditTemplate from "./ConcertLogEditTemplate.vue";
+import type { ConcertLog } from "@/types";
+import ConcertLogEditTemplate from "@/components/templates/ConcertLogEditTemplate.vue";
 
 const meta: Meta<typeof ConcertLogEditTemplate> = {
   title: "Templates/ConcertLogEditTemplate",

--- a/app/components/templates/ConcertLogEditTemplate.test.ts
+++ b/app/components/templates/ConcertLogEditTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogEditTemplate from "./ConcertLogEditTemplate.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogEditTemplate from "@/components/templates/ConcertLogEditTemplate.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLog: ConcertLog = {
   id: "log-1",

--- a/app/components/templates/ConcertLogEditTemplate.vue
+++ b/app/components/templates/ConcertLogEditTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ConcertLog, UpdateConcertLogInput } from "~/types";
+import type { ConcertLog, UpdateConcertLogInput } from "@/types";
 
 defineProps<{
   log: ConcertLog;

--- a/app/components/templates/ConcertLogNewTemplate.stories.ts
+++ b/app/components/templates/ConcertLogNewTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ConcertLogNewTemplate from "./ConcertLogNewTemplate.vue";
+import ConcertLogNewTemplate from "@/components/templates/ConcertLogNewTemplate.vue";
 
 const meta: Meta<typeof ConcertLogNewTemplate> = {
   title: "Templates/ConcertLogNewTemplate",

--- a/app/components/templates/ConcertLogNewTemplate.test.ts
+++ b/app/components/templates/ConcertLogNewTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogNewTemplate from "./ConcertLogNewTemplate.vue";
+import ConcertLogNewTemplate from "@/components/templates/ConcertLogNewTemplate.vue";
 
 describe("ConcertLogNewTemplate", () => {
   it("ページタイトルが表示される", async () => {

--- a/app/components/templates/ConcertLogNewTemplate.vue
+++ b/app/components/templates/ConcertLogNewTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateConcertLogInput } from "~/types";
+import type { CreateConcertLogInput } from "@/types";
 
 defineProps<{
   error: string | null;

--- a/app/components/templates/ConcertLogsTemplate.stories.ts
+++ b/app/components/templates/ConcertLogsTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ConcertLog } from "~/types";
-import ConcertLogsTemplate from "./ConcertLogsTemplate.vue";
+import type { ConcertLog } from "@/types";
+import ConcertLogsTemplate from "@/components/templates/ConcertLogsTemplate.vue";
 
 const meta: Meta<typeof ConcertLogsTemplate> = {
   title: "Templates/ConcertLogsTemplate",

--- a/app/components/templates/ConcertLogsTemplate.test.ts
+++ b/app/components/templates/ConcertLogsTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogsTemplate from "./ConcertLogsTemplate.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogsTemplate from "@/components/templates/ConcertLogsTemplate.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLogs: ConcertLog[] = [
   {

--- a/app/components/templates/ConcertLogsTemplate.vue
+++ b/app/components/templates/ConcertLogsTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ConcertLog } from "~/types";
+import type { ConcertLog } from "@/types";
 
 const props = defineProps<{
   logs: ConcertLog[];

--- a/app/components/templates/HomeTemplate.stories.ts
+++ b/app/components/templates/HomeTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import HomeTemplate from "./HomeTemplate.vue";
+import HomeTemplate from "@/components/templates/HomeTemplate.vue";
 
 const meta: Meta<typeof HomeTemplate> = {
   title: "Templates/HomeTemplate",

--- a/app/components/templates/HomeTemplate.test.ts
+++ b/app/components/templates/HomeTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import HomeTemplate from "./HomeTemplate.vue";
+import HomeTemplate from "@/components/templates/HomeTemplate.vue";
 
 const stubs = { FeaturedPiece: true };
 

--- a/app/components/templates/HomeTemplate.vue
+++ b/app/components/templates/HomeTemplate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
-import FeaturedPiece from "~/components/organisms/FeaturedPiece.vue";
+import type { PieceWork } from "@/types";
+import FeaturedPiece from "@/components/organisms/FeaturedPiece.vue";
 
 defineProps<{
   pieces: PieceWork[];

--- a/app/components/templates/ListeningLogDetailTemplate.stories.ts
+++ b/app/components/templates/ListeningLogDetailTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import ListeningLogDetailTemplate from "./ListeningLogDetailTemplate.vue";
+import type { ListeningLog } from "@/types";
+import ListeningLogDetailTemplate from "@/components/templates/ListeningLogDetailTemplate.vue";
 
 const meta: Meta<typeof ListeningLogDetailTemplate> = {
   title: "Templates/ListeningLogDetailTemplate",

--- a/app/components/templates/ListeningLogDetailTemplate.test.ts
+++ b/app/components/templates/ListeningLogDetailTemplate.test.ts
@@ -1,9 +1,9 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ListeningLogDetailTemplate from "./ListeningLogDetailTemplate.vue";
-import ButtonDanger from "~/components/atoms/ButtonDanger.vue";
-import ButtonSecondary from "~/components/atoms/ButtonSecondary.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogDetailTemplate from "@/components/templates/ListeningLogDetailTemplate.vue";
+import ButtonDanger from "@/components/atoms/ButtonDanger.vue";
+import ButtonSecondary from "@/components/atoms/ButtonSecondary.vue";
+import type { ListeningLog } from "@/types";
 
 const mockDeleteLog = vi.fn();
 

--- a/app/components/templates/ListeningLogDetailTemplate.vue
+++ b/app/components/templates/ListeningLogDetailTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLog } from "~/types";
+import type { ListeningLog } from "@/types";
 
 const props = defineProps<{
   log: ListeningLog;

--- a/app/components/templates/ListeningLogEditTemplate.stories.ts
+++ b/app/components/templates/ListeningLogEditTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import ListeningLogEditTemplate from "./ListeningLogEditTemplate.vue";
+import type { ListeningLog } from "@/types";
+import ListeningLogEditTemplate from "@/components/templates/ListeningLogEditTemplate.vue";
 
 const meta: Meta<typeof ListeningLogEditTemplate> = {
   title: "Templates/ListeningLogEditTemplate",

--- a/app/components/templates/ListeningLogEditTemplate.test.ts
+++ b/app/components/templates/ListeningLogEditTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import ListeningLogEditTemplate from "./ListeningLogEditTemplate.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogEditTemplate from "@/components/templates/ListeningLogEditTemplate.vue";
+import type { ListeningLog } from "@/types";
 
 const { PIECE_ID, COMPOSER_ID } = vi.hoisted(() => ({
   PIECE_ID: "00000000-0000-4000-8000-00000000aaaa",

--- a/app/components/templates/ListeningLogEditTemplate.vue
+++ b/app/components/templates/ListeningLogEditTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateListeningLogInput, ListeningLog, UpdateListeningLogInput } from "~/types";
+import type { CreateListeningLogInput, ListeningLog, UpdateListeningLogInput } from "@/types";
 
 const props = defineProps<{
   log: ListeningLog;

--- a/app/components/templates/ListeningLogNewTemplate.stories.ts
+++ b/app/components/templates/ListeningLogNewTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ListeningLogNewTemplate from "./ListeningLogNewTemplate.vue";
+import ListeningLogNewTemplate from "@/components/templates/ListeningLogNewTemplate.vue";
 
 const meta: Meta<typeof ListeningLogNewTemplate> = {
   title: "Templates/ListeningLogNewTemplate",

--- a/app/components/templates/ListeningLogNewTemplate.test.ts
+++ b/app/components/templates/ListeningLogNewTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import ListeningLogNewTemplate from "./ListeningLogNewTemplate.vue";
+import ListeningLogNewTemplate from "@/components/templates/ListeningLogNewTemplate.vue";
 
 mockNuxtImport("usePiecesAll", () =>
   vi

--- a/app/components/templates/ListeningLogNewTemplate.vue
+++ b/app/components/templates/ListeningLogNewTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateListeningLogInput } from "~/types";
+import type { CreateListeningLogInput } from "@/types";
 
 defineProps<{
   error: string | null;

--- a/app/components/templates/ListeningLogStatisticsTemplate.stories.ts
+++ b/app/components/templates/ListeningLogStatisticsTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import ListeningLogStatisticsTemplate from "./ListeningLogStatisticsTemplate.vue";
-import type { ListeningLogStatistics } from "~/composables/useListeningLogStatistics";
+import ListeningLogStatisticsTemplate from "@/components/templates/ListeningLogStatisticsTemplate.vue";
+import type { ListeningLogStatistics } from "@/composables/useListeningLogStatistics";
 
 const meta: Meta<typeof ListeningLogStatisticsTemplate> = {
   title: "Templates/ListeningLogStatisticsTemplate",

--- a/app/components/templates/ListeningLogStatisticsTemplate.test.ts
+++ b/app/components/templates/ListeningLogStatisticsTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogStatisticsTemplate from "./ListeningLogStatisticsTemplate.vue";
-import type { ListeningLogStatistics } from "~/composables/useListeningLogStatistics";
+import ListeningLogStatisticsTemplate from "@/components/templates/ListeningLogStatisticsTemplate.vue";
+import type { ListeningLogStatistics } from "@/composables/useListeningLogStatistics";
 
 const stats: ListeningLogStatistics = {
   total: 3,

--- a/app/components/templates/ListeningLogStatisticsTemplate.vue
+++ b/app/components/templates/ListeningLogStatisticsTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLogStatistics } from "~/composables/useListeningLogStatistics";
+import type { ListeningLogStatistics } from "@/composables/useListeningLogStatistics";
 
 defineProps<{
   statistics: ListeningLogStatistics;

--- a/app/components/templates/ListeningLogsTemplate.stories.ts
+++ b/app/components/templates/ListeningLogsTemplate.stories.ts
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog } from "~/types";
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
-import ListeningLogsTemplate from "./ListeningLogsTemplate.vue";
+import type { ListeningLog } from "@/types";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
+import ListeningLogsTemplate from "@/components/templates/ListeningLogsTemplate.vue";
 
 const meta: Meta<typeof ListeningLogsTemplate> = {
   title: "Templates/ListeningLogsTemplate",

--- a/app/components/templates/ListeningLogsTemplate.test.ts
+++ b/app/components/templates/ListeningLogsTemplate.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ListeningLogsTemplate from "./ListeningLogsTemplate.vue";
-import type { ListeningLog } from "~/types";
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
+import ListeningLogsTemplate from "@/components/templates/ListeningLogsTemplate.vue";
+import type { ListeningLog } from "@/types";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
 
 const sampleLogs: ListeningLog[] = [
   {

--- a/app/components/templates/ListeningLogsTemplate.vue
+++ b/app/components/templates/ListeningLogsTemplate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { ListeningLog } from "~/types";
-import type { ListeningLogFilterState } from "~/composables/useListeningLogFilter";
+import type { ListeningLog } from "@/types";
+import type { ListeningLogFilterState } from "@/composables/useListeningLogFilter";
 
 const props = defineProps<{
   logs: ListeningLog[];

--- a/app/components/templates/LoginTemplate.stories.ts
+++ b/app/components/templates/LoginTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import LoginTemplate from "./LoginTemplate.vue";
+import LoginTemplate from "@/components/templates/LoginTemplate.vue";
 
 const meta: Meta<typeof LoginTemplate> = {
   title: "Templates/LoginTemplate",

--- a/app/components/templates/LoginTemplate.test.ts
+++ b/app/components/templates/LoginTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import LoginTemplate from "./LoginTemplate.vue";
+import LoginTemplate from "@/components/templates/LoginTemplate.vue";
 
 const defaultErrors = { email: "", password: "", general: "" };
 

--- a/app/components/templates/PieceDetailTemplate.stories.ts
+++ b/app/components/templates/PieceDetailTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { ListeningLog, PieceMovement, PieceWork } from "~/types";
-import PieceDetailTemplate from "./PieceDetailTemplate.vue";
+import type { ListeningLog, PieceMovement, PieceWork } from "@/types";
+import PieceDetailTemplate from "@/components/templates/PieceDetailTemplate.vue";
 
 const meta: Meta<typeof PieceDetailTemplate> = {
   title: "Templates/PieceDetailTemplate",

--- a/app/components/templates/PieceDetailTemplate.test.ts
+++ b/app/components/templates/PieceDetailTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceDetailTemplate from "./PieceDetailTemplate.vue";
-import type { ListeningLog, PieceMovement, PieceWork } from "~/types";
+import PieceDetailTemplate from "@/components/templates/PieceDetailTemplate.vue";
+import type { ListeningLog, PieceMovement, PieceWork } from "@/types";
 
 const pieceWithVideo: PieceWork = {
   kind: "work",

--- a/app/components/templates/PieceDetailTemplate.vue
+++ b/app/components/templates/PieceDetailTemplate.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { formatDate } from "~/utils/date";
-import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "~/types";
+import { formatDate } from "@/utils/date";
+import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "@/types";
 
 const props = defineProps<{
   piece: Piece | null;

--- a/app/components/templates/PieceEditTemplate.stories.ts
+++ b/app/components/templates/PieceEditTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { Composer, PieceMovement, PieceWork } from "~/types";
-import PieceEditTemplate from "./PieceEditTemplate.vue";
+import type { Composer, PieceMovement, PieceWork } from "@/types";
+import PieceEditTemplate from "@/components/templates/PieceEditTemplate.vue";
 
 const meta: Meta<typeof PieceEditTemplate> = {
   title: "Templates/PieceEditTemplate",

--- a/app/components/templates/PieceEditTemplate.test.ts
+++ b/app/components/templates/PieceEditTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceEditTemplate from "./PieceEditTemplate.vue";
-import type { Composer, PieceMovement, PieceWork } from "~/types";
+import PieceEditTemplate from "@/components/templates/PieceEditTemplate.vue";
+import type { Composer, PieceMovement, PieceWork } from "@/types";
 
 const mockReplaceMovements = vi.fn();
 

--- a/app/components/templates/PieceEditTemplate.vue
+++ b/app/components/templates/PieceEditTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer, PieceMovement, PieceWork, UpdatePieceInput } from "~/types";
+import type { Composer, PieceMovement, PieceWork, UpdatePieceInput } from "@/types";
 
 defineProps<{
   piece: PieceWork | null;

--- a/app/components/templates/PieceNewTemplate.stories.ts
+++ b/app/components/templates/PieceNewTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import PieceNewTemplate from "./PieceNewTemplate.vue";
+import PieceNewTemplate from "@/components/templates/PieceNewTemplate.vue";
 
 const meta: Meta<typeof PieceNewTemplate> = {
   title: "Templates/PieceNewTemplate",

--- a/app/components/templates/PieceNewTemplate.test.ts
+++ b/app/components/templates/PieceNewTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PieceNewTemplate from "./PieceNewTemplate.vue";
+import PieceNewTemplate from "@/components/templates/PieceNewTemplate.vue";
 
 const commonProps = { error: null, composers: [] } as const;
 

--- a/app/components/templates/PieceNewTemplate.vue
+++ b/app/components/templates/PieceNewTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer, CreatePieceInput } from "~/types";
+import type { Composer, CreatePieceInput } from "@/types";
 
 defineProps<{
   error: string | null;

--- a/app/components/templates/PiecesTemplate.stories.ts
+++ b/app/components/templates/PiecesTemplate.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import type { PieceWork } from "~/types";
-import PiecesTemplate from "./PiecesTemplate.vue";
+import type { PieceWork } from "@/types";
+import PiecesTemplate from "@/components/templates/PiecesTemplate.vue";
 
 const meta: Meta<typeof PiecesTemplate> = {
   title: "Templates/PiecesTemplate",

--- a/app/components/templates/PiecesTemplate.test.ts
+++ b/app/components/templates/PiecesTemplate.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import PiecesTemplate from "./PiecesTemplate.vue";
-import type { PieceWork } from "~/types";
+import PiecesTemplate from "@/components/templates/PiecesTemplate.vue";
+import type { PieceWork } from "@/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const composerNameById = { [COMPOSER_ID]: "ベートーヴェン" };

--- a/app/components/templates/PiecesTemplate.vue
+++ b/app/components/templates/PiecesTemplate.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 const props = defineProps<{
   pieces: PieceWork[];

--- a/app/components/templates/UserRegisterTemplate.stories.ts
+++ b/app/components/templates/UserRegisterTemplate.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import UserRegisterTemplate from "./UserRegisterTemplate.vue";
+import UserRegisterTemplate from "@/components/templates/UserRegisterTemplate.vue";
 
 const meta: Meta<typeof UserRegisterTemplate> = {
   title: "Templates/UserRegisterTemplate",

--- a/app/components/templates/UserRegisterTemplate.test.ts
+++ b/app/components/templates/UserRegisterTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import UserRegisterTemplate from "./UserRegisterTemplate.vue";
+import UserRegisterTemplate from "@/components/templates/UserRegisterTemplate.vue";
 
 const defaultErrors = { email: "", password: "" };
 

--- a/app/components/templates/VerifyEmailTemplate.test.ts
+++ b/app/components/templates/VerifyEmailTemplate.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import VerifyEmailTemplate from "./VerifyEmailTemplate.vue";
+import VerifyEmailTemplate from "@/components/templates/VerifyEmailTemplate.vue";
 
 describe("VerifyEmailTemplate", () => {
   it("VerifyEmailForm が表示される", async () => {

--- a/app/composables/useAuth.test.ts
+++ b/app/composables/useAuth.test.ts
@@ -4,7 +4,7 @@ import {
   ID_TOKEN_KEY,
   REFRESH_TOKEN_KEY,
   TOKEN_EXPIRES_AT_KEY,
-} from "./useAuth";
+} from "@/composables/useAuth";
 
 const mockFetch = vi.fn();
 const mockRouterPush = vi.fn();

--- a/app/composables/useAuth.ts
+++ b/app/composables/useAuth.ts
@@ -1,6 +1,6 @@
 import { useRouter } from "#app";
-import { useApiBase } from "./useApiBase";
-import { useCognitoConfig } from "./useCognitoConfig";
+import { useApiBase } from "@/composables/useApiBase";
+import { useCognitoConfig } from "@/composables/useCognitoConfig";
 
 const ADMIN_GROUP_NAME = "admin";
 

--- a/app/composables/useAuthenticatedApi.ts
+++ b/app/composables/useAuthenticatedApi.ts
@@ -1,5 +1,5 @@
 import { useRouter } from "#app";
-import { useAuth, ID_TOKEN_KEY } from "./useAuth";
+import { useAuth, ID_TOKEN_KEY } from "@/composables/useAuth";
 
 export const useAuthenticatedApi = () => {
   const router = useRouter();

--- a/app/composables/useComposers.test.ts
+++ b/app/composables/useComposers.test.ts
@@ -1,8 +1,8 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { useComposersAll, useComposer } from "./useComposers";
-import type { Composer } from "~/types";
-import { COMPOSERS_PAGE_SIZE_MAX } from "~/types";
-import { ID_TOKEN_KEY } from "./useAuth";
+import { useComposersAll, useComposer } from "@/composables/useComposers";
+import type { Composer } from "@/types";
+import { COMPOSERS_PAGE_SIZE_MAX } from "@/types";
+import { ID_TOKEN_KEY } from "@/composables/useAuth";
 
 const { mockUseFetch } = vi.hoisted(() => ({
   mockUseFetch: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock("#app", () => ({
 }));
 
 vi.mock("./useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({

--- a/app/composables/useComposers.ts
+++ b/app/composables/useComposers.ts
@@ -1,7 +1,7 @@
-import { COMPOSERS_PAGE_SIZE_MAX } from "~/types";
-import type { Composer, CreateComposerInput, UpdateComposerInput } from "~/types";
-import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { fetchCursorPage } from "./usePaginatedList";
+import { COMPOSERS_PAGE_SIZE_MAX } from "@/types";
+import type { Composer, CreateComposerInput, UpdateComposerInput } from "@/types";
+import { useAuthenticatedApi } from "@/composables/useAuthenticatedApi";
+import { fetchCursorPage } from "@/composables/usePaginatedList";
 
 const fetchComposersPage = (apiBase: string, options: { limit: number; cursor?: string }) =>
   fetchCursorPage<Composer>(`${apiBase}/composers`, options);

--- a/app/composables/useConcertLogs.test.ts
+++ b/app/composables/useConcertLogs.test.ts
@@ -1,6 +1,11 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { useConcertLogs } from "./useConcertLogs";
-import { ACCESS_TOKEN_KEY, ID_TOKEN_KEY, REFRESH_TOKEN_KEY, TOKEN_EXPIRES_AT_KEY } from "./useAuth";
+import { useConcertLogs } from "@/composables/useConcertLogs";
+import {
+  ACCESS_TOKEN_KEY,
+  ID_TOKEN_KEY,
+  REFRESH_TOKEN_KEY,
+  TOKEN_EXPIRES_AT_KEY,
+} from "@/composables/useAuth";
 
 const mockFetch = vi.fn();
 const mockRouterPush = vi.fn();
@@ -15,7 +20,7 @@ vi.mock("#app", () => ({
 }));
 
 vi.mock("./useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({

--- a/app/composables/useConcertLogs.ts
+++ b/app/composables/useConcertLogs.ts
@@ -1,5 +1,5 @@
-import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "~/types";
-import { useCrudResource, useCrudResourceItem } from "./useCrudResource";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "@/types";
+import { useCrudResource, useCrudResourceItem } from "@/composables/useCrudResource";
 
 export const useConcertLogs = () => {
   const { deleteItem, ...rest } = useCrudResource<

--- a/app/composables/useCrudResource.ts
+++ b/app/composables/useCrudResource.ts
@@ -1,4 +1,4 @@
-import { useAuthenticatedApi } from "./useAuthenticatedApi";
+import { useAuthenticatedApi } from "@/composables/useAuthenticatedApi";
 
 /**
  * 認証付きで単一のリソースエンドポイントに対する CRUD 操作を提供する汎用 composable。

--- a/app/composables/useListeningLogFilter.test.ts
+++ b/app/composables/useListeningLogFilter.test.ts
@@ -1,5 +1,5 @@
-import { filterListeningLogs, useListeningLogFilter } from "./useListeningLogFilter";
-import type { ListeningLog } from "~/types";
+import { filterListeningLogs, useListeningLogFilter } from "@/composables/useListeningLogFilter";
+import type { ListeningLog } from "@/types";
 
 const log = (overrides: Partial<ListeningLog> = {}): ListeningLog => ({
   id: "log-1",

--- a/app/composables/useListeningLogFilter.ts
+++ b/app/composables/useListeningLogFilter.ts
@@ -1,5 +1,5 @@
 import type { Ref } from "vue";
-import type { ListeningLog, Rating } from "~/types";
+import type { ListeningLog, Rating } from "@/types";
 
 export type ListeningLogFilterState = {
   keyword: string;

--- a/app/composables/useListeningLogStatistics.test.ts
+++ b/app/composables/useListeningLogStatistics.test.ts
@@ -1,5 +1,8 @@
-import { computeStatistics, useListeningLogStatistics } from "./useListeningLogStatistics";
-import type { ListeningLog } from "~/types";
+import {
+  computeStatistics,
+  useListeningLogStatistics,
+} from "@/composables/useListeningLogStatistics";
+import type { ListeningLog } from "@/types";
 
 const log = (overrides: Partial<ListeningLog> = {}): ListeningLog => ({
   id: "log-1",

--- a/app/composables/useListeningLogStatistics.ts
+++ b/app/composables/useListeningLogStatistics.ts
@@ -1,5 +1,5 @@
 import type { Ref } from "vue";
-import type { ListeningLog, Rating } from "~/types";
+import type { ListeningLog, Rating } from "@/types";
 
 export type RatingDistribution = Record<1 | 2 | 3 | 4 | 5, number>;
 

--- a/app/composables/useListeningLogs.test.ts
+++ b/app/composables/useListeningLogs.test.ts
@@ -1,6 +1,11 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { useListeningLogs } from "./useListeningLogs";
-import { ACCESS_TOKEN_KEY, ID_TOKEN_KEY, REFRESH_TOKEN_KEY, TOKEN_EXPIRES_AT_KEY } from "./useAuth";
+import { useListeningLogs } from "@/composables/useListeningLogs";
+import {
+  ACCESS_TOKEN_KEY,
+  ID_TOKEN_KEY,
+  REFRESH_TOKEN_KEY,
+  TOKEN_EXPIRES_AT_KEY,
+} from "@/composables/useAuth";
 
 const mockFetch = vi.fn();
 const mockRouterPush = vi.fn();
@@ -15,7 +20,7 @@ vi.mock("#app", () => ({
 }));
 
 vi.mock("./useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({

--- a/app/composables/useListeningLogs.ts
+++ b/app/composables/useListeningLogs.ts
@@ -1,6 +1,6 @@
-import type { CreateListeningLogInput, ListeningLog, UpdateListeningLogInput } from "~/types";
-import { useCrudResource, useCrudResourceItem } from "./useCrudResource";
-import { useAuthenticatedApi } from "./useAuthenticatedApi";
+import type { CreateListeningLogInput, ListeningLog, UpdateListeningLogInput } from "@/types";
+import { useCrudResource, useCrudResourceItem } from "@/composables/useCrudResource";
+import { useAuthenticatedApi } from "@/composables/useAuthenticatedApi";
 
 export const useListeningLogs = () => {
   const { deleteItem, ...rest } = useCrudResource<

--- a/app/composables/useMovements.ts
+++ b/app/composables/useMovements.ts
@@ -1,5 +1,5 @@
-import type { PieceMovement } from "~/types";
-import { useAuthenticatedApi } from "./useAuthenticatedApi";
+import type { PieceMovement } from "@/types";
+import { useAuthenticatedApi } from "@/composables/useAuthenticatedApi";
 
 /**
  * 親 Work 配下の楽章一覧を取得する composable。

--- a/app/composables/usePieces.test.ts
+++ b/app/composables/usePieces.test.ts
@@ -1,13 +1,13 @@
 import { mockNuxtImport } from "@nuxt/test-utils/runtime";
-import { usePiecesPaginated, usePiecesAll, usePiece } from "./usePieces";
-import type { PageResult } from "./usePaginatedList";
-import type { PieceWork } from "~/types";
-import { ID_TOKEN_KEY } from "./useAuth";
+import { usePiecesPaginated, usePiecesAll, usePiece } from "@/composables/usePieces";
+import type { PageResult } from "@/composables/usePaginatedList";
+import type { PieceWork } from "@/types";
+import { ID_TOKEN_KEY } from "@/composables/useAuth";
 import {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_ALL_MAX_EMPTY_PAGES,
   PIECES_ALL_MAX_TOTAL,
-} from "~/types";
+} from "@/types";
 
 const { mockUseFetch } = vi.hoisted(() => ({
   mockUseFetch: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock("#app", () => ({
 }));
 
 vi.mock("./useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("./useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({

--- a/app/composables/usePieces.ts
+++ b/app/composables/usePieces.ts
@@ -2,10 +2,10 @@ import {
   PIECES_ALL_MAX_EMPTY_PAGES,
   PIECES_ALL_MAX_TOTAL,
   PIECES_PAGE_SIZE_DEFAULT,
-} from "~/types";
-import type { CreatePieceInput, Piece, PieceWork, UpdatePieceInput } from "~/types";
-import { useAuthenticatedApi } from "./useAuthenticatedApi";
-import { fetchCursorPage, usePaginatedList } from "./usePaginatedList";
+} from "@/types";
+import type { CreatePieceInput, Piece, PieceWork, UpdatePieceInput } from "@/types";
+import { useAuthenticatedApi } from "@/composables/useAuthenticatedApi";
+import { fetchCursorPage, usePaginatedList } from "@/composables/usePaginatedList";
 
 // `GET /pieces` は root の Work のみを返す（楽章は `GET /pieces/{id}/children` 経由）。
 const fetchPiecesPage = (apiBase: string, options: { limit: number; cursor?: string }) =>

--- a/app/composables/useRatingDisplay.test.ts
+++ b/app/composables/useRatingDisplay.test.ts
@@ -1,4 +1,4 @@
-import { useRatingDisplay } from "./useRatingDisplay";
+import { useRatingDisplay } from "@/composables/useRatingDisplay";
 
 describe("useRatingDisplay", () => {
   it("ratingStars: 評価0のとき☆5つを返す", () => {

--- a/app/layouts/auth.stories.ts
+++ b/app/layouts/auth.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import AuthLayout from "./auth.vue";
+import AuthLayout from "@/layouts/auth.vue";
 
 const meta: Meta<typeof AuthLayout> = {
   title: "Layouts/AuthLayout",

--- a/app/layouts/auth.test.ts
+++ b/app/layouts/auth.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import AuthLayout from "./auth.vue";
+import AuthLayout from "@/layouts/auth.vue";
 
 const colorModeState = reactive({
   preference: "light",

--- a/app/layouts/default.stories.ts
+++ b/app/layouts/default.stories.ts
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from "@storybook-vue/nuxt";
-import DefaultLayout from "./default.vue";
+import DefaultLayout from "@/layouts/default.vue";
 
 const meta: Meta<typeof DefaultLayout> = {
   title: "Layouts/DefaultLayout",

--- a/app/layouts/default.test.ts
+++ b/app/layouts/default.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
-import DefaultLayout from "./default.vue";
+import DefaultLayout from "@/layouts/default.vue";
 
 const mockLogout = vi.fn();
 const mockIsAuthenticated = vi.fn();

--- a/app/middleware/admin.test.ts
+++ b/app/middleware/admin.test.ts
@@ -1,4 +1,4 @@
-import { ID_TOKEN_KEY } from "~/composables/useAuth";
+import { ID_TOKEN_KEY } from "@/composables/useAuth";
 
 const { mockNavigateTo, mockIsAdmin } = vi.hoisted(() => ({
   mockNavigateTo: vi.fn(),
@@ -14,7 +14,7 @@ vi.mock("#app/composables/router", async (importOriginal) => {
 });
 
 vi.mock("~/composables/useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/composables/useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({
@@ -30,7 +30,7 @@ beforeEach(() => {
 });
 
 async function runMiddleware(path: string) {
-  const { default: adminMiddleware } = await import("./admin");
+  const { default: adminMiddleware } = await import("@/middleware/admin");
   const to = { path, fullPath: path, query: {} } as Parameters<typeof adminMiddleware>[0];
   const from = {} as Parameters<typeof adminMiddleware>[1];
   return adminMiddleware(to, from);

--- a/app/middleware/auth.test.ts
+++ b/app/middleware/auth.test.ts
@@ -3,7 +3,7 @@ import {
   ID_TOKEN_KEY,
   TOKEN_EXPIRES_AT_KEY,
   REFRESH_TOKEN_KEY,
-} from "~/composables/useAuth";
+} from "@/composables/useAuth";
 
 const { mockNavigateTo, mockRefreshTokens, mockIsTokenExpired } = vi.hoisted(() => ({
   mockNavigateTo: vi.fn(),
@@ -20,7 +20,7 @@ vi.mock("#app/composables/router", async (importOriginal) => {
 });
 
 vi.mock("~/composables/useAuth", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("~/composables/useAuth")>();
+  const actual = await importOriginal<typeof import("@/composables/useAuth")>();
   return {
     ...actual,
     useAuth: () => ({
@@ -59,7 +59,7 @@ beforeEach(() => {
 });
 
 async function runMiddleware(path: string) {
-  const { default: authMiddleware } = await import("./auth");
+  const { default: authMiddleware } = await import("@/middleware/auth");
   const to = { path, fullPath: path, query: {} } as Parameters<typeof authMiddleware>[0];
   const from = {} as Parameters<typeof authMiddleware>[1];
   return authMiddleware(to, from);

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -1,4 +1,4 @@
-import { ACCESS_TOKEN_KEY } from "~/composables/useAuth";
+import { ACCESS_TOKEN_KEY } from "@/composables/useAuth";
 
 export default defineNuxtRouteMiddleware(async () => {
   if (import.meta.server) {

--- a/app/pages/auth/callback.test.ts
+++ b/app/pages/auth/callback.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import CallbackPage from "./callback.vue";
+import CallbackPage from "@/pages/auth/callback.vue";
 
 const mockHandleOAuthCallback = vi.fn();
 

--- a/app/pages/auth/login.test.ts
+++ b/app/pages/auth/login.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import LoginPage from "./login.vue";
+import LoginPage from "@/pages/auth/login.vue";
 
 const mockLogin = vi.fn();
 

--- a/app/pages/auth/user-register.test.ts
+++ b/app/pages/auth/user-register.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import UserRegisterPage from "./user-register.vue";
+import UserRegisterPage from "@/pages/auth/user-register.vue";
 
 const mockRegister = vi.fn();
 const mockValidateEmail = vi.fn();

--- a/app/pages/auth/verify-email.test.ts
+++ b/app/pages/auth/verify-email.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import VerifyEmailPage from "./verify-email.vue";
+import VerifyEmailPage from "@/pages/auth/verify-email.vue";
 
 const mockVerifyEmail = vi.fn();
 const mockResendVerificationCode = vi.fn();

--- a/app/pages/composers/[id]/edit.test.ts
+++ b/app/pages/composers/[id]/edit.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ComposerEditPage from "./edit.vue";
-import type { Composer, UpdateComposerInput } from "~/types";
+import ComposerEditPage from "@/pages/composers/[id]/edit.vue";
+import type { Composer, UpdateComposerInput } from "@/types";
 
 const mockUpdateComposer = vi.fn();
 

--- a/app/pages/composers/[id]/edit.vue
+++ b/app/pages/composers/[id]/edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { UpdateComposerInput } from "~/types";
+import type { UpdateComposerInput } from "@/types";
 
 definePageMeta({ middleware: ["admin"] });
 

--- a/app/pages/composers/[id]/index.test.ts
+++ b/app/pages/composers/[id]/index.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ComposerDetailPage from "./index.vue";
-import type { Composer } from "~/types";
+import ComposerDetailPage from "@/pages/composers/[id]/index.vue";
+import type { Composer } from "@/types";
 
 const sampleComposer: Composer = {
   id: "composer-1",

--- a/app/pages/composers/[id]/index.vue
+++ b/app/pages/composers/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
+import type { Composer } from "@/types";
 
 const route = useRoute();
 const composerId = computed(() => route.params.id as string);

--- a/app/pages/composers/index.test.ts
+++ b/app/pages/composers/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ComposersPage from "./index.vue";
-import type { Composer } from "~/types";
+import ComposersPage from "@/pages/composers/index.vue";
+import type { Composer } from "@/types";
 
 const { sampleComposers, mockRefresh, mockDeleteComposer } = vi.hoisted(() => {
   const sampleComposers: Composer[] = [

--- a/app/pages/composers/index.vue
+++ b/app/pages/composers/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { Composer } from "~/types";
+import type { Composer } from "@/types";
 
 const router = useRouter();
 const { data, pending, error, refresh, deleteComposer } = useComposersAll();

--- a/app/pages/composers/new.test.ts
+++ b/app/pages/composers/new.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ComposerNewPage from "./new.vue";
-import type { CreateComposerInput } from "~/types";
+import ComposerNewPage from "@/pages/composers/new.vue";
+import type { CreateComposerInput } from "@/types";
 
 const mockCreateComposer = vi.fn();
 

--- a/app/pages/composers/new.vue
+++ b/app/pages/composers/new.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateComposerInput } from "~/types";
+import type { CreateComposerInput } from "@/types";
 
 definePageMeta({ middleware: ["admin"] });
 

--- a/app/pages/concert-logs/[id]/edit.test.ts
+++ b/app/pages/concert-logs/[id]/edit.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ConcertLogEditPage from "./edit.vue";
-import type { ConcertLog, UpdateConcertLogInput } from "~/types";
+import ConcertLogEditPage from "@/pages/concert-logs/[id]/edit.vue";
+import type { ConcertLog, UpdateConcertLogInput } from "@/types";
 
 const mockUpdate = vi.fn();
 

--- a/app/pages/concert-logs/[id]/edit.vue
+++ b/app/pages/concert-logs/[id]/edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { UpdateConcertLogInput } from "~/types";
+import type { UpdateConcertLogInput } from "@/types";
 
 definePageMeta({ middleware: "auth" });
 

--- a/app/pages/concert-logs/[id]/index.test.ts
+++ b/app/pages/concert-logs/[id]/index.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogDetailPage from "./index.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogDetailPage from "@/pages/concert-logs/[id]/index.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLog: ConcertLog = {
   id: "cl-123",

--- a/app/pages/concert-logs/index.test.ts
+++ b/app/pages/concert-logs/index.test.ts
@@ -1,6 +1,6 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import ConcertLogsPage from "./index.vue";
-import type { ConcertLog } from "~/types";
+import ConcertLogsPage from "@/pages/concert-logs/index.vue";
+import type { ConcertLog } from "@/types";
 
 const sampleLogs: ConcertLog[] = [
   {

--- a/app/pages/concert-logs/new.test.ts
+++ b/app/pages/concert-logs/new.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ConcertLogNewPage from "./new.vue";
-import type { CreateConcertLogInput } from "~/types";
+import ConcertLogNewPage from "@/pages/concert-logs/new.vue";
+import type { CreateConcertLogInput } from "@/types";
 
 const mockCreate = vi.fn();
 

--- a/app/pages/concert-logs/new.vue
+++ b/app/pages/concert-logs/new.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateConcertLogInput } from "~/types";
+import type { CreateConcertLogInput } from "@/types";
 
 definePageMeta({ middleware: "auth" });
 

--- a/app/pages/index.test.ts
+++ b/app/pages/index.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
-import IndexPage from "./index.vue";
+import IndexPage from "@/pages/index.vue";
 
 describe("IndexPage", () => {
   it("楽曲を探すリンクが表示される", async () => {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import type { PageResult } from "~/composables/usePaginatedList";
-import type { PieceWork } from "~/types";
+import type { PageResult } from "@/composables/usePaginatedList";
+import type { PieceWork } from "@/types";
 
 const apiBase = useApiBase();
 const { data, pending } = useFetch<PageResult<PieceWork>>(`${apiBase}/pieces`);

--- a/app/pages/listening-logs/[id]/edit.test.ts
+++ b/app/pages/listening-logs/[id]/edit.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ListeningLogEditPage from "./edit.vue";
-import type { ListeningLog, UpdateListeningLogInput } from "~/types";
+import ListeningLogEditPage from "@/pages/listening-logs/[id]/edit.vue";
+import type { ListeningLog, UpdateListeningLogInput } from "@/types";
 
 const mockUpdate = vi.fn();
 

--- a/app/pages/listening-logs/[id]/edit.vue
+++ b/app/pages/listening-logs/[id]/edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { UpdateListeningLogInput } from "~/types";
+import type { UpdateListeningLogInput } from "@/types";
 
 definePageMeta({ middleware: "auth" });
 

--- a/app/pages/listening-logs/[id]/index.test.ts
+++ b/app/pages/listening-logs/[id]/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ListeningLogDetailPage from "./index.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogDetailPage from "@/pages/listening-logs/[id]/index.vue";
+import type { ListeningLog } from "@/types";
 
 vi.mock("~/composables/useAuth", () => ({
   ACCESS_TOKEN_KEY: "accessToken",

--- a/app/pages/listening-logs/index.test.ts
+++ b/app/pages/listening-logs/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ListeningLogsPage from "./index.vue";
-import type { ListeningLog } from "~/types";
+import ListeningLogsPage from "@/pages/listening-logs/index.vue";
+import type { ListeningLog } from "@/types";
 
 const mockDeleteLog = vi.fn();
 const mockRefresh = vi.fn();

--- a/app/pages/listening-logs/new.test.ts
+++ b/app/pages/listening-logs/new.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import ListeningLogNewPage from "./new.vue";
-import type { CreateListeningLogInput } from "~/types";
+import ListeningLogNewPage from "@/pages/listening-logs/new.vue";
+import type { CreateListeningLogInput } from "@/types";
 
 const mockCreate = vi.fn();
 

--- a/app/pages/listening-logs/new.vue
+++ b/app/pages/listening-logs/new.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreateListeningLogInput } from "~/types";
+import type { CreateListeningLogInput } from "@/types";
 
 definePageMeta({ middleware: "auth" });
 

--- a/app/pages/pieces/[id]/edit.test.ts
+++ b/app/pages/pieces/[id]/edit.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import PieceEditPage from "./edit.vue";
-import type { PieceWork, UpdatePieceInput } from "~/types";
+import PieceEditPage from "@/pages/pieces/[id]/edit.vue";
+import type { PieceWork, UpdatePieceInput } from "@/types";
 
 const mockUpdatePiece = vi.fn();
 

--- a/app/pages/pieces/[id]/edit.vue
+++ b/app/pages/pieces/[id]/edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork, UpdatePieceInput } from "~/types";
+import type { PieceWork, UpdatePieceInput } from "@/types";
 
 definePageMeta({ middleware: ["admin"] });
 

--- a/app/pages/pieces/[id]/index.test.ts
+++ b/app/pages/pieces/[id]/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import PieceDetailPage from "./index.vue";
-import type { Composer, ListeningLog, PieceWork, Rating } from "~/types";
+import PieceDetailPage from "@/pages/pieces/[id]/index.vue";
+import type { Composer, ListeningLog, PieceWork, Rating } from "@/types";
 
 vi.mock("~/composables/useAuth", () => ({
   ACCESS_TOKEN_KEY: "accessToken",
@@ -76,7 +76,7 @@ const sampleLogs: ListeningLog[] = [
   },
 ];
 
-const usePieceData = ref<PieceWork | import("~/types").PieceMovement | null>(samplePiece);
+const usePieceData = ref<PieceWork | import("@/types").PieceMovement | null>(samplePiece);
 
 vi.mock("~/composables/usePieces", () => ({
   usePiecesPaginated: vi.fn(),
@@ -124,7 +124,7 @@ beforeEach(async () => {
   vi.stubGlobal("$fetch", mockDollarFetch);
   // デフォルトは Work
   usePieceData.value = samplePiece;
-  const { useAuth } = await import("~/composables/useAuth");
+  const { useAuth } = await import("@/composables/useAuth");
   vi.mocked(useAuth).mockReturnValue({
     isAdmin: () => false,
     isAuthenticated: () => true,
@@ -192,7 +192,7 @@ describe("PieceDetailPage", () => {
     });
 
     it("未認証時は鑑賞記録を取得せず空配列を渡す", async () => {
-      const { useAuth } = await import("~/composables/useAuth");
+      const { useAuth } = await import("@/composables/useAuth");
       vi.mocked(useAuth).mockReturnValue({
         isAdmin: () => false,
         isAuthenticated: () => false,
@@ -209,7 +209,7 @@ describe("PieceDetailPage", () => {
 
   describe("楽章一覧（Work）", () => {
     it("Work の場合 GET /pieces/{id}/children を呼んで movements にセットする", async () => {
-      const sampleMovements: import("~/types").PieceMovement[] = [
+      const sampleMovements: import("@/types").PieceMovement[] = [
         {
           kind: "movement",
           id: "movement-1",
@@ -229,7 +229,7 @@ describe("PieceDetailPage", () => {
       const wrapper = await mountSuspended(PieceDetailPage);
       await flushPromises();
       const template = wrapper.findComponent({ name: "PieceDetailTemplate" });
-      const movements = template.props("movements") as import("~/types").PieceMovement[];
+      const movements = template.props("movements") as import("@/types").PieceMovement[];
       expect(movements).toHaveLength(1);
       expect(movements[0].id).toBe("movement-1");
     });
@@ -238,7 +238,7 @@ describe("PieceDetailPage", () => {
   describe("Movement 詳細", () => {
     const PARENT_ID = "parent-work";
     const MOVEMENT_ID = "movement-99";
-    const movementSample: import("~/types").PieceMovement = {
+    const movementSample: import("@/types").PieceMovement = {
       kind: "movement",
       id: MOVEMENT_ID,
       parentId: PARENT_ID,

--- a/app/pages/pieces/[id]/index.vue
+++ b/app/pages/pieces/[id]/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "~/types";
+import type { ListeningLog, Piece, PieceMovement, PieceWork, Rating } from "@/types";
 
 const route = useRoute();
 const apiBase = useApiBase();

--- a/app/pages/pieces/index.test.ts
+++ b/app/pages/pieces/index.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended, mockNuxtImport } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import PiecesPage from "./index.vue";
-import type { PieceWork } from "~/types";
+import PiecesPage from "@/pages/pieces/index.vue";
+import type { PieceWork } from "@/types";
 
 const { samplePieces, sampleComposers, mockLoadMore, mockReset, mockRetry } = vi.hoisted(() => {
   const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";

--- a/app/pages/pieces/index.vue
+++ b/app/pages/pieces/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PieceWork } from "~/types";
+import type { PieceWork } from "@/types";
 
 const apiBase = useApiBase();
 const { items, pending, error, hasMore, loadMore, reset, retry } = usePiecesPaginated();

--- a/app/pages/pieces/new.test.ts
+++ b/app/pages/pieces/new.test.ts
@@ -1,7 +1,7 @@
 import { mountSuspended } from "@nuxt/test-utils/runtime";
 import { flushPromises } from "@vue/test-utils";
-import PieceNewPage from "./new.vue";
-import type { CreatePieceInput } from "~/types";
+import PieceNewPage from "@/pages/pieces/new.vue";
+import type { CreatePieceInput } from "@/types";
 
 const mockCreatePiece = vi.fn();
 

--- a/app/pages/pieces/new.vue
+++ b/app/pages/pieces/new.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CreatePieceInput } from "~/types";
+import type { CreatePieceInput } from "@/types";
 
 definePageMeta({ middleware: ["admin"] });
 

--- a/app/types/index.ts
+++ b/app/types/index.ts
@@ -1,5 +1,5 @@
 // 楽曲カテゴリ（shared/constants.ts から re-export）
-import type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "../../shared/constants";
+import type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "@shared/constants";
 export {
   PIECE_GENRES,
   PIECE_ERAS,
@@ -17,15 +17,15 @@ export {
   COMPOSERS_PAGE_SIZE_MIN,
   COMPOSERS_PAGE_SIZE_MAX,
   COMPOSERS_PAGE_SIZE_DEFAULT,
-} from "../../shared/constants";
+} from "@shared/constants";
 export type {
   PieceGenre,
   PieceEra,
   PieceFormation,
   PieceRegion,
   PieceKind,
-} from "../../shared/constants";
-export type { Paginated } from "../../shared/constants";
+} from "@shared/constants";
+export type { Paginated } from "@shared/constants";
 
 export type Rating = 1 | 2 | 3 | 4 | 5;
 

--- a/app/utils/date.test.ts
+++ b/app/utils/date.test.ts
@@ -1,4 +1,4 @@
-import { formatDate, formatDatetime, toDatetimeLocal, nowAsDatetimeLocal } from "./date";
+import { formatDate, formatDatetime, toDatetimeLocal, nowAsDatetimeLocal } from "@/utils/date";
 
 describe("formatDate", () => {
   it("ISO 8601 文字列から日付部分（YYYY-MM-DD）のみを返す", () => {

--- a/app/utils/lifespan.test.ts
+++ b/app/utils/lifespan.test.ts
@@ -1,4 +1,4 @@
-import { formatLifespan } from "./lifespan";
+import { formatLifespan } from "@/utils/lifespan";
 
 describe("formatLifespan", () => {
   it("両方未指定なら空文字を返す", () => {

--- a/app/utils/select-options.test.ts
+++ b/app/utils/select-options.test.ts
@@ -1,4 +1,4 @@
-import { toSelectOptions } from "./select-options";
+import { toSelectOptions } from "@/utils/select-options";
 
 describe("toSelectOptions", () => {
   it("文字列配列を { value, label } 配列に変換する", () => {

--- a/app/utils/video.test.ts
+++ b/app/utils/video.test.ts
@@ -1,4 +1,4 @@
-import { isYouTubeUrl, extractYouTubeVideoId, toYouTubeEmbedUrl } from "./video";
+import { isYouTubeUrl, extractYouTubeVideoId, toYouTubeEmbedUrl } from "@/utils/video";
 
 describe("isYouTubeUrl", () => {
   it("youtube.com/watch?v= を含む URL は true", () => {

--- a/backend/src/domain/composer.test.ts
+++ b/backend/src/domain/composer.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 
-import { ComposerEntity } from "./composer";
-import type { Composer, CreateComposerInput } from "../types";
+import { ComposerEntity } from "@/domain/composer";
+import type { Composer, CreateComposerInput } from "@/types";
 
 const makeInput = (overrides: Partial<CreateComposerInput> = {}): CreateComposerInput => ({
   name: "ベートーヴェン",

--- a/backend/src/domain/composer.ts
+++ b/backend/src/domain/composer.ts
@@ -4,13 +4,13 @@ import type {
   PieceEra,
   PieceRegion,
   UpdateComposerInput,
-} from "../types";
-import { Entity, type EntityProps } from "./entity";
-import { buildUpdateProps } from "./entity-helpers";
-import { ComposerName } from "./value-objects/composer-name";
-import { ComposerId } from "./value-objects/ids";
-import { Url } from "./value-objects/url";
-import { Year } from "./value-objects/year";
+} from "@/types";
+import { Entity, type EntityProps } from "@/domain/entity";
+import { buildUpdateProps } from "@/domain/entity-helpers";
+import { ComposerName } from "@/domain/value-objects/composer-name";
+import { ComposerId } from "@/domain/value-objects/ids";
+import { Url } from "@/domain/value-objects/url";
+import { Year } from "@/domain/value-objects/year";
 
 export type ComposerRepository = {
   findById(id: ComposerId): Promise<Composer | undefined>;

--- a/backend/src/domain/concert-log.test.ts
+++ b/backend/src/domain/concert-log.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-import { ConcertLogEntity } from "./concert-log";
-import { UserId } from "./value-objects/ids";
-import type { ConcertLog, CreateConcertLogInput } from "../types";
+import { ConcertLogEntity } from "@/domain/concert-log";
+import { UserId } from "@/domain/value-objects/ids";
+import type { ConcertLog, CreateConcertLogInput } from "@/types";
 
 const USER_ID = "cognito-sub-user-1";
 const OTHER_USER_ID = "cognito-sub-user-2";

--- a/backend/src/domain/concert-log.ts
+++ b/backend/src/domain/concert-log.ts
@@ -1,9 +1,9 @@
-import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
-import { Entity, type EntityProps } from "./entity";
-import { buildUpdateProps } from "./entity-helpers";
-import { ConcertTitle } from "./value-objects/concert-title";
-import { ConcertLogId, PieceId, UserId } from "./value-objects/ids";
-import { Venue } from "./value-objects/venue";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "@/types";
+import { Entity, type EntityProps } from "@/domain/entity";
+import { buildUpdateProps } from "@/domain/entity-helpers";
+import { ConcertTitle } from "@/domain/value-objects/concert-title";
+import { ConcertLogId, PieceId, UserId } from "@/domain/value-objects/ids";
+import { Venue } from "@/domain/value-objects/venue";
 
 export type ConcertLogRepository = {
   findById(id: ConcertLogId): Promise<ConcertLog | undefined>;

--- a/backend/src/domain/entity.test.ts
+++ b/backend/src/domain/entity.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { Entity, type EntityProps } from "./entity";
-import { ComposerId, PieceId } from "./value-objects/ids";
+import { Entity, type EntityProps } from "@/domain/entity";
+import { ComposerId, PieceId } from "@/domain/value-objects/ids";
 
 type DummyPieceProps = EntityProps<PieceId> & { label: string };
 type DummyComposerProps = EntityProps<ComposerId> & { label: string };

--- a/backend/src/domain/entity.ts
+++ b/backend/src/domain/entity.ts
@@ -1,4 +1,4 @@
-import type { IdValueObject } from "./value-objects/ids";
+import type { IdValueObject } from "@/domain/value-objects/ids";
 
 export type EntityProps<TId extends IdValueObject> = {
   id: TId;

--- a/backend/src/domain/listening-log-detail.ts
+++ b/backend/src/domain/listening-log-detail.ts
@@ -1,6 +1,6 @@
-import type { Composer, ListeningLog } from "../types";
-import type { ListeningLogEntity } from "./listening-log";
-import { PieceMovementEntity, type PieceWorkEntity } from "./piece";
+import type { Composer, ListeningLog } from "@/types";
+import type { ListeningLogEntity } from "@/domain/listening-log";
+import { PieceMovementEntity, type PieceWorkEntity } from "@/domain/piece";
 
 type PieceEntity = PieceWorkEntity | PieceMovementEntity;
 

--- a/backend/src/domain/listening-log.test.ts
+++ b/backend/src/domain/listening-log.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-import { ListeningLogEntity } from "./listening-log";
-import { UserId } from "./value-objects/ids";
-import type { CreateListeningLogInput, ListeningLogRecord } from "../types";
+import { ListeningLogEntity } from "@/domain/listening-log";
+import { UserId } from "@/domain/value-objects/ids";
+import type { CreateListeningLogInput, ListeningLogRecord } from "@/types";
 
 const USER_ID = "cognito-sub-user-1";
 const OTHER_USER_ID = "cognito-sub-user-2";

--- a/backend/src/domain/listening-log.ts
+++ b/backend/src/domain/listening-log.ts
@@ -1,11 +1,7 @@
-import type {
-  CreateListeningLogInput,
-  ListeningLogRecord,
-  UpdateListeningLogInput,
-} from "../types";
-import { Entity, type EntityProps } from "./entity";
-import { Rating } from "./value-objects/rating";
-import { ListeningLogId, PieceId, UserId } from "./value-objects/ids";
+import type { CreateListeningLogInput, ListeningLogRecord, UpdateListeningLogInput } from "@/types";
+import { Entity, type EntityProps } from "@/domain/entity";
+import { Rating } from "@/domain/value-objects/rating";
+import { ListeningLogId, PieceId, UserId } from "@/domain/value-objects/ids";
 
 export type ListeningLogRepository = {
   findById(id: ListeningLogId): Promise<ListeningLogRecord | undefined>;

--- a/backend/src/domain/piece.test.ts
+++ b/backend/src/domain/piece.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from "vitest";
 
-import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "./piece";
-import { PieceId } from "./value-objects/ids";
-import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "../types";
+import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "@/domain/piece";
+import { PieceId } from "@/domain/value-objects/ids";
+import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "@/types";
 
 const COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const PARENT_ID = "00000000-0000-4000-8000-0000000000aa";

--- a/backend/src/domain/piece.ts
+++ b/backend/src/domain/piece.ts
@@ -12,13 +12,13 @@ import type {
   UpdateMovementInput,
   UpdatePieceInput,
   UpdateWorkInput,
-} from "../types";
-import { Entity, type EntityProps } from "./entity";
-import { buildUpdateProps } from "./entity-helpers";
-import { ComposerId, PieceId } from "./value-objects/ids";
-import { MovementIndex } from "./value-objects/movement-index";
-import { PieceTitle } from "./value-objects/piece-title";
-import { Url } from "./value-objects/url";
+} from "@/types";
+import { Entity, type EntityProps } from "@/domain/entity";
+import { buildUpdateProps } from "@/domain/entity-helpers";
+import { ComposerId, PieceId } from "@/domain/value-objects/ids";
+import { MovementIndex } from "@/domain/value-objects/movement-index";
+import { PieceTitle } from "@/domain/value-objects/piece-title";
+import { Url } from "@/domain/value-objects/url";
 
 const WORK_METADATA_CLEARABLE_FIELDS: readonly string[] = ["genre", "era", "formation", "region"];
 const MOVEMENT_METADATA_CLEARABLE_FIELDS: readonly string[] = [];

--- a/backend/src/domain/value-objects/composer-name.test.ts
+++ b/backend/src/domain/value-objects/composer-name.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { ComposerName } from "./composer-name";
+import { ComposerName } from "@/domain/value-objects/composer-name";
 
 describe("ComposerName", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/concert-title.test.ts
+++ b/backend/src/domain/value-objects/concert-title.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { ConcertTitle } from "./concert-title";
+import { ConcertTitle } from "@/domain/value-objects/concert-title";
 
 describe("ConcertTitle", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/ids.test.ts
+++ b/backend/src/domain/value-objects/ids.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from "vitest";
 
-import { ComposerId, ConcertLogId, ListeningLogId, PieceId, UserId } from "./ids";
+import {
+  ComposerId,
+  ConcertLogId,
+  ListeningLogId,
+  PieceId,
+  UserId,
+} from "@/domain/value-objects/ids";
 
 describe("IdValueObject", () => {
   describe("生成と値参照", () => {

--- a/backend/src/domain/value-objects/movement-index.test.ts
+++ b/backend/src/domain/value-objects/movement-index.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { MovementIndex } from "./movement-index";
+import { MovementIndex } from "@/domain/value-objects/movement-index";
 
 describe("MovementIndex", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/movement-index.ts
+++ b/backend/src/domain/value-objects/movement-index.ts
@@ -5,7 +5,7 @@
  * - 範囲は 0 〜 999。1 楽曲に持てる楽章数の現実的な上限を考慮。
  * - 値の取り出しは `.value` または `toString()`、等価判定は `.equals(other)`。
  */
-import { MOVEMENT_INDEX_MAX, MOVEMENT_INDEX_MIN } from "../../../../shared/constants";
+import { MOVEMENT_INDEX_MAX, MOVEMENT_INDEX_MIN } from "@shared/constants";
 
 export class MovementIndex {
   public readonly value: number;

--- a/backend/src/domain/value-objects/piece-title.test.ts
+++ b/backend/src/domain/value-objects/piece-title.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { PieceTitle } from "./piece-title";
+import { PieceTitle } from "@/domain/value-objects/piece-title";
 
 describe("PieceTitle", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/rating.test.ts
+++ b/backend/src/domain/value-objects/rating.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { Rating } from "./rating";
+import { Rating } from "@/domain/value-objects/rating";
 
 describe("Rating", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/url.test.ts
+++ b/backend/src/domain/value-objects/url.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { Url } from "./url";
+import { Url } from "@/domain/value-objects/url";
 
 describe("Url", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/venue.test.ts
+++ b/backend/src/domain/value-objects/venue.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { Venue } from "./venue";
+import { Venue } from "@/domain/value-objects/venue";
 
 describe("Venue", () => {
   describe("of", () => {

--- a/backend/src/domain/value-objects/year.test.ts
+++ b/backend/src/domain/value-objects/year.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { Year } from "./year";
+import { Year } from "@/domain/value-objects/year";
 
 describe("Year", () => {
   describe("of", () => {

--- a/backend/src/handlers/auth/login.test.ts
+++ b/backend/src/handlers/auth/login.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./login";
-import {
-  makeEvent,
-  mockContext,
-  mockCallback,
-  describeInvalidBodyCases,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/auth/login";
+import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/login.ts
+++ b/backend/src/handlers/auth/login.ts
@@ -1,7 +1,7 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { loginSchema } from "../../utils/schemas";
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { loginSchema } from "@/utils/schemas";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/auth/pre-signup.test.ts
+++ b/backend/src/handlers/auth/pre-signup.test.ts
@@ -1,6 +1,6 @@
 import type { PreSignUpTriggerEvent } from "aws-lambda";
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { handler } from "./pre-signup";
+import { handler } from "@/handlers/auth/pre-signup";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/pre-signup.ts
+++ b/backend/src/handlers/auth/pre-signup.ts
@@ -1,6 +1,6 @@
 import type { PreSignUpTriggerHandler } from "aws-lambda";
 
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/auth/refresh.test.ts
+++ b/backend/src/handlers/auth/refresh.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./refresh";
-import {
-  makeEvent,
-  mockContext,
-  mockCallback,
-  describeInvalidBodyCases,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/auth/refresh";
+import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/refresh.ts
+++ b/backend/src/handlers/auth/refresh.ts
@@ -1,7 +1,7 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { refreshTokenSchema } from "../../utils/schemas";
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { refreshTokenSchema } from "@/utils/schemas";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./register";
-import {
-  makeEvent,
-  mockContext,
-  mockCallback,
-  describeInvalidBodyCases,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/auth/register";
+import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/register.ts
+++ b/backend/src/handlers/auth/register.ts
@@ -1,7 +1,7 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { registerSchema } from "../../utils/schemas";
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { registerSchema } from "@/utils/schemas";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./resend-verification-code";
-import {
-  makeEvent,
-  mockContext,
-  mockCallback,
-  describeInvalidBodyCases,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/auth/resend-verification-code";
+import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/resend-verification-code.ts
+++ b/backend/src/handlers/auth/resend-verification-code.ts
@@ -1,7 +1,7 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { resendVerificationCodeSchema } from "../../utils/schemas";
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { resendVerificationCodeSchema } from "@/utils/schemas";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./verify-email";
-import {
-  makeEvent,
-  mockContext,
-  mockCallback,
-  describeInvalidBodyCases,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/auth/verify-email";
+import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   signUp: vi.fn(),

--- a/backend/src/handlers/auth/verify-email.ts
+++ b/backend/src/handlers/auth/verify-email.ts
@@ -1,7 +1,7 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { verifyEmailSchema } from "../../utils/schemas";
-import { createAuthUsecase } from "../../usecases/auth-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { verifyEmailSchema } from "@/utils/schemas";
+import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { handler } from "./create";
+import { handler } from "@/handlers/composers/create";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -8,7 +8,7 @@ import {
   mockCallback,
   mockContext,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/composers/create.ts
+++ b/backend/src/handlers/composers/create.ts
@@ -1,7 +1,7 @@
-import { withHandler } from "../../utils/handler";
-import { createComposerSchema } from "../../utils/schemas";
-import { created } from "../../utils/response";
-import { createComposerUsecase } from "../../usecases/composer-usecase";
+import { withHandler } from "@/utils/handler";
+import { createComposerSchema } from "@/utils/schemas";
+import { created } from "@/utils/response";
+import { createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
-import { ComposerId } from "../../domain/value-objects/ids";
-import { handler } from "./delete";
+import { ComposerId } from "@/domain/value-objects/ids";
+import { handler } from "@/handlers/composers/delete";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -10,7 +10,7 @@ import {
   mockCallback,
   mockContext,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/composers/delete.ts
+++ b/backend/src/handlers/composers/delete.ts
@@ -1,6 +1,6 @@
-import { withHandler } from "../../utils/handler";
-import { noContent } from "../../utils/response";
-import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
+import { withHandler } from "@/utils/handler";
+import { noContent } from "@/utils/response";
+import { ComposerId, createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 

--- a/backend/src/handlers/composers/get.test.ts
+++ b/backend/src/handlers/composers/get.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { Composer } from "../../types";
+import type { Composer } from "@/types";
 
-import { handler } from "./get";
+import { handler } from "@/handlers/composers/get";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/composers/get.ts
+++ b/backend/src/handlers/composers/get.ts
@@ -1,6 +1,6 @@
-import { withHandler } from "../../utils/handler";
-import { ok } from "../../utils/response";
-import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
+import { withHandler } from "@/utils/handler";
+import { ok } from "@/utils/response";
+import { ComposerId, createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 

--- a/backend/src/handlers/composers/list.test.ts
+++ b/backend/src/handlers/composers/list.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./list";
-import { makeEvent, makeComposer, mockContext, mockCallback } from "../../test/fixtures";
-import { encodeCursor } from "../../utils/cursor";
-import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "../../types";
-import type { Composer, Paginated } from "../../types";
+import { handler } from "@/handlers/composers/list";
+import { makeEvent, makeComposer, mockContext, mockCallback } from "@/test/fixtures";
+import { encodeCursor } from "@/utils/cursor";
+import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "@/types";
+import type { Composer, Paginated } from "@/types";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/composers/list.ts
+++ b/backend/src/handlers/composers/list.ts
@@ -1,8 +1,8 @@
-import { createHandler } from "../../utils/middleware";
-import { parseListQuery } from "../../utils/parsing";
-import { ok } from "../../utils/response";
-import { listComposersQuerySchema } from "../../utils/schemas";
-import { createComposerUsecase } from "../../usecases/composer-usecase";
+import { createHandler } from "@/utils/middleware";
+import { parseListQuery } from "@/utils/parsing";
+import { ok } from "@/utils/response";
+import { listComposersQuerySchema } from "@/utils/schemas";
+import { createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
-import type { Composer } from "../../types";
+import type { Composer } from "@/types";
 
-import { handler } from "./update";
+import { handler } from "@/handlers/composers/update";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -11,7 +11,7 @@ import {
   mockCallback,
   mockContext,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/composers/update.ts
+++ b/backend/src/handlers/composers/update.ts
@@ -1,7 +1,7 @@
-import { withHandler } from "../../utils/handler";
-import { updateComposerSchema } from "../../utils/schemas";
-import { ok } from "../../utils/response";
-import { ComposerId, createComposerUsecase } from "../../usecases/composer-usecase";
+import { withHandler } from "@/utils/handler";
+import { updateComposerSchema } from "@/utils/schemas";
+import { ok } from "@/utils/response";
+import { ComposerId, createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context } from "aws-lambda";
 
-import { handler } from "./create";
-import { makeEvent, makeAuthEvent } from "../../test/fixtures";
+import { handler } from "@/handlers/concert-logs/create";
+import { makeEvent, makeAuthEvent } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/concert-logs/create.ts
+++ b/backend/src/handlers/concert-logs/create.ts
@@ -1,9 +1,9 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { createConcertLogSchema } from "../../utils/schemas";
-import { getUserId } from "../../utils/auth";
-import { created } from "../../utils/response";
-import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { createConcertLogSchema } from "@/utils/schemas";
+import { getUserId } from "@/utils/auth";
+import { created } from "@/utils/response";
+import { createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./delete";
+import { handler } from "@/handlers/concert-logs/delete";
 import {
   mockContext,
   mockCallback,
   TEST_USER_ID,
   OTHER_USER_ID,
   makeDeleteEvent,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/concert-logs/delete.ts
+++ b/backend/src/handlers/concert-logs/delete.ts
@@ -1,8 +1,8 @@
-import { createHandler } from "../../utils/middleware";
-import { getIdParam } from "../../utils/path-params";
-import { getUserId } from "../../utils/auth";
-import { noContent } from "../../utils/response";
-import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { createHandler } from "@/utils/middleware";
+import { getIdParam } from "@/utils/path-params";
+import { getUserId } from "@/utils/auth";
+import { noContent } from "@/utils/response";
+import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { ConcertLog } from "../../types";
+import type { ConcertLog } from "@/types";
 
-import { handler } from "./get";
+import { handler } from "@/handlers/concert-logs/get";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/concert-logs/get.ts
+++ b/backend/src/handlers/concert-logs/get.ts
@@ -1,8 +1,8 @@
-import { createHandler } from "../../utils/middleware";
-import { getIdParam } from "../../utils/path-params";
-import { getUserId } from "../../utils/auth";
-import { ok } from "../../utils/response";
-import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { createHandler } from "@/utils/middleware";
+import { getIdParam } from "@/utils/path-params";
+import { getUserId } from "@/utils/auth";
+import { ok } from "@/utils/response";
+import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 

--- a/backend/src/handlers/concert-logs/integration.test.ts
+++ b/backend/src/handlers/concert-logs/integration.test.ts
@@ -5,12 +5,12 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { ConcertLog } from "../../types";
+import type { ConcertLog } from "@/types";
 
-import { handler as createHandler } from "./create";
-import { handler as listHandler } from "./list";
-import { handler as getHandler } from "./get";
-import { handler as deleteHandler } from "./delete";
+import { handler as createHandler } from "@/handlers/concert-logs/create";
+import { handler as listHandler } from "@/handlers/concert-logs/list";
+import { handler as getHandler } from "@/handlers/concert-logs/get";
+import { handler as deleteHandler } from "@/handlers/concert-logs/delete";
 import { GetCommand, PutCommand, QueryCommand, DeleteCommand } from "@aws-sdk/lib-dynamodb";
 
 const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));

--- a/backend/src/handlers/concert-logs/list.test.ts
+++ b/backend/src/handlers/concert-logs/list.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ConcertLog } from "../../types";
+import type { ConcertLog } from "@/types";
 
-import { UserId } from "../../domain/value-objects/ids";
-import { handler } from "./list";
-import { makeAuthEvent } from "../../test/fixtures";
+import { UserId } from "@/domain/value-objects/ids";
+import { handler } from "@/handlers/concert-logs/list";
+import { makeAuthEvent } from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/concert-logs/list.ts
+++ b/backend/src/handlers/concert-logs/list.ts
@@ -1,7 +1,7 @@
-import { createHandler } from "../../utils/middleware";
-import { getUserId } from "../../utils/auth";
-import { ok } from "../../utils/response";
-import { createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { createHandler } from "@/utils/middleware";
+import { getUserId } from "@/utils/auth";
+import { ok } from "@/utils/response";
+import { createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Conflict } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { ConcertLog } from "../../types";
+import type { ConcertLog } from "@/types";
 
-import { handler } from "./update";
+import { handler } from "@/handlers/concert-logs/update";
 
 const mockRepo = vi.hoisted(() => ({
   save: vi.fn(),

--- a/backend/src/handlers/concert-logs/update.ts
+++ b/backend/src/handlers/concert-logs/update.ts
@@ -1,10 +1,10 @@
-import { createHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { updateConcertLogSchema } from "../../utils/schemas";
-import { getIdParam } from "../../utils/path-params";
-import { getUserId } from "../../utils/auth";
-import { ok } from "../../utils/response";
-import { ConcertLogId, createConcertLogUsecase } from "../../usecases/concert-log-usecase";
+import { createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { updateConcertLogSchema } from "@/utils/schemas";
+import { getIdParam } from "@/utils/path-params";
+import { getUserId } from "@/utils/auth";
+import { ok } from "@/utils/response";
+import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -1,14 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context } from "aws-lambda";
 
-import { handler } from "./create";
-import {
-  makeAuthEvent,
-  makeComposer,
-  makeEvent,
-  makePiece,
-  TEST_PIECE_ID,
-} from "../../test/fixtures";
+import { handler } from "@/handlers/listening-logs/create";
+import { makeAuthEvent, makeComposer, makeEvent, makePiece, TEST_PIECE_ID } from "@/test/fixtures";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {

--- a/backend/src/handlers/listening-logs/create.ts
+++ b/backend/src/handlers/listening-logs/create.ts
@@ -1,8 +1,8 @@
-import { withHandler } from "../../utils/handler";
-import { createListeningLogSchema } from "../../utils/schemas";
-import { created } from "../../utils/response";
-import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
-import type { Rating } from "../../types";
+import { withHandler } from "@/utils/handler";
+import { createListeningLogSchema } from "@/utils/schemas";
+import { created } from "@/utils/response";
+import { createListeningLogUsecase } from "@/usecases/listening-log-usecase";
+import type { Rating } from "@/types";
 
 const usecase = createListeningLogUsecase();
 

--- a/backend/src/handlers/listening-logs/delete.test.ts
+++ b/backend/src/handlers/listening-logs/delete.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./delete";
+import { handler } from "@/handlers/listening-logs/delete";
 import {
   mockContext,
   mockCallback,
@@ -8,7 +8,7 @@ import {
   OTHER_USER_ID,
   makeDeleteEvent,
   makeLogRecord,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {

--- a/backend/src/handlers/listening-logs/delete.ts
+++ b/backend/src/handlers/listening-logs/delete.ts
@@ -1,6 +1,6 @@
-import { withHandler } from "../../utils/handler";
-import { noContent } from "../../utils/response";
-import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
+import { withHandler } from "@/utils/handler";
+import { noContent } from "@/utils/response";
+import { createListeningLogUsecase, ListeningLogId } from "@/usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
 

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
-import { handler } from "./get";
-import { makeComposer, makeLogRecord, makePiece } from "../../test/fixtures";
+import { handler } from "@/handlers/listening-logs/get";
+import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {

--- a/backend/src/handlers/listening-logs/get.ts
+++ b/backend/src/handlers/listening-logs/get.ts
@@ -1,6 +1,6 @@
-import { withHandler } from "../../utils/handler";
-import { ok } from "../../utils/response";
-import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
+import { withHandler } from "@/utils/handler";
+import { ok } from "@/utils/response";
+import { createListeningLogUsecase, ListeningLogId } from "@/usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
 

--- a/backend/src/handlers/listening-logs/integration.test.ts
+++ b/backend/src/handlers/listening-logs/integration.test.ts
@@ -5,13 +5,13 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { Composer, ListeningLogRecord, Piece } from "../../types";
+import type { Composer, ListeningLogRecord, Piece } from "@/types";
 
-import { handler as createHandler } from "./create";
-import { handler as listHandler } from "./list";
-import { handler as getHandler } from "./get";
-import { handler as updateHandler } from "./update";
-import { handler as deleteHandler } from "./delete";
+import { handler as createHandler } from "@/handlers/listening-logs/create";
+import { handler as listHandler } from "@/handlers/listening-logs/list";
+import { handler as getHandler } from "@/handlers/listening-logs/get";
+import { handler as updateHandler } from "@/handlers/listening-logs/update";
+import { handler as deleteHandler } from "@/handlers/listening-logs/delete";
 import { GetCommand, PutCommand, DeleteCommand, QueryCommand } from "@aws-sdk/lib-dynamodb";
 
 const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));

--- a/backend/src/handlers/listening-logs/list.test.ts
+++ b/backend/src/handlers/listening-logs/list.test.ts
@@ -1,15 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { ListeningLog } from "../../types";
+import type { ListeningLog } from "@/types";
 
-import { UserId } from "../../domain/value-objects/ids";
-import { handler } from "./list";
+import { UserId } from "@/domain/value-objects/ids";
+import { handler } from "@/handlers/listening-logs/list";
 import {
   makeAuthEvent,
   makeComposer,
   makeLogRecord,
   makePiece,
   TEST_PIECE_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {

--- a/backend/src/handlers/listening-logs/list.ts
+++ b/backend/src/handlers/listening-logs/list.ts
@@ -1,6 +1,6 @@
-import { withHandler } from "../../utils/handler";
-import { ok } from "../../utils/response";
-import { createListeningLogUsecase } from "../../usecases/listening-log-usecase";
+import { withHandler } from "@/utils/handler";
+import { ok } from "@/utils/response";
+import { createListeningLogUsecase } from "@/usecases/listening-log-usecase";
 
 const usecase = createListeningLogUsecase();
 

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Conflict } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
-import { handler } from "./update";
-import { makeComposer, makeLogRecord, makePiece } from "../../test/fixtures";
+import { handler } from "@/handlers/listening-logs/update";
+import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {

--- a/backend/src/handlers/listening-logs/update.ts
+++ b/backend/src/handlers/listening-logs/update.ts
@@ -1,8 +1,8 @@
-import { withHandler } from "../../utils/handler";
-import { updateListeningLogSchema } from "../../utils/schemas";
-import { ok } from "../../utils/response";
-import { createListeningLogUsecase, ListeningLogId } from "../../usecases/listening-log-usecase";
-import type { UpdateListeningLogInput } from "../../types";
+import { withHandler } from "@/utils/handler";
+import { updateListeningLogSchema } from "@/utils/schemas";
+import { ok } from "@/utils/response";
+import { createListeningLogUsecase, ListeningLogId } from "@/usecases/listening-log-usecase";
+import type { UpdateListeningLogInput } from "@/types";
 
 const usecase = createListeningLogUsecase();
 

--- a/backend/src/handlers/pieces/children.test.ts
+++ b/backend/src/handlers/pieces/children.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
-import { handler } from "./children";
+import { handler } from "@/handlers/pieces/children";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/children.ts
+++ b/backend/src/handlers/pieces/children.ts
@@ -1,7 +1,7 @@
-import { createHandler } from "../../utils/middleware";
-import { getIdParam } from "../../utils/path-params";
-import { ok } from "../../utils/response";
-import { createMovementUsecase, PieceId } from "../../usecases/piece-usecase";
+import { createHandler } from "@/utils/middleware";
+import { getIdParam } from "@/utils/path-params";
+import { ok } from "@/utils/response";
+import { createMovementUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createMovementUsecase();
 

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
-import { handler } from "./create";
+import { handler } from "@/handlers/pieces/create";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -9,7 +9,7 @@ import {
   mockContext,
   TEST_COMPOSER_ID,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/create.ts
+++ b/backend/src/handlers/pieces/create.ts
@@ -1,8 +1,8 @@
-import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { createPieceSchema } from "../../utils/schemas";
-import { created } from "../../utils/response";
-import { createPieceUsecase } from "../../usecases/piece-usecase";
+import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { createPieceSchema } from "@/utils/schemas";
+import { created } from "@/utils/response";
+import { createPieceUsecase } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
-import { PieceId } from "../../domain/value-objects/ids";
-import { handler } from "./delete";
+import { PieceId } from "@/domain/value-objects/ids";
+import { handler } from "@/handlers/pieces/delete";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -10,7 +10,7 @@ import {
   mockCallback,
   mockContext,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,7 +1,7 @@
-import { createAdminHandler } from "../../utils/middleware";
-import { getIdParam } from "../../utils/path-params";
-import { noContent } from "../../utils/response";
-import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
+import { createAdminHandler } from "@/utils/middleware";
+import { getIdParam } from "@/utils/path-params";
+import { noContent } from "@/utils/response";
+import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 

--- a/backend/src/handlers/pieces/get.test.ts
+++ b/backend/src/handlers/pieces/get.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-import type { Piece, PieceWork } from "../../types";
+import type { Piece, PieceWork } from "@/types";
 
-import { handler } from "./get";
+import { handler } from "@/handlers/pieces/get";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/get.ts
+++ b/backend/src/handlers/pieces/get.ts
@@ -1,7 +1,7 @@
-import { createHandler } from "../../utils/middleware";
-import { getIdParam } from "../../utils/path-params";
-import { ok } from "../../utils/response";
-import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
+import { createHandler } from "@/utils/middleware";
+import { getIdParam } from "@/utils/path-params";
+import { ok } from "@/utils/response";
+import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 

--- a/backend/src/handlers/pieces/list.test.ts
+++ b/backend/src/handlers/pieces/list.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { handler } from "./list";
-import { makeEvent, makePiece, mockContext, mockCallback } from "../../test/fixtures";
-import { encodeCursor } from "../../utils/cursor";
-import { PIECES_PAGE_SIZE_DEFAULT, PIECES_PAGE_SIZE_MAX } from "../../types";
-import type { Paginated, Piece } from "../../types";
+import { handler } from "@/handlers/pieces/list";
+import { makeEvent, makePiece, mockContext, mockCallback } from "@/test/fixtures";
+import { encodeCursor } from "@/utils/cursor";
+import { PIECES_PAGE_SIZE_DEFAULT, PIECES_PAGE_SIZE_MAX } from "@/types";
+import type { Paginated, Piece } from "@/types";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/list.ts
+++ b/backend/src/handlers/pieces/list.ts
@@ -1,8 +1,8 @@
-import { createHandler } from "../../utils/middleware";
-import { parseListQuery } from "../../utils/parsing";
-import { ok } from "../../utils/response";
-import { listPiecesQuerySchema } from "../../utils/schemas";
-import { createPieceUsecase } from "../../usecases/piece-usecase";
+import { createHandler } from "@/utils/middleware";
+import { parseListQuery } from "@/utils/parsing";
+import { ok } from "@/utils/response";
+import { listPiecesQuerySchema } from "@/utils/schemas";
+import { createPieceUsecase } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 

--- a/backend/src/handlers/pieces/replace-movements.test.ts
+++ b/backend/src/handlers/pieces/replace-movements.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 
-import { handler } from "./replace-movements";
+import { handler } from "@/handlers/pieces/replace-movements";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -11,7 +11,7 @@ import {
   mockContext,
   TEST_COMPOSER_ID,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/replace-movements.ts
+++ b/backend/src/handlers/pieces/replace-movements.ts
@@ -1,9 +1,9 @@
-import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { getIdParam } from "../../utils/path-params";
-import { ok } from "../../utils/response";
-import { replaceMovementsSchema } from "../../utils/schemas";
-import { createMovementUsecase, PieceId } from "../../usecases/piece-usecase";
+import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { getIdParam } from "@/utils/path-params";
+import { ok } from "@/utils/response";
+import { replaceMovementsSchema } from "@/utils/schemas";
+import { createMovementUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createMovementUsecase();
 

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
-import type { Piece, PieceWork } from "../../types";
+import type { Piece, PieceWork } from "@/types";
 
-import { handler } from "./update";
+import { handler } from "@/handlers/pieces/update";
 import {
   makeAdminEvent,
   makeAuthEvent,
@@ -12,7 +12,7 @@ import {
   mockContext,
   TEST_COMPOSER_ID,
   TEST_USER_ID,
-} from "../../test/fixtures";
+} from "@/test/fixtures";
 
 const mockRepo = vi.hoisted(() => ({
   saveWork: vi.fn(),

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -1,9 +1,9 @@
-import { createAdminHandler, jsonBodyParser } from "../../utils/middleware";
-import { parseRequestBody } from "../../utils/parsing";
-import { updatePieceSchema } from "../../utils/schemas";
-import { getIdParam } from "../../utils/path-params";
-import { ok } from "../../utils/response";
-import { createPieceUsecase, PieceId } from "../../usecases/piece-usecase";
+import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { updatePieceSchema } from "@/utils/schemas";
+import { getIdParam } from "@/utils/path-params";
+import { ok } from "@/utils/response";
+import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 

--- a/backend/src/migrations/piece-kind-backfill/index.test.ts
+++ b/backend/src/migrations/piece-kind-backfill/index.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { runMigration } from "./index";
+import { runMigration } from "@/migrations/piece-kind-backfill/index";
 
 type PieceRecord = {
   id: string;

--- a/backend/src/repositories/cognito-auth-repository.ts
+++ b/backend/src/repositories/cognito-auth-repository.ts
@@ -8,8 +8,8 @@ import {
   AdminLinkProviderForUserCommand,
 } from "@aws-sdk/client-cognito-identity-provider";
 
-import { getEnv } from "../utils/env";
-import type { AuthRepository, AuthTokens, RefreshedTokens } from "../domain/auth";
+import { getEnv } from "@/utils/env";
+import type { AuthRepository, AuthTokens, RefreshedTokens } from "@/domain/auth";
 
 const cognito = new CognitoIdentityProviderClient({});
 

--- a/backend/src/repositories/composer-repository.ts
+++ b/backend/src/repositories/composer-repository.ts
@@ -1,9 +1,9 @@
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
-import type { ComposerId } from "../domain/value-objects/ids";
-import { dynamo, putItemWithOptimisticLock, scanPage, TABLE_COMPOSERS } from "../utils/dynamodb";
-import type { Composer } from "../types";
-import type { ComposerRepository } from "../domain/composer";
+import type { ComposerId } from "@/domain/value-objects/ids";
+import { dynamo, putItemWithOptimisticLock, scanPage, TABLE_COMPOSERS } from "@/utils/dynamodb";
+import type { Composer } from "@/types";
+import type { ComposerRepository } from "@/domain/composer";
 
 export class DynamoDBComposerRepository implements ComposerRepository {
   async findById(id: ComposerId): Promise<Composer | undefined> {

--- a/backend/src/repositories/concert-log-repository.ts
+++ b/backend/src/repositories/concert-log-repository.ts
@@ -1,14 +1,14 @@
 import { DeleteCommand, GetCommand, PutCommand } from "@aws-sdk/lib-dynamodb";
 
-import type { ConcertLogId, UserId } from "../domain/value-objects/ids";
+import type { ConcertLogId, UserId } from "@/domain/value-objects/ids";
 import {
   dynamo,
   putItemWithOptimisticLock,
   queryItemsByUserId,
   TABLE_CONCERT_LOGS,
-} from "../utils/dynamodb";
-import type { ConcertLog } from "../types";
-import type { ConcertLogRepository } from "../domain/concert-log";
+} from "@/utils/dynamodb";
+import type { ConcertLog } from "@/types";
+import type { ConcertLogRepository } from "@/domain/concert-log";
 
 export class DynamoDBConcertLogRepository implements ConcertLogRepository {
   async findById(id: ConcertLogId): Promise<ConcertLog | undefined> {

--- a/backend/src/repositories/listening-log-repository.ts
+++ b/backend/src/repositories/listening-log-repository.ts
@@ -1,14 +1,14 @@
 import { DeleteCommand, GetCommand, PutCommand, ScanCommand } from "@aws-sdk/lib-dynamodb";
 
-import type { ListeningLogId, PieceId, UserId } from "../domain/value-objects/ids";
+import type { ListeningLogId, PieceId, UserId } from "@/domain/value-objects/ids";
 import {
   dynamo,
   putItemWithOptimisticLock,
   queryItemsByUserId,
   TABLE_LISTENING_LOGS,
-} from "../utils/dynamodb";
-import type { ListeningLogRecord } from "../types";
-import type { ListeningLogRepository } from "../domain/listening-log";
+} from "@/utils/dynamodb";
+import type { ListeningLogRecord } from "@/types";
+import type { ListeningLogRepository } from "@/domain/listening-log";
 
 export class DynamoDBListeningLogRepository implements ListeningLogRepository {
   async findById(id: ListeningLogId): Promise<ListeningLogRecord | undefined> {

--- a/backend/src/repositories/piece-repository.test.ts
+++ b/backend/src/repositories/piece-repository.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { PieceId } from "../domain/value-objects/ids";
-import type { Piece, PieceMovement, PieceWork } from "../types";
-import { DynamoDBPieceRepository } from "./piece-repository";
+import { PieceId } from "@/domain/value-objects/ids";
+import type { Piece, PieceMovement, PieceWork } from "@/types";
+import { DynamoDBPieceRepository } from "@/repositories/piece-repository";
 
 const { mockSend } = vi.hoisted(() => ({ mockSend: vi.fn() }));
 

--- a/backend/src/repositories/piece-repository.ts
+++ b/backend/src/repositories/piece-repository.ts
@@ -8,10 +8,10 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import createError from "http-errors";
 
-import type { PieceRepository } from "../domain/piece";
-import type { PieceId } from "../domain/value-objects/ids";
-import type { Piece, PieceMovement, PieceWork } from "../types";
-import { dynamo, putItemWithOptimisticLock, scanPage, TABLE_PIECES } from "../utils/dynamodb";
+import type { PieceRepository } from "@/domain/piece";
+import type { PieceId } from "@/domain/value-objects/ids";
+import type { Piece, PieceMovement, PieceWork } from "@/types";
+import { dynamo, putItemWithOptimisticLock, scanPage, TABLE_PIECES } from "@/utils/dynamodb";
 
 type LegacyVideoUrlPiece = Piece & { videoUrl?: string };
 

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import type { Composer, ListeningLog, ListeningLogRecord, Piece } from "../types";
+import type { Composer, ListeningLog, ListeningLogRecord, Piece } from "@/types";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 export const TEST_COMPOSER_ID = "00000000-0000-4000-8000-000000000001";

--- a/backend/src/types/index.ts
+++ b/backend/src/types/index.ts
@@ -1,5 +1,5 @@
 // 楽曲カテゴリ（shared/constants.ts から re-export）
-import type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "../../../shared/constants";
+import type { PieceGenre, PieceEra, PieceFormation, PieceRegion } from "@shared/constants";
 export {
   PIECE_GENRES,
   PIECE_ERAS,
@@ -17,15 +17,15 @@ export {
   COMPOSERS_PAGE_SIZE_MIN,
   COMPOSERS_PAGE_SIZE_MAX,
   COMPOSERS_PAGE_SIZE_DEFAULT,
-} from "../../../shared/constants";
+} from "@shared/constants";
 export type {
   PieceGenre,
   PieceEra,
   PieceFormation,
   PieceRegion,
   PieceKind,
-} from "../../../shared/constants";
-export type { Paginated } from "../../../shared/constants";
+} from "@shared/constants";
+export type { Paginated } from "@shared/constants";
 
 export type Rating = 1 | 2 | 3 | 4 | 5;
 

--- a/backend/src/usecases/auth-usecase.ts
+++ b/backend/src/usecases/auth-usecase.ts
@@ -1,10 +1,10 @@
 import { StatusCodes } from "http-status-codes";
 
-import { mapCognitoError } from "../domain/auth-error";
-import type { AuthContext } from "../domain/auth-error";
-import type { AuthRepository } from "../domain/auth";
-import { CognitoAuthRepository } from "../repositories/cognito-auth-repository";
-import type { CognitoError } from "../types";
+import { mapCognitoError } from "@/domain/auth-error";
+import type { AuthContext } from "@/domain/auth-error";
+import type { AuthRepository } from "@/domain/auth";
+import { CognitoAuthRepository } from "@/repositories/cognito-auth-repository";
+import type { CognitoError } from "@/types";
 
 const providerNameMap: Record<string, string> = {
   google: "Google",

--- a/backend/src/usecases/composer-usecase.ts
+++ b/backend/src/usecases/composer-usecase.ts
@@ -1,9 +1,9 @@
-import { ComposerEntity } from "../domain/composer";
-import type { ComposerRepository } from "../domain/composer";
-import { ComposerId } from "../domain/value-objects/ids";
-import { DynamoDBComposerRepository } from "../repositories/composer-repository";
-import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "../types";
-import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
+import { ComposerEntity } from "@/domain/composer";
+import type { ComposerRepository } from "@/domain/composer";
+import { ComposerId } from "@/domain/value-objects/ids";
+import { DynamoDBComposerRepository } from "@/repositories/composer-repository";
+import type { Composer, CreateComposerInput, Paginated, UpdateComposerInput } from "@/types";
+import { findByIdOrNotFound, toPaginatedResult } from "@/usecases/helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
 export { ComposerId };

--- a/backend/src/usecases/concert-log-usecase.ts
+++ b/backend/src/usecases/concert-log-usecase.ts
@@ -1,10 +1,10 @@
-import { ConcertLogEntity } from "../domain/concert-log";
-import type { ConcertLogRepository } from "../domain/concert-log";
-import { ConcertLogId } from "../domain/value-objects/ids";
-import type { UserId } from "../domain/value-objects/ids";
-import { DynamoDBConcertLogRepository } from "../repositories/concert-log-repository";
-import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "../types";
-import { loadOwnedEntityOrNotFound } from "./helpers";
+import { ConcertLogEntity } from "@/domain/concert-log";
+import type { ConcertLogRepository } from "@/domain/concert-log";
+import { ConcertLogId } from "@/domain/value-objects/ids";
+import type { UserId } from "@/domain/value-objects/ids";
+import { DynamoDBConcertLogRepository } from "@/repositories/concert-log-repository";
+import type { ConcertLog, CreateConcertLogInput, UpdateConcertLogInput } from "@/types";
+import { loadOwnedEntityOrNotFound } from "@/usecases/helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
 export { ConcertLogId };

--- a/backend/src/usecases/helpers.ts
+++ b/backend/src/usecases/helpers.ts
@@ -1,8 +1,8 @@
 import createError from "http-errors";
 
-import type { EntityId, UserId } from "../domain/value-objects/ids";
-import type { Paginated } from "../types";
-import { encodeCursor } from "../utils/cursor";
+import type { EntityId, UserId } from "@/domain/value-objects/ids";
+import type { Paginated } from "@/types";
+import { encodeCursor } from "@/utils/cursor";
 
 type Owned = { isOwnedBy(userId: UserId): boolean };
 

--- a/backend/src/usecases/listening-log-usecase.ts
+++ b/backend/src/usecases/listening-log-usecase.ts
@@ -1,16 +1,16 @@
 import createError from "http-errors";
 
-import type { ComposerRepository } from "../domain/composer";
-import { ListeningLogDetail } from "../domain/listening-log-detail";
-import { ListeningLogEntity } from "../domain/listening-log";
-import type { ListeningLogRepository } from "../domain/listening-log";
-import { PieceComponent, PieceWorkEntity } from "../domain/piece";
-import type { PieceRepository } from "../domain/piece";
-import { ComposerId, ListeningLogId, PieceId } from "../domain/value-objects/ids";
-import type { UserId } from "../domain/value-objects/ids";
-import { DynamoDBComposerRepository } from "../repositories/composer-repository";
-import { DynamoDBListeningLogRepository } from "../repositories/listening-log-repository";
-import { DynamoDBPieceRepository } from "../repositories/piece-repository";
+import type { ComposerRepository } from "@/domain/composer";
+import { ListeningLogDetail } from "@/domain/listening-log-detail";
+import { ListeningLogEntity } from "@/domain/listening-log";
+import type { ListeningLogRepository } from "@/domain/listening-log";
+import { PieceComponent, PieceWorkEntity } from "@/domain/piece";
+import type { PieceRepository } from "@/domain/piece";
+import { ComposerId, ListeningLogId, PieceId } from "@/domain/value-objects/ids";
+import type { UserId } from "@/domain/value-objects/ids";
+import { DynamoDBComposerRepository } from "@/repositories/composer-repository";
+import { DynamoDBListeningLogRepository } from "@/repositories/listening-log-repository";
+import { DynamoDBPieceRepository } from "@/repositories/piece-repository";
 import type {
   Composer,
   CreateListeningLogInput,
@@ -18,8 +18,8 @@ import type {
   Piece,
   PieceWork,
   UpdateListeningLogInput,
-} from "../types";
-import { loadOwnedEntityOrNotFound } from "./helpers";
+} from "@/types";
+import { loadOwnedEntityOrNotFound } from "@/usecases/helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
 export { ListeningLogId };

--- a/backend/src/usecases/piece-usecase.test.ts
+++ b/backend/src/usecases/piece-usecase.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import type { ListeningLogRepository } from "../domain/listening-log";
-import type { PieceRepository } from "../domain/piece";
-import { PieceId } from "../domain/value-objects/ids";
-import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "../types";
-import { MovementUsecase, PieceUsecase, WorkUsecase } from "./piece-usecase";
+import type { ListeningLogRepository } from "@/domain/listening-log";
+import type { PieceRepository } from "@/domain/piece";
+import { PieceId } from "@/domain/value-objects/ids";
+import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "@/types";
+import { MovementUsecase, PieceUsecase, WorkUsecase } from "@/usecases/piece-usecase";
 
 const TEST_COMPOSER_ID = "00000000-0000-4000-8000-000000000001";
 const TEST_WORK_ID = "00000000-0000-4000-8000-00000000aaaa";

--- a/backend/src/usecases/piece-usecase.ts
+++ b/backend/src/usecases/piece-usecase.ts
@@ -1,11 +1,11 @@
 import createError from "http-errors";
 
-import type { ListeningLogRepository } from "../domain/listening-log";
-import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "../domain/piece";
-import type { PieceRepository } from "../domain/piece";
-import { ComposerId, PieceId } from "../domain/value-objects/ids";
-import { DynamoDBListeningLogRepository } from "../repositories/listening-log-repository";
-import { DynamoDBPieceRepository } from "../repositories/piece-repository";
+import type { ListeningLogRepository } from "@/domain/listening-log";
+import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "@/domain/piece";
+import type { PieceRepository } from "@/domain/piece";
+import { ComposerId, PieceId } from "@/domain/value-objects/ids";
+import { DynamoDBListeningLogRepository } from "@/repositories/listening-log-repository";
+import { DynamoDBPieceRepository } from "@/repositories/piece-repository";
 import type {
   CreateMovementInput,
   CreatePieceInput,
@@ -17,8 +17,8 @@ import type {
   UpdateMovementInput,
   UpdatePieceInput,
   UpdateWorkInput,
-} from "../types";
-import { findByIdOrNotFound, toPaginatedResult } from "./helpers";
+} from "@/types";
+import { findByIdOrNotFound, toPaginatedResult } from "@/usecases/helpers";
 
 // handlers 層は domain へ直接アクセスできないため、ID 値オブジェクトを usecase 層経由で公開する
 export { PieceId };

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
-import { getUserId, getUserGroups, isAdmin, requireAdmin } from "./auth";
+import { getUserId, getUserGroups, isAdmin, requireAdmin } from "@/utils/auth";
 
 const makeEvent = (authorizer: unknown): APIGatewayProxyEvent =>
   ({

--- a/backend/src/utils/auth.ts
+++ b/backend/src/utils/auth.ts
@@ -1,7 +1,7 @@
 import createError from "http-errors";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
-import { UserId } from "../domain/value-objects/ids";
+import { UserId } from "@/domain/value-objects/ids";
 
 type CognitoAuthorizerContext = {
   claims: {

--- a/backend/src/utils/cursor.test.ts
+++ b/backend/src/utils/cursor.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
 
-import { encodeCursor, decodeCursor, InvalidCursorError } from "./cursor";
+import { encodeCursor, decodeCursor, InvalidCursorError } from "@/utils/cursor";
 
 describe("encodeCursor / decodeCursor", () => {
   it("LastEvaluatedKey をエンコードしてデコードすると元の値に戻る", () => {

--- a/backend/src/utils/dynamodb.test.ts
+++ b/backend/src/utils/dynamodb.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 
-import { putItemWithOptimisticLock, queryItemsByUserId, scanAllItems, scanPage } from "./dynamodb";
+import {
+  putItemWithOptimisticLock,
+  queryItemsByUserId,
+  scanAllItems,
+  scanPage,
+} from "@/utils/dynamodb";
 
 const { mockSend } = vi.hoisted(() => ({
   mockSend: vi.fn(),

--- a/backend/src/utils/dynamodb.ts
+++ b/backend/src/utils/dynamodb.ts
@@ -7,7 +7,7 @@ import {
 } from "@aws-sdk/lib-dynamodb";
 import createError from "http-errors";
 
-import { getEnv } from "./env";
+import { getEnv } from "@/utils/env";
 
 const client = new DynamoDBClient({ region: getEnv().awsRegion });
 

--- a/backend/src/utils/env.test.ts
+++ b/backend/src/utils/env.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach } from "vitest";
 
-import { AppEnv } from "./env";
+import { AppEnv } from "@/utils/env";
 
 describe("AppEnv", () => {
   afterEach(() => {

--- a/backend/src/utils/handler.ts
+++ b/backend/src/utils/handler.ts
@@ -1,11 +1,11 @@
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import type { ZodType } from "zod";
 
-import { getUserId, requireAdmin } from "./auth";
-import { createAdminHandler, createHandler, jsonBodyParser } from "./middleware";
-import { parseRequestBody } from "./parsing";
-import { getIdParam } from "./path-params";
-import type { UserId } from "../domain/value-objects/ids";
+import { getUserId, requireAdmin } from "@/utils/auth";
+import { createAdminHandler, createHandler, jsonBodyParser } from "@/utils/middleware";
+import { parseRequestBody } from "@/utils/parsing";
+import { getIdParam } from "@/utils/path-params";
+import type { UserId } from "@/domain/value-objects/ids";
 
 type IdFactory<TId> = (value: string) => TId;
 

--- a/backend/src/utils/middleware.ts
+++ b/backend/src/utils/middleware.ts
@@ -5,8 +5,8 @@ import httpResponseSerializer from "@middy/http-response-serializer";
 import type { HttpError } from "http-errors";
 import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from "aws-lambda";
 
-import { requireAdmin } from "./auth";
-import { getEnv } from "./env";
+import { requireAdmin } from "@/utils/auth";
+import { getEnv } from "@/utils/env";
 
 export type LambdaHandler = (
   event: APIGatewayProxyEvent,

--- a/backend/src/utils/parsing.test.ts
+++ b/backend/src/utils/parsing.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { encodeCursor } from "./cursor";
-import { parseListQuery, parseRequestBody } from "./parsing";
+import { encodeCursor } from "@/utils/cursor";
+import { parseListQuery, parseRequestBody } from "@/utils/parsing";
 
 type TestInput = { name: string; value?: number };
 

--- a/backend/src/utils/parsing.ts
+++ b/backend/src/utils/parsing.ts
@@ -1,7 +1,7 @@
 import createError from "http-errors";
 import type { ZodType } from "zod";
 
-import { decodeCursor, InvalidCursorError } from "./cursor";
+import { decodeCursor, InvalidCursorError } from "@/utils/cursor";
 
 export function parseRequestBody<T>(body: unknown, schema?: ZodType<T>): T {
   if (body === null || body === undefined) {

--- a/backend/src/utils/path-params.test.ts
+++ b/backend/src/utils/path-params.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
-import { getIdParam } from "./path-params";
-import { PieceId } from "../domain/value-objects/ids";
+import { getIdParam } from "@/utils/path-params";
+import { PieceId } from "@/domain/value-objects/ids";
 
 const makeEvent = (pathParameters: Record<string, string> | null): APIGatewayProxyEvent =>
   ({ pathParameters }) as unknown as APIGatewayProxyEvent;

--- a/backend/src/utils/response.test.ts
+++ b/backend/src/utils/response.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ok, badRequest, tooManyRequests, internalError } from "./response";
+import { ok, badRequest, tooManyRequests, internalError } from "@/utils/response";
 
 describe("response helpers", () => {
   describe("ok", () => {

--- a/backend/src/utils/schemas.test.ts
+++ b/backend/src/utils/schemas.test.ts
@@ -10,12 +10,12 @@ import {
   verifyEmailSchema,
   resendVerificationCodeSchema,
   listPiecesQuerySchema,
-} from "./schemas";
+} from "@/utils/schemas";
 import {
   PIECES_PAGE_SIZE_DEFAULT,
   PIECES_PAGE_SIZE_MAX,
   PIECES_PAGE_SIZE_MIN,
-} from "../types/index.js";
+} from "@/types/index.js";
 
 const fails = (result: { success: boolean }): boolean => !result.success;
 const succeeds = (result: { success: boolean }): boolean => result.success;

--- a/backend/src/utils/schemas.ts
+++ b/backend/src/utils/schemas.ts
@@ -13,7 +13,7 @@ import {
   COMPOSERS_PAGE_SIZE_DEFAULT,
   COMPOSERS_PAGE_SIZE_MAX,
   COMPOSERS_PAGE_SIZE_MIN,
-} from "../types/index.js";
+} from "@/types/index.js";
 
 const ratingSchema = z
   .number({ error: () => "rating must be between 1 and 5" })

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,9 +13,8 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node", "vitest/globals"],
-    "baseUrl": ".",
     "paths": {
-      "@/*": ["src/*"],
+      "@/*": ["./src/*"],
       "@shared/*": ["../shared/*"]
     }
   },

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -12,7 +12,12 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node", "vitest/globals"]
+    "types": ["node", "vitest/globals"],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@shared/*": ["../shared/*"]
+    }
   },
   "include": ["src/**/*", "../shared/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -3,6 +3,12 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   root: path.resolve(__dirname, ".."),
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+      "@shared": path.resolve(__dirname, "../shared"),
+    },
+  },
   server: {
     fs: {
       allow: [path.resolve(__dirname, "..")],

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -377,6 +377,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
         minify: true,
         sourceMap: false,
         target: "es2022",
+        tsconfig: path.join(backendSrcDir, "..", "tsconfig.json"),
       },
     };
 

--- a/cdk/lib/migrations-stack.ts
+++ b/cdk/lib/migrations-stack.ts
@@ -72,6 +72,7 @@ export class MigrationsStack extends cdk.Stack {
         minify: true,
         sourceMap: false,
         target: "es2022",
+        tsconfig: path.join(backendSrcDir, "..", "tsconfig.json"),
       },
       role: this.makeMigrationRole("MigratePieceKindBackfillRole", [piecesTable]),
     });

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -528,6 +528,26 @@ cd cdk && pnpm install && cdk bootstrap && cdk deploy
 
 ## 8. 型定義管理方針
 
+### 8.0 import エイリアス方針
+
+フロント・バックエンド・テストの全ファイルで相対 import（`./` `../`）と Nuxt の `~/` は使わず、`@/` `@shared/` エイリアスに統一する。
+
+- フロントエンド（`app/` 配下）: `@/` → `app/` ルート（Nuxt 標準）/ `@shared/` → リポジトリルートの `shared/`（`nuxt.config.ts` の `alias` で定義）
+- バックエンド（`backend/src/` 配下）: `@/` → `backend/src/` / `@shared/` → `shared/`（`backend/tsconfig.json` の `paths` と `backend/vitest.config.mts` の `resolve.alias` で定義）
+- NodejsFunction の esbuild バンドルは `bundling.tsconfig` で backend の tsconfig を明示しているため、Lambda ビルド時もエイリアスが解決される
+
+例:
+
+```ts
+// 良い
+import { PIECE_GENRES } from "@shared/constants";
+import { ListeningLogEntity } from "@/domain/listening-log";
+
+// 悪い（相対 import / ~/ は禁止）
+import { PIECE_GENRES } from "../../shared/constants";
+import type { PieceWork } from "~/types";
+```
+
 ### 8.1 フロント・バックエンド共通型の管理
 
 フロントエンド（`app/types/index.ts`）とバックエンド（`backend/src/types/index.ts`）はパッケージが分離されているため、共有型は両ファイルに重複定義する。ただしフロント・バックエンドで共通の定数・型は `shared/` ディレクトリに一元管理し、各パッケージの型定義ファイルから re-export する。

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,12 @@
+import { fileURLToPath } from "node:url";
 import { codecovVitePlugin } from "@codecov/vite-plugin";
 
 // https://nuxt.com/docs/api/configuration/nuxt-config
 export default defineNuxtConfig({
   compatibilityDate: "2025-01-01",
+  alias: {
+    "@shared": fileURLToPath(new URL("./shared", import.meta.url)),
+  },
   ssr: false,
   devtools: { enabled: true },
   // NOTE: 3000だとなぜか起動できない

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineVitestConfig } from "@nuxt/test-utils/config";
 
 export default defineVitestConfig({
+  resolve: {
+    alias: {
+      "@shared": path.resolve(__dirname, "./shared"),
+    },
+  },
   test: {
     globals: true,
     environment: "nuxt",


### PR DESCRIPTION
## Summary

フロントエンド・バックエンド両方の import を相対パス（`./`, `../`, `~/`）から `@/...` / `@shared/...` のエイリアス形式に統一しました。

### 変更内容

- **設定**
  - `nuxt.config.ts`: `alias.@shared` を追加
  - `backend/tsconfig.json`: `baseUrl` + `paths` (`@/*` → `src/*`, `@shared/*` → `../shared/*`)
  - `backend/vitest.config.mts` / `vitest.config.ts`: `resolve.alias` を追加
  - `cdk/lib/*-stack.ts`: NodejsFunction bundling に `tsconfig` を明示
- **import 書き換え**: `app/**`, `backend/src/**`, `tests/**` の相対 import を一括変換（349 ファイル）
- **ドキュメント**: `docs/SPEC.md` §8 に import エイリアス方針を追記

### 品質チェック

- `pnpm run lint` ✅
- `pnpm run test:backend` ✅ 799 tests
- `pnpm run test:frontend` ✅ 786 tests
- `pnpm run format:check` ✅

## Test plan

- [ ] CI が緑であること
- [ ] CDK synth / deploy で esbuild が tsconfig paths を解決できるか stg で確認


---
_Generated by [Claude Code](https://claude.ai/code/session_01YDqHC8YaXK8YpJVy9f2qAw)_