### PR TITLE
refactor: 不要な真偽リテラル比較を削除して if (x) に統一

### DIFF
--- a/app/components/atoms/ThemeToggle.vue
+++ b/app/components/atoms/ThemeToggle.vue
@@ -4,11 +4,11 @@ const colorMode = useColorMode();
 const isDark = computed(() => colorMode.value === "dark");
 
 const toggle = () => {
-  colorMode.preference = isDark.value === true ? "light" : "dark";
+  colorMode.preference = isDark.value ? "light" : "dark";
 };
 
 const ariaLabel = computed(() =>
-  isDark.value === true ? "ライトモードに切り替え" : "ダークモードに切り替え",
+  isDark.value ? "ライトモードに切り替え" : "ダークモードに切り替え",
 );
 </script>
 

--- a/app/components/molecules/PasswordInput.vue
+++ b/app/components/molecules/PasswordInput.vue
@@ -14,7 +14,7 @@ defineEmits<{
 const isVisible = ref(false);
 
 function toggleVisibility() {
-  isVisible.value = isVisible.value === false;
+  isVisible.value = !isVisible.value;
 }
 </script>
 

--- a/app/components/molecules/VideoPlayer.vue
+++ b/app/components/molecules/VideoPlayer.vue
@@ -32,7 +32,7 @@ const iframeId = `yt-player-${Math.random().toString(36).slice(2)}`; // NOSONAR:
 let player: YTPlayer | undefined;
 
 onMounted(() => {
-  if (isYouTube.value === false) {
+  if (!isYouTube.value) {
     return;
   }
 

--- a/app/components/organisms/ConcertLogForm.vue
+++ b/app/components/organisms/ConcertLogForm.vue
@@ -66,7 +66,7 @@ function addPiece() {
   if (piece === undefined) {
     return;
   }
-  if (selectedPieces.value.some((p) => p.id === piece.id) === true) {
+  if (selectedPieces.value.some((p) => p.id === piece.id)) {
     return;
   }
   selectedPieces.value.push(piece);

--- a/app/components/organisms/FeaturedPiece.vue
+++ b/app/components/organisms/FeaturedPiece.vue
@@ -30,7 +30,7 @@ const featured = computed(() => piecesWithVideo.value[currentIndex.value] ?? nul
 const canShuffle = computed(() => piecesWithVideo.value.length > 1);
 
 const shuffle = () => {
-  if (canShuffle.value === false) {
+  if (!canShuffle.value) {
     return;
   }
   let next = currentIndex.value;

--- a/app/components/organisms/PieceForm.vue
+++ b/app/components/organisms/PieceForm.vue
@@ -70,7 +70,7 @@ watch(
 const canAddVideoUrl = computed<boolean>(() => form.videoUrls.length < VIDEO_URLS_MAX);
 
 function addVideoUrl() {
-  if (canAddVideoUrl.value === true) {
+  if (canAddVideoUrl.value) {
     form.videoUrls.push("");
   }
 }
@@ -110,8 +110,8 @@ function handleSubmit() {
         v-model="form.composerId"
         required
         :options="composerOptions"
-        :disabled="composersPending === true"
-        :placeholder="composersPending === true ? '読み込み中...' : '作曲家を選択'"
+        :disabled="composersPending"
+        :placeholder="composersPending ? '読み込み中...' : '作曲家を選択'"
       />
     </FormGroup>
 

--- a/app/composables/useAuthenticatedApi.ts
+++ b/app/composables/useAuthenticatedApi.ts
@@ -16,8 +16,7 @@ export const useAuthenticatedApi = () => {
 
     const { refreshTokens, clearTokens } = useAuth();
     const refreshed = await refreshTokens();
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare -- 自動インポートにより any として解決される環境があるため
-    if (refreshed === true) {
+    if (refreshed) {
       return true;
     }
 
@@ -72,8 +71,7 @@ export const useAuthenticatedApi = () => {
 
     if (response.status === 401) {
       const refreshed = await handleAuthError(response.status);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare -- 自動インポートにより any として解決される環境があるため
-      if (refreshed === true) {
+      if (refreshed) {
         const retried = await doFetch(url, options);
         if (retried.status === 401) {
           const { clearTokens } = useAuth();

--- a/app/composables/useCrudResource.ts
+++ b/app/composables/useCrudResource.ts
@@ -16,8 +16,7 @@ export const useCrudResource = <TEntity, TCreateInput, TUpdateInput>(resourceNam
     headers: computed(() => getAuthHeaders()),
     async onResponseError({ response }) {
       const refreshed = await handleAuthError(response.status);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare -- 自動インポートにより any として解決される環境があるため
-      if (refreshed === true) {
+      if (refreshed) {
         await list.refresh();
       }
     },
@@ -64,8 +63,7 @@ export const useCrudResourceItem = <TEntity>(resourceName: string, id: () => str
     headers: computed(() => getAuthHeaders()),
     async onResponseError({ response }) {
       const refreshed = await handleAuthError(response.status);
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare -- 自動インポートにより any として解決される環境があるため
-      if (refreshed === true) {
+      if (refreshed) {
         await result.refresh();
       }
     },

--- a/app/composables/useListeningLogFilter.ts
+++ b/app/composables/useListeningLogFilter.ts
@@ -82,7 +82,7 @@ export const useListeningLogFilter = (logs: Ref<ListeningLog[] | null | undefine
     return (
       s.keyword.length > 0 ||
       s.rating !== "" ||
-      s.favoriteOnly === true ||
+      s.favoriteOnly ||
       s.fromDate.length > 0 ||
       s.toDate.length > 0
     );

--- a/app/composables/usePaginatedList.ts
+++ b/app/composables/usePaginatedList.ts
@@ -28,10 +28,10 @@ export const usePaginatedList = <T>(fetchPage: (cursor?: string) => Promise<Page
   const hasMore = ref<boolean>(true);
 
   const loadMore = async () => {
-    if (pending.value === true) {
+    if (pending.value) {
       return;
     }
-    if (hasMore.value === false) {
+    if (!hasMore.value) {
       return;
     }
     pending.value = true;

--- a/app/middleware/admin.ts
+++ b/app/middleware/admin.ts
@@ -4,7 +4,7 @@ export default defineNuxtRouteMiddleware(() => {
   }
 
   const { isAdmin } = useAuth();
-  if (isAdmin() !== true) {
+  if (!isAdmin()) {
     return navigateTo("/", { replace: true });
   }
 });

--- a/app/middleware/auth.ts
+++ b/app/middleware/auth.ts
@@ -13,9 +13,9 @@ export default defineNuxtRouteMiddleware(async () => {
   }
 
   const { isTokenExpired, refreshTokens, clearTokens } = useAuth();
-  if (isTokenExpired() === true) {
+  if (isTokenExpired()) {
     const refreshed = await refreshTokens();
-    if (refreshed !== true) {
+    if (!refreshed) {
       clearTokens();
       return navigateTo("/auth/login", { replace: true });
     }

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -25,7 +25,7 @@ onMounted(async () => {
     return;
   }
   const result = await handleOAuthCallback(code);
-  if (result.success === true) {
+  if (result.success) {
     await router.push("/");
   } else {
     error.value = "ログインに失敗しました。もう一度お試しください。";

--- a/app/pages/auth/login.vue
+++ b/app/pages/auth/login.vue
@@ -21,7 +21,7 @@ async function handleSubmit(email: string, password: string) {
   try {
     const result = await login(email, password);
 
-    if (result.success === true) {
+    if (result.success) {
       await router.push("/");
     } else if (result.errorType === "email") {
       errors.email = "有効なメールアドレスを入力してください";

--- a/app/pages/auth/user-register.vue
+++ b/app/pages/auth/user-register.vue
@@ -15,7 +15,7 @@ async function handleSubmit(email: string, password: string) {
   errors.email = "";
   errors.password = "";
 
-  if (validateEmail(email) === false) {
+  if (!validateEmail(email)) {
     errors.email = "有効なメールアドレスを入力してください";
     return;
   }
@@ -25,7 +25,7 @@ async function handleSubmit(email: string, password: string) {
   try {
     const result = await register(email, password);
 
-    if (result.success === true) {
+    if (result.success) {
       sessionStorage.setItem("pendingPassword", password);
       router.push({ path: "/auth/verify-email", state: { email } });
       return;
@@ -37,7 +37,7 @@ async function handleSubmit(email: string, password: string) {
       errors.email = message;
     } else if (result.errorType === "password") {
       errors.password = message;
-    } else if (message.includes("already") === true || message.includes("既に") === true) {
+    } else if (message.includes("already") || message.includes("既に")) {
       errors.email = "このメールアドレスは既に登録されています";
     } else {
       errors.email = message;

--- a/app/pages/auth/verify-email.vue
+++ b/app/pages/auth/verify-email.vue
@@ -29,7 +29,7 @@ async function handleSubmit(code: string) {
 
   try {
     const verifyResult = await verifyEmail(email.value, code);
-    if (verifyResult.success === false) {
+    if (!verifyResult.success) {
       error.value =
         verifyResult.error !== undefined && verifyResult.error !== ""
           ? verifyResult.error
@@ -39,7 +39,7 @@ async function handleSubmit(code: string) {
 
     const loginResult = await login(email.value, password.value);
     sessionStorage.removeItem("pendingPassword");
-    if (loginResult.success === false) {
+    if (!loginResult.success) {
       error.value =
         "確認は完了しましたが、ログインに失敗しました。ログイン画面からログインしてください。";
       return;
@@ -58,7 +58,7 @@ async function handleResend() {
 
   try {
     const result = await resendVerificationCode(email.value);
-    if (result.success === true) {
+    if (result.success) {
       infoMessage.value = "認証コードを再送しました。メールをご確認ください。";
     } else {
       error.value =

--- a/backend/src/utils/parsing.ts
+++ b/backend/src/utils/parsing.ts
@@ -12,8 +12,7 @@ export function parseRequestBody<T>(body: unknown, schema?: ZodType<T>): T {
   }
   if (schema !== undefined) {
     const result = schema.safeParse(body);
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-boolean-literal-compare -- SafeParseReturnType の success が any として解決される環境があるため明示比較が必要
-    if (result.success === false) {
+    if (!result.success) {
       throw new createError.BadRequest(result.error.issues[0].message);
     }
     return result.data;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["vitest/globals"]
   },
-  "exclude": ["backend/**", "cdk/**", "node_modules", ".nuxt", "dist", ".output"]
+  "exclude": ["backend/**", "cdk/**", "node_modules", "dist", ".output"]
 }


### PR DESCRIPTION
## Summary

`if (hoge === true)` のような不要な真偽リテラル比較を `if (hoge)` に統一した。

### 根本原因と修正

`tsconfig.json` の `exclude` に `.nuxt` が含まれていたため、Nuxt の auto-import 型定義（`.nuxt/types/imports.d.ts` の `const ref: typeof import('vue').ref` など）が ESLint の TypeScript プロジェクト解決から外れていた。結果として `ref` / `computed` / `useFetch` などの戻り値が `any` 扱いになり、`@typescript-eslint/strict-boolean-expressions` がトリガーされ、回避のため `=== true` パターンが各所に蓄積していた。

`tsconfig.json` の exclude から `.nuxt` を外したことで型解決が正常化し、`@typescript-eslint/no-unnecessary-boolean-literal-compare` を満たす形に書き換え可能になった。

### 変更内容

- `tsconfig.json`: exclude から `.nuxt` を削除
- Vue / composables / middleware / page 各所の `=== true` / `=== false` / `!== true` を `if (x)` / `if (!x)` に整理
- `useAuthenticatedApi.ts` / `useCrudResource.ts` / `parsing.ts` の `eslint-disable @typescript-eslint/no-unnecessary-boolean-literal-compare` コメントを除去
- `middleware.ts` の `HttpError.expose === true` は `[key: string]: any` index signature 由来の `any` のため eslint-disable を維持

### 残した `=== true`

`backend/src/utils/handler.ts` の `options.admin?: boolean` / `options.userId?: boolean` と migrations の `event.dryRun` は `boolean | undefined` で、`strict-boolean-expressions` の `allowNullableBoolean: false` 設定上、明示比較が必要なため据え置き。

## Test plan

- [x] `pnpm run lint` がグリーン
- [x] `pnpm run test:frontend` 全 786 テスト通過
- [x] `pnpm run test:backend` 全 799 テスト通過

https://claude.ai/code/session_014mHNwV3XAqhDKFoedSar6T

---
_Generated by [Claude Code](https://claude.ai/code/session_014mHNwV3XAqhDKFoedSar6T)_