### PR TITLE
fix(backend): tsconfig の moduleResolution を bundler に切り替えて型解決を回復

### DIFF
--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2023",
-    "module": "commonjs",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["ES2023"],
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
## 概要

`backend/src/handlers/auth/login.ts` で `parseRequestBody(...)` の戻り値 `input` が `unknown` として扱われ、`input.email` / `input.password` を型安全に参照できない問題を修正する。

## 原因

`@middy/core` 7.5.0（および周辺パッケージ）が `package.json` の `exports` フィールドから `require` 条件を落とした ESM-only パッケージに移行しているにもかかわらず、`backend/tsconfig.json` は `module: "commonjs"`（= `moduleResolution: "node"` 既定）のままだった。

旧 `node` 解決アルゴリズムは `exports` の条件付きエクスポートを読まないため、

```text
src/utils/middleware.ts(1,19): error TS2307: Cannot find module '@middy/core' or its corresponding type declarations.
src/utils/middleware.ts(2,22): error TS2307: Cannot find module '@middy/http-cors' …
src/utils/middleware.ts(3,32): error TS2307: Cannot find module '@middy/http-json-body-parser' …
src/utils/middleware.ts(4,36): error TS2307: Cannot find module '@middy/http-response-serializer' …
src/utils/middleware.ts(25,19): error TS7006: Parameter 'request' implicitly has an 'any' type.
src/utils/middleware.ts(75,26): error TS7006: Parameter 'response' implicitly has an 'any' type.
```

が発生していた。これにより `middleware.ts` で定義している `createHandler` の戻り値型・コールバック引数型が事実上 `any` 相当に退化し、`createHandler(async (event) => …)` 内の `event` が `any` 化、その結果 `parseRequestBody(event.body as unknown, loginSchema)` の戻り値である `input` までもが `unknown` として表示される、というカスケードが起きていた。

つまり「`login.ts` で `input` が `unknown`」という症状は表面的な現象で、`@middy/*` の型が `tsconfig` の解決設定で見つけられていないことが根本原因だった。同じ `createHandler` を経由する `handlers/auth/*`・`handlers/concert-logs/*`・`handlers/composers/*`・`handlers/pieces/*`・`handlers/listening-logs/*` のすべてが同じ性質の劣化を受けていた。

## 修正

`backend/tsconfig.json` を以下のように更新:

- `module: "commonjs"` → `module: "esnext"`
- `moduleResolution: "bundler"` を追加

`bundler` 解決は `exports` 条件付きパッケージを正しく解決するため、`@middy/*` の型が読み込まれるようになり、`createHandler` 経由のすべてのハンドラで `event` / `body` の型が正しく流れる。Lambda 用の実行体は `NodejsFunction` の esbuild バンドルで CJS に変換しているため、ランタイム挙動には影響しない。

## 検証

- `pnpm -C backend exec tsc --noEmit`: `@middy` 関連の 6 件のエラーと、それに連鎖していた `unknown` 系のハンドラ側エラーが解消（残るエラーは本 PR の範囲外の既存ドメイン層の型ずれや `.test.ts` 側のもので、別 PR で扱う）
- `pnpm -C backend test`: 55 ファイル / 799 ケース すべてグリーン

## Test plan

- [ ] CI のバックエンドテストがグリーンであること
- [ ] `pnpm -C backend exec tsc --noEmit` で `Cannot find module '@middy/*'` が発生しないこと
- [ ] `backend/src/handlers/auth/login.ts` の `input` が `{ email: string; password: string }` として推論されること


---
_Generated by [Claude Code](https://claude.ai/code/session_013XXahTef24EUsBXfEjdtnv)_