### PR TITLE
refactor(backend): event.body の不要な as unknown キャストを削除

### DIFF
--- a/backend/src/handlers/auth/login.ts
+++ b/backend/src/handlers/auth/login.ts
@@ -6,6 +6,6 @@ import { createAuthUsecase } from "@/usecases/auth-usecase";
 const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, loginSchema);
+  const input = parseRequestBody(event.body, loginSchema);
   return usecase.login(input.email, input.password);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/refresh.ts
+++ b/backend/src/handlers/auth/refresh.ts
@@ -6,6 +6,6 @@ import { createAuthUsecase } from "@/usecases/auth-usecase";
 const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, refreshTokenSchema);
+  const input = parseRequestBody(event.body, refreshTokenSchema);
   return usecase.refreshToken(input.refreshToken);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/register.ts
+++ b/backend/src/handlers/auth/register.ts
@@ -6,6 +6,6 @@ import { createAuthUsecase } from "@/usecases/auth-usecase";
 const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, registerSchema);
+  const input = parseRequestBody(event.body, registerSchema);
   return usecase.register(input.email, input.password);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/resend-verification-code.ts
+++ b/backend/src/handlers/auth/resend-verification-code.ts
@@ -6,6 +6,6 @@ import { createAuthUsecase } from "@/usecases/auth-usecase";
 const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, resendVerificationCodeSchema);
+  const input = parseRequestBody(event.body, resendVerificationCodeSchema);
   return usecase.resendVerificationCode(input.email);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/auth/verify-email.ts
+++ b/backend/src/handlers/auth/verify-email.ts
@@ -6,6 +6,6 @@ import { createAuthUsecase } from "@/usecases/auth-usecase";
 const usecase = createAuthUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, verifyEmailSchema);
+  const input = parseRequestBody(event.body, verifyEmailSchema);
   return usecase.verifyEmail(input.email, input.code);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/concert-logs/create.ts
+++ b/backend/src/handlers/concert-logs/create.ts
@@ -8,7 +8,7 @@ import { createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 const usecase = createConcertLogUsecase();
 
 export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, createConcertLogSchema);
+  const input = parseRequestBody(event.body, createConcertLogSchema);
   const userId = getUserId(event);
   const log = await usecase.create(input, userId);
   return created(log);

--- a/backend/src/handlers/concert-logs/update.ts
+++ b/backend/src/handlers/concert-logs/update.ts
@@ -10,7 +10,7 @@ const usecase = createConcertLogUsecase();
 
 export const handler = createHandler(async (event) => {
   const id = getIdParam(event, ConcertLogId.from);
-  const input = parseRequestBody(event.body as unknown, updateConcertLogSchema);
+  const input = parseRequestBody(event.body, updateConcertLogSchema);
   const userId = getUserId(event);
   const updated = await usecase.update(id, input, userId);
   return ok(updated);

--- a/backend/src/handlers/pieces/create.ts
+++ b/backend/src/handlers/pieces/create.ts
@@ -7,7 +7,7 @@ import { createPieceUsecase } from "@/usecases/piece-usecase";
 const usecase = createPieceUsecase();
 
 export const handler = createAdminHandler(async (event) => {
-  const input = parseRequestBody(event.body as unknown, createPieceSchema);
+  const input = parseRequestBody(event.body, createPieceSchema);
   const piece = await usecase.create(input);
   return created(piece);
 }).use(jsonBodyParser);

--- a/backend/src/handlers/pieces/replace-movements.ts
+++ b/backend/src/handlers/pieces/replace-movements.ts
@@ -22,7 +22,7 @@ const usecase = createMovementUsecase();
  */
 export const handler = createAdminHandler(async (event) => {
   const workId = getIdParam(event, PieceId.from);
-  const input = parseRequestBody(event.body as unknown, replaceMovementsSchema);
+  const input = parseRequestBody(event.body, replaceMovementsSchema);
   const movements = await usecase.replaceAll(workId, input.movements);
   return ok({ movements });
 }).use(jsonBodyParser);

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -9,7 +9,7 @@ const usecase = createPieceUsecase();
 
 export const handler = createAdminHandler(async (event) => {
   const id = getIdParam(event, PieceId.from);
-  const input = parseRequestBody(event.body as unknown, updatePieceSchema);
+  const input = parseRequestBody(event.body, updatePieceSchema);
   const piece = await usecase.update(id, input);
   return ok(piece);
 }).use(jsonBodyParser);

--- a/backend/src/utils/handler.ts
+++ b/backend/src/utils/handler.ts
@@ -50,7 +50,7 @@ export const withHandler = <TBody = undefined, TId = undefined>(options: {
         : (undefined as unknown as TId);
     const body =
       options.schema !== undefined
-        ? parseRequestBody(event.body as unknown, options.schema)
+        ? parseRequestBody(event.body, options.schema)
         : (undefined as unknown as TBody);
     const userId = options.userId === true ? getUserId(event) : (undefined as unknown as UserId);
     return options.handler({ event, body, id, userId });


### PR DESCRIPTION
## Summary

- `parseRequestBody` の第1引数 `body: unknown` に対し、`string | null` 型の `event.body` は暗黙的に代入可能であるため、`as unknown` キャストは不要だった
- 11ファイルから一括削除
- 型エラー件数に変化なし（削除前後ともに既存の無関係なエラーのみ）

## Test plan

- [x] `pnpm tsc --noEmit` でエラー件数が変化しないことを確認
- [x] フロントエンド・バックエンド全テストがグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)