### PR TITLE
refactor(backend): vitest globals を有効化し明示インポートを削除

### DIFF
--- a/backend/src/domain/composer.test.ts
+++ b/backend/src/domain/composer.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { ComposerEntity } from "@/domain/composer";
 import type { Composer, CreateComposerInput } from "@/types";
 

--- a/backend/src/domain/concert-log.test.ts
+++ b/backend/src/domain/concert-log.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { ConcertLogEntity } from "@/domain/concert-log";
 import { UserId } from "@/domain/value-objects/ids";
 import type { ConcertLog, CreateConcertLogInput } from "@/types";

--- a/backend/src/domain/entity.test.ts
+++ b/backend/src/domain/entity.test.ts
@@ -1,4 +1,3 @@
-import { describe, expect, it } from "vitest";
 import { Entity, type EntityProps } from "@/domain/entity";
 import { ComposerId, PieceId } from "@/domain/value-objects/ids";
 

--- a/backend/src/domain/listening-log.test.ts
+++ b/backend/src/domain/listening-log.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { ListeningLogEntity } from "@/domain/listening-log";
 import { UserId } from "@/domain/value-objects/ids";
 import type { CreateListeningLogInput, ListeningLogRecord } from "@/types";

--- a/backend/src/domain/piece.test.ts
+++ b/backend/src/domain/piece.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { PieceComponent, PieceMovementEntity, PieceWorkEntity } from "@/domain/piece";
 import { PieceId } from "@/domain/value-objects/ids";
 import type { CreateMovementInput, CreateWorkInput, PieceMovement, PieceWork } from "@/types";

--- a/backend/src/domain/value-objects/composer-name.test.ts
+++ b/backend/src/domain/value-objects/composer-name.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { ComposerName } from "@/domain/value-objects/composer-name";
 
 describe("ComposerName", () => {

--- a/backend/src/domain/value-objects/concert-title.test.ts
+++ b/backend/src/domain/value-objects/concert-title.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { ConcertTitle } from "@/domain/value-objects/concert-title";
 
 describe("ConcertTitle", () => {

--- a/backend/src/domain/value-objects/ids.test.ts
+++ b/backend/src/domain/value-objects/ids.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import {
   ComposerId,
   ConcertLogId,

--- a/backend/src/domain/value-objects/movement-index.test.ts
+++ b/backend/src/domain/value-objects/movement-index.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { MovementIndex } from "@/domain/value-objects/movement-index";
 
 describe("MovementIndex", () => {

--- a/backend/src/domain/value-objects/piece-title.test.ts
+++ b/backend/src/domain/value-objects/piece-title.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { PieceTitle } from "@/domain/value-objects/piece-title";
 
 describe("PieceTitle", () => {

--- a/backend/src/domain/value-objects/rating.test.ts
+++ b/backend/src/domain/value-objects/rating.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { Rating } from "@/domain/value-objects/rating";
 
 describe("Rating", () => {

--- a/backend/src/domain/value-objects/url.test.ts
+++ b/backend/src/domain/value-objects/url.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { Url } from "@/domain/value-objects/url";
 
 describe("Url", () => {

--- a/backend/src/domain/value-objects/venue.test.ts
+++ b/backend/src/domain/value-objects/venue.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { Venue } from "@/domain/value-objects/venue";
 
 describe("Venue", () => {

--- a/backend/src/domain/value-objects/year.test.ts
+++ b/backend/src/domain/value-objects/year.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect } from "vitest";
-
 import { Year } from "@/domain/value-objects/year";
 
 describe("Year", () => {

--- a/backend/src/handlers/auth/login.test.ts
+++ b/backend/src/handlers/auth/login.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/auth/login";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 

--- a/backend/src/handlers/auth/pre-signup.test.ts
+++ b/backend/src/handlers/auth/pre-signup.test.ts
@@ -1,5 +1,4 @@
 import type { PreSignUpTriggerEvent } from "aws-lambda";
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handler } from "@/handlers/auth/pre-signup";
 
 const mockRepo = vi.hoisted(() => ({

--- a/backend/src/handlers/auth/refresh.test.ts
+++ b/backend/src/handlers/auth/refresh.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/auth/refresh";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/auth/register";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/auth/resend-verification-code";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/auth/verify-email";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
 

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
 import { handler } from "@/handlers/composers/create";
 import {
   makeAdminEvent,

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
 import { ComposerId } from "@/domain/value-objects/ids";

--- a/backend/src/handlers/composers/get.test.ts
+++ b/backend/src/handlers/composers/get.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Composer } from "@/types";
 

--- a/backend/src/handlers/composers/list.test.ts
+++ b/backend/src/handlers/composers/list.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/composers/list";
 import { makeEvent, makeComposer, mockContext, mockCallback } from "@/test/fixtures";
 import { encodeCursor } from "@/utils/cursor";

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 import type { Composer } from "@/types";

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context } from "aws-lambda";
 
 import { handler } from "@/handlers/concert-logs/create";

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/concert-logs/delete";
 import {
   mockContext,

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 

--- a/backend/src/handlers/concert-logs/integration.test.ts
+++ b/backend/src/handlers/concert-logs/integration.test.ts
@@ -3,7 +3,6 @@
  * utils/dynamodb.ts の実コード（テーブル名・DynamoDBDocumentClient設定）と
  * Lambda ハンドラーの結合を検証する。
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 

--- a/backend/src/handlers/concert-logs/list.test.ts
+++ b/backend/src/handlers/concert-logs/list.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ConcertLog } from "@/types";
 
 import { UserId } from "@/domain/value-objects/ids";

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Conflict } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/create";

--- a/backend/src/handlers/listening-logs/delete.test.ts
+++ b/backend/src/handlers/listening-logs/delete.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/listening-logs/delete";
 import {
   mockContext,

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/get";

--- a/backend/src/handlers/listening-logs/integration.test.ts
+++ b/backend/src/handlers/listening-logs/integration.test.ts
@@ -3,7 +3,6 @@
  * utils/dynamodb.ts の実コード（テーブル名・DynamoDBDocumentClient設定）と
  * Lambda ハンドラーの結合を検証する。
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Composer, ListeningLogRecord, Piece } from "@/types";
 

--- a/backend/src/handlers/listening-logs/list.test.ts
+++ b/backend/src/handlers/listening-logs/list.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { ListeningLog } from "@/types";
 
 import { UserId } from "@/domain/value-objects/ids";

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Conflict } from "http-errors";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 

--- a/backend/src/handlers/pieces/children.test.ts
+++ b/backend/src/handlers/pieces/children.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/pieces/children";

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-
 import { handler } from "@/handlers/pieces/create";
 import {
   makeAdminEvent,

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 
 import { PieceId } from "@/domain/value-objects/ids";

--- a/backend/src/handlers/pieces/get.test.ts
+++ b/backend/src/handlers/pieces/get.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Piece, PieceWork } from "@/types";
 

--- a/backend/src/handlers/pieces/list.test.ts
+++ b/backend/src/handlers/pieces/list.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { handler } from "@/handlers/pieces/list";
 import { makeEvent, makePiece, mockContext, mockCallback } from "@/test/fixtures";
 import { encodeCursor } from "@/utils/cursor";

--- a/backend/src/handlers/pieces/replace-movements.test.ts
+++ b/backend/src/handlers/pieces/replace-movements.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 import type { Piece, PieceWork } from "@/types";

--- a/backend/src/migrations/piece-kind-backfill/index.test.ts
+++ b/backend/src/migrations/piece-kind-backfill/index.test.ts
@@ -1,5 +1,3 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
 import { runMigration } from "@/migrations/piece-kind-backfill/index";
 
 type PieceRecord = {

--- a/backend/src/repositories/piece-repository.test.ts
+++ b/backend/src/repositories/piece-repository.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import { PieceId } from "@/domain/value-objects/ids";
 import type { Piece, PieceMovement, PieceWork } from "@/types";
 import { DynamoDBPieceRepository } from "@/repositories/piece-repository";

--- a/backend/src/test/vitest.d.ts
+++ b/backend/src/test/vitest.d.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/globals" />
 import "vitest";
 
 interface CustomMatchers<R = unknown> {

--- a/backend/src/usecases/piece-usecase.test.ts
+++ b/backend/src/usecases/piece-usecase.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-
 import type { ListeningLogRepository } from "@/domain/listening-log";
 import type { PieceRepository } from "@/domain/piece";
 import { PieceId } from "@/domain/value-objects/ids";

--- a/backend/src/utils/auth.test.ts
+++ b/backend/src/utils/auth.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import { getUserId, getUserGroups, isAdmin, requireAdmin } from "@/utils/auth";
 

--- a/backend/src/utils/cursor.test.ts
+++ b/backend/src/utils/cursor.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
 
 import { encodeCursor, decodeCursor, InvalidCursorError } from "@/utils/cursor";

--- a/backend/src/utils/dynamodb.test.ts
+++ b/backend/src/utils/dynamodb.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { ConditionalCheckFailedException } from "@aws-sdk/client-dynamodb";
 
 import {

--- a/backend/src/utils/env.test.ts
+++ b/backend/src/utils/env.test.ts
@@ -1,5 +1,3 @@
-import { describe, it, expect, afterEach } from "vitest";
-
 import { AppEnv } from "@/utils/env";
 
 describe("AppEnv", () => {

--- a/backend/src/utils/parsing.test.ts
+++ b/backend/src/utils/parsing.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { encodeCursor } from "@/utils/cursor";
 import { parseListQuery, parseRequestBody } from "@/utils/parsing";

--- a/backend/src/utils/path-params.test.ts
+++ b/backend/src/utils/path-params.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import type { APIGatewayProxyEvent } from "aws-lambda";
 import { getIdParam } from "@/utils/path-params";
 import { PieceId } from "@/domain/value-objects/ids";

--- a/backend/src/utils/response.test.ts
+++ b/backend/src/utils/response.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import { ok, badRequest, tooManyRequests, internalError } from "@/utils/response";
 
 describe("response helpers", () => {

--- a/backend/src/utils/schemas.test.ts
+++ b/backend/src/utils/schemas.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
 import {
   createListeningLogSchema,

--- a/backend/vitest.config.mts
+++ b/backend/vitest.config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
   test: {
     root: __dirname,
     setupFiles: ["./src/test/setup.ts"],
+    globals: true,
     environment: "node",
     exclude: ["node_modules/**", "dist/**"],
     coverage: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -170,7 +170,7 @@ export default withNuxt(
       "vue/multi-word-component-names": "off",
     },
   },
-  // Nuxt 3 / vitest globals が自動インポートするものの明示的インポートを禁止
+  // Nuxt 3 が自動インポートする vue API の明示的インポートを禁止
   {
     files: ["app/**/*.{ts,vue}"],
     rules: {
@@ -202,6 +202,19 @@ export default withNuxt(
               ],
               message: "Nuxt 3 が自動インポートします。明示的なインポートは不要です。",
             },
+          ],
+        },
+      ],
+    },
+  },
+  // vitest globals が有効なため明示的インポートを禁止（フロント・バック共通）
+  {
+    files: ["app/**/*.{ts,vue}", "backend/src/**/*.test.ts"],
+    rules: {
+      "no-restricted-imports": [
+        "error",
+        {
+          paths: [
             {
               name: "vitest",
               importNames: [


### PR DESCRIPTION
## Summary

- `backend/vitest.config.mts` に `globals: true` を追加し、vitest のグローバル API（`describe` / `it` / `expect` / `vi` 等）をオートインポート化
- `backend/src/test/vitest.d.ts` に `/// <reference types="vitest/globals" />` を追加してカスタムマッチャー型がグローバルに乗るよう対応
- `eslint.config.mjs` の vitest 明示インポート禁止ルールをフロント・バック共通のブロックに統合（`app/**/*.{ts,vue}` と `backend/src/**/*.test.ts` を同一ルールでカバー）
- 55件のバックエンドテストファイルから `import { ... } from "vitest"` を削除

## Test plan

- [x] バックエンドテスト 799件グリーン
- [x] フロントエンドテスト 786件グリーン
- [x] ESLint・Prettier エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)