### PR TITLE
refactor(backend): 認証テストの CognitoAuthRepository モックを __mocks__ に集約

### DIFF
--- a/backend/src/handlers/auth/login.test.ts
+++ b/backend/src/handlers/auth/login.test.ts
@@ -1,21 +1,8 @@
 import { handler } from "@/handlers/auth/login";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const validInput = {
   email: "user@example.com",

--- a/backend/src/handlers/auth/pre-signup.test.ts
+++ b/backend/src/handlers/auth/pre-signup.test.ts
@@ -1,21 +1,8 @@
 import type { PreSignUpTriggerEvent } from "aws-lambda";
 import { handler } from "@/handlers/auth/pre-signup";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const makeEvent = (overrides: Partial<PreSignUpTriggerEvent> = {}): PreSignUpTriggerEvent =>
   ({

--- a/backend/src/handlers/auth/refresh.test.ts
+++ b/backend/src/handlers/auth/refresh.test.ts
@@ -1,21 +1,8 @@
 import { handler } from "@/handlers/auth/refresh";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const validInput = {
   refreshToken: "valid-refresh-token",

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -1,21 +1,8 @@
 import { handler } from "@/handlers/auth/register";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const validInput = {
   email: "user@example.com",

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -1,21 +1,8 @@
 import { handler } from "@/handlers/auth/resend-verification-code";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const validInput = {
   email: "user@example.com",

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -1,21 +1,8 @@
 import { handler } from "@/handlers/auth/verify-email";
 import { makeEvent, mockContext, mockCallback, describeInvalidBodyCases } from "@/test/fixtures";
+import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  signUp: vi.fn(),
-  initiateAuth: vi.fn(),
-  confirmSignUp: vi.fn(),
-  resendConfirmationCode: vi.fn(),
-  refreshToken: vi.fn(),
-  listUsersByEmail: vi.fn(),
-  linkProviderForUser: vi.fn(),
-}));
-
-vi.mock("../../repositories/cognito-auth-repository", () => ({
-  CognitoAuthRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/cognito-auth-repository");
 
 const validInput = {
   email: "user@example.com",

--- a/backend/src/repositories/__mocks__/cognito-auth-repository.ts
+++ b/backend/src/repositories/__mocks__/cognito-auth-repository.ts
@@ -1,0 +1,13 @@
+export const mockCognitoAuthRepo = {
+  signUp: vi.fn(),
+  initiateAuth: vi.fn(),
+  confirmSignUp: vi.fn(),
+  resendConfirmationCode: vi.fn(),
+  refreshToken: vi.fn(),
+  listUsersByEmail: vi.fn(),
+  linkProviderForUser: vi.fn(),
+};
+
+export const CognitoAuthRepository = vi.fn().mockImplementation(function () {
+  return mockCognitoAuthRepo;
+});


### PR DESCRIPTION
## Summary

- `backend/src/repositories/__mocks__/cognito-auth-repository.ts` を新規作成し、`mockCognitoAuthRepo`（7メソッド）と `CognitoAuthRepository` モッククラスを一元定義
- 6つの認証テストファイル（login / register / verify-email / refresh / resend-verification-code / pre-signup）から、各14行の `vi.hoisted()` + `vi.mock()` ファクトリーブロックを削除し、`vi.mock("@/repositories/cognito-auth-repository")` 1行に置き換え
- `mockCognitoAuthRepo as mockRepo` のインポートに統一したため、各テストファイルのアサーション部分は変更なし

## Before / After

```typescript
// Before（各ファイルに14行のコピペ）
const mockRepo = vi.hoisted(() => ({
  signUp: vi.fn(),
  initiateAuth: vi.fn(),
  // ... 5メソッド
}));
vi.mock("../../repositories/cognito-auth-repository", () => ({
  CognitoAuthRepository: vi.fn().mockImplementation(function () {
    return mockRepo;
  }),
}));

// After（2行）
import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
vi.mock("@/repositories/cognito-auth-repository");
```

## Test plan

- [x] バックエンドテスト 799件グリーン
- [x] フロントエンドテスト 786件グリーン
- [x] Prettier チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)