### PR TITLE
refactor(backend): pre-signup ハンドラを handlers/cognito/ へ移動

### DIFF
--- a/backend/src/handlers/cognito/pre-signup.test.ts
+++ b/backend/src/handlers/cognito/pre-signup.test.ts
@@ -1,5 +1,5 @@
 import type { PreSignUpTriggerEvent } from "aws-lambda";
-import { handler } from "@/handlers/auth/pre-signup";
+import { handler } from "@/handlers/cognito/pre-signup";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
 vi.mock("@/repositories/cognito-auth-repository");

--- a/backend/src/handlers/cognito/pre-signup.ts
+++ b/backend/src/handlers/cognito/pre-signup.ts
@@ -1,3 +1,4 @@
+// AWS Cognito User Pool PreSignUp Lambda trigger
 import type { PreSignUpTriggerHandler } from "aws-lambda";
 
 import { createAuthUsecase } from "@/usecases/auth-usecase";

--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -420,7 +420,7 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     const authVerifyEmail = fn("AuthVerifyEmail", "handlers/auth/verify-email.ts");
     const authResendCode = fn("AuthResendCode", "handlers/auth/resend-verification-code.ts");
     const authRefresh = fn("AuthRefresh", "handlers/auth/refresh.ts");
-    const authPreSignUp = fn("AuthPreSignUp", "handlers/auth/pre-signup.ts");
+    const authPreSignUp = fn("AuthPreSignUp", "handlers/cognito/pre-signup.ts");
 
     const concertLogsList = fn("ConcertLogsList", "handlers/concert-logs/list.ts");
     const concertLogsCreate = fn("ConcertLogsCreate", "handlers/concert-logs/create.ts");


### PR DESCRIPTION
## Summary

- `backend/src/handlers/auth/pre-signup.ts` を `backend/src/handlers/cognito/pre-signup.ts` へ移動
- Cognito トリガー専用ディレクトリ `handlers/cognito/` を新設し、認証 REST API ハンドラ（`handlers/auth/`）と分離
- テストファイルのインポートパスおよび CDK スタックのエントリポイントパスを更新

## Test plan

- [x] `pnpm run test:backend` — 55ファイル798テストすべてパス
- [x] `pnpm run test:frontend` — 105ファイル786テストすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)