### PR TITLE
fix(backend): mockResolvedValueOnce() に undefined を明示し型エラーを修正

### DIFF
--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -52,7 +52,7 @@ describe("POST /auth/register", () => {
 
   describe("成功系", () => {
     it("有効なメール・パスワードで登録に成功し、201 を返す", async () => {
-      mockRepo.signUp.mockResolvedValueOnce();
+      mockRepo.signUp.mockResolvedValueOnce(undefined);
 
       const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
 

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -40,7 +40,7 @@ describe("POST /auth/resend-verification-code", () => {
 
   describe("成功系", () => {
     it("有効な email で再送信に成功し、200 を返す", async () => {
-      mockRepo.resendConfirmationCode.mockResolvedValueOnce();
+      mockRepo.resendConfirmationCode.mockResolvedValueOnce(undefined);
 
       const result = await handler(makeResendEvent(), mockContext, mockCallback);
 

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -48,7 +48,7 @@ describe("POST /auth/verify-email", () => {
 
   describe("成功系", () => {
     it("有効な email と code で確認に成功し、200 を返す", async () => {
-      mockRepo.confirmSignUp.mockResolvedValueOnce();
+      mockRepo.confirmSignUp.mockResolvedValueOnce(undefined);
 
       const result = await handler(makeVerifyEmailEvent(), mockContext, mockCallback);
 

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -98,7 +98,7 @@ describe("POST /composers (create)", () => {
   });
 
   it("必須項目のみで正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -120,7 +120,7 @@ describe("POST /composers (create)", () => {
   });
 
   it("作成アイテムに UUID が付与される", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -139,7 +139,7 @@ describe("POST /composers (create)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -157,7 +157,7 @@ describe("POST /composers (create)", () => {
 
   describe("カテゴリフィールド", () => {
     it("era と region を指定して作成できる", async () => {
-      mockRepo.save.mockResolvedValueOnce();
+      mockRepo.save.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({
@@ -204,7 +204,7 @@ describe("POST /composers (create)", () => {
     });
 
     it("imageUrl を指定して作成できる", async () => {
-      mockRepo.save.mockResolvedValueOnce();
+      mockRepo.save.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({
@@ -239,7 +239,7 @@ describe("POST /composers (create)", () => {
     });
 
     it("birthYear と deathYear を指定して作成できる", async () => {
-      mockRepo.save.mockResolvedValueOnce();
+      mockRepo.save.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, birthYear: 1770, deathYear: 1827 }),
@@ -256,7 +256,7 @@ describe("POST /composers (create)", () => {
     });
 
     it("birthYear のみ指定（存命作曲家）で作成できる", async () => {
-      mockRepo.save.mockResolvedValueOnce();
+      mockRepo.save.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, birthYear: 1958 }),

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -54,14 +54,14 @@ describe("DELETE /composers/{id} (delete)", () => {
   });
 
   it("正常に削除して 204 を返す", async () => {
-    mockRepo.remove.mockResolvedValueOnce();
+    mockRepo.remove.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
   });
 
   it("正しい id で Repository.remove を呼び出す", async () => {
-    mockRepo.remove.mockResolvedValueOnce();
+    mockRepo.remove.mockResolvedValueOnce(undefined);
     await handler(makeEvent("test-id-123"), mockContext, mockCallback);
 
     expect(mockRepo.remove).toHaveBeenCalledWith(ComposerId.from("test-id-123"));

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -105,7 +105,7 @@ describe("PUT /composers/{id} (update)", () => {
 
   it("正常更新して 200 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
@@ -121,7 +121,7 @@ describe("PUT /composers/{id} (update)", () => {
 
   it("createdAt は上書きされない", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ name: "モーツァルト" })),
@@ -134,7 +134,7 @@ describe("PUT /composers/{id} (update)", () => {
 
   it("era と region を追加して更新できる", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ era: "古典派", region: "ドイツ・オーストリア" })),
@@ -154,7 +154,7 @@ describe("PUT /composers/{id} (update)", () => {
       region: "ドイツ・オーストリア",
     };
     mockRepo.findById.mockResolvedValueOnce(existing);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ era: "", region: "" })),
@@ -169,7 +169,7 @@ describe("PUT /composers/{id} (update)", () => {
 
   it("imageUrl を追加して更新できる", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent(
@@ -188,7 +188,7 @@ describe("PUT /composers/{id} (update)", () => {
 
   it("birthYear と deathYear を追加して更新できる", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingComposer);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ birthYear: 1770, deathYear: 1827 })),
@@ -204,7 +204,7 @@ describe("PUT /composers/{id} (update)", () => {
   it("birthYear を null で送信すると削除される", async () => {
     const existing: Composer = { ...existingComposer, birthYear: 1770, deathYear: 1827 };
     mockRepo.findById.mockResolvedValueOnce(existing);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ birthYear: null, deathYear: null })),
@@ -233,7 +233,7 @@ describe("PUT /composers/{id} (update)", () => {
       imageUrl: "https://example.com/beethoven.jpg",
     };
     mockRepo.findById.mockResolvedValueOnce(existing);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce();
+    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ imageUrl: "" })),

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -128,7 +128,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -148,7 +148,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("任意フィールドを含めて正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify({
@@ -172,7 +172,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("作成アイテムに UUID が付与される", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -187,7 +187,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("createdAt と updatedAt が同じ値で設定される", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -202,7 +202,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("userId が保存される", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -218,7 +218,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("レスポンスボディに userId が含まれる", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -247,7 +247,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("pieceIds を含めて正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const pieceIds = [
       "550e8400-e29b-41d4-a716-446655440000",
       "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
@@ -267,7 +267,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("pieceIds が空配列でも正常に作成できる", async () => {
-    mockRepo.save.mockResolvedValueOnce();
+    mockRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, pieceIds: [] }),

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -70,7 +70,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
 
   it("正常削除して 204 を返す", async () => {
     mockRepo.findById.mockResolvedValueOnce(existingItem);
-    mockRepo.remove.mockResolvedValueOnce();
+    mockRepo.remove.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", TEST_USER_ID),
       mockContext,


### PR DESCRIPTION
## Summary

- `Promise<void>` を返すモックメソッドの `mockResolvedValueOnce()` を `mockResolvedValueOnce(undefined)` に統一し、TypeScript の「Expected 1 arguments, but got 0」エラーを修正
- 対象8ファイル（`register` / `resend-verification-code` / `verify-email` / `composers/create` / `composers/delete` / `composers/update` / `concert-logs/create` / `concert-logs/delete`）

## Test plan

- [x] `pnpm run test:backend` — 55ファイル798テストすべてパス
- [x] `pnpm run test:frontend` — 105ファイル786テストすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)