### PR TITLE
refactor(backend): 全ハンドラを withHandler に統一し createHandler を廃止

### DIFF
--- a/backend/src/handlers/auth/login.ts
+++ b/backend/src/handlers/auth/login.ts
@@ -1,11 +1,10 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { loginSchema } from "@/utils/schemas";
 import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, loginSchema);
-  return usecase.login(input.email, input.password);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: loginSchema,
+  handler: async ({ body }) => usecase.login(body.email, body.password),
+});

--- a/backend/src/handlers/auth/refresh.ts
+++ b/backend/src/handlers/auth/refresh.ts
@@ -1,11 +1,10 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { refreshTokenSchema } from "@/utils/schemas";
 import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, refreshTokenSchema);
-  return usecase.refreshToken(input.refreshToken);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: refreshTokenSchema,
+  handler: async ({ body }) => usecase.refreshToken(body.refreshToken),
+});

--- a/backend/src/handlers/auth/register.ts
+++ b/backend/src/handlers/auth/register.ts
@@ -1,11 +1,10 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { registerSchema } from "@/utils/schemas";
 import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, registerSchema);
-  return usecase.register(input.email, input.password);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: registerSchema,
+  handler: async ({ body }) => usecase.register(body.email, body.password),
+});

--- a/backend/src/handlers/auth/resend-verification-code.ts
+++ b/backend/src/handlers/auth/resend-verification-code.ts
@@ -1,11 +1,10 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { resendVerificationCodeSchema } from "@/utils/schemas";
 import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, resendVerificationCodeSchema);
-  return usecase.resendVerificationCode(input.email);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: resendVerificationCodeSchema,
+  handler: async ({ body }) => usecase.resendVerificationCode(body.email),
+});

--- a/backend/src/handlers/auth/verify-email.ts
+++ b/backend/src/handlers/auth/verify-email.ts
@@ -1,11 +1,10 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { verifyEmailSchema } from "@/utils/schemas";
 import { createAuthUsecase } from "@/usecases/auth-usecase";
 
 const usecase = createAuthUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, verifyEmailSchema);
-  return usecase.verifyEmail(input.email, input.code);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: verifyEmailSchema,
+  handler: async ({ body }) => usecase.verifyEmail(body.email, body.code),
+});

--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -7,20 +7,9 @@ import {
   mockContext,
   TEST_USER_ID,
 } from "@/test/fixtures";
+import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findPage: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/composer-repository");
 
 const validInput = {
   name: "ベートーヴェン",

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -11,19 +11,9 @@ import {
   TEST_USER_ID,
 } from "@/test/fixtures";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findPage: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
+import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/composer-repository");
 
 type AuthMode = "admin" | "non-admin" | "none";
 

--- a/backend/src/handlers/composers/get.test.ts
+++ b/backend/src/handlers/composers/get.test.ts
@@ -3,19 +3,9 @@ import type { Composer } from "@/types";
 
 import { handler } from "@/handlers/composers/get";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findPage: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
+import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/composer-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };

--- a/backend/src/handlers/composers/list.test.ts
+++ b/backend/src/handlers/composers/list.test.ts
@@ -4,19 +4,9 @@ import { encodeCursor } from "@/utils/cursor";
 import { COMPOSERS_PAGE_SIZE_DEFAULT, COMPOSERS_PAGE_SIZE_MAX } from "@/types";
 import type { Composer, Paginated } from "@/types";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findPage: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
+import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/composer-repository");
 
 const parseBody = (result: { body?: string } | null | undefined): Paginated<Composer> =>
   JSON.parse(result?.body ?? '{"items":[],"nextCursor":null}') as Paginated<Composer>;

--- a/backend/src/handlers/composers/list.ts
+++ b/backend/src/handlers/composers/list.ts
@@ -1,4 +1,4 @@
-import { createHandler } from "@/utils/middleware";
+import { withHandler } from "@/utils/handler";
 import { parseListQuery } from "@/utils/parsing";
 import { ok } from "@/utils/response";
 import { listComposersQuerySchema } from "@/utils/schemas";
@@ -6,11 +6,13 @@ import { createComposerUsecase } from "@/usecases/composer-usecase";
 
 const usecase = createComposerUsecase();
 
-export const handler = createHandler(async (event) => {
-  const { limit, exclusiveStartKey } = parseListQuery(
-    event.queryStringParameters,
-    listComposersQuerySchema,
-  );
-  const page = await usecase.list({ limit, exclusiveStartKey });
-  return ok(page);
+export const handler = withHandler({
+  handler: async ({ event }) => {
+    const { limit, exclusiveStartKey } = parseListQuery(
+      event.queryStringParameters,
+      listComposersQuerySchema,
+    );
+    const page = await usecase.list({ limit, exclusiveStartKey });
+    return ok(page);
+  },
 });

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -12,19 +12,9 @@ import {
   TEST_USER_ID,
 } from "@/test/fixtures";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findPage: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
+import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/composer-repository");
 
 type AuthMode = "admin" | "non-admin" | "none";
 

--- a/backend/src/handlers/concert-logs/create.ts
+++ b/backend/src/handlers/concert-logs/create.ts
@@ -1,15 +1,15 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { createConcertLogSchema } from "@/utils/schemas";
-import { getUserId } from "@/utils/auth";
 import { created } from "@/utils/response";
 import { createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
-export const handler = createHandler(async (event) => {
-  const input = parseRequestBody(event.body, createConcertLogSchema);
-  const userId = getUserId(event);
-  const log = await usecase.create(input, userId);
-  return created(log);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  schema: createConcertLogSchema,
+  userId: true,
+  handler: async ({ body, userId }) => {
+    const log = await usecase.create(body, userId);
+    return created(log);
+  },
+});

--- a/backend/src/handlers/concert-logs/delete.ts
+++ b/backend/src/handlers/concert-logs/delete.ts
@@ -1,14 +1,14 @@
-import { createHandler } from "@/utils/middleware";
-import { getIdParam } from "@/utils/path-params";
-import { getUserId } from "@/utils/auth";
+import { withHandler } from "@/utils/handler";
 import { noContent } from "@/utils/response";
 import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
-export const handler = createHandler(async (event) => {
-  const id = getIdParam(event, ConcertLogId.from);
-  const userId = getUserId(event);
-  await usecase.delete(id, userId);
-  return noContent();
+export const handler = withHandler({
+  idFrom: ConcertLogId.from,
+  userId: true,
+  handler: async ({ id, userId }) => {
+    await usecase.delete(id, userId);
+    return noContent();
+  },
 });

--- a/backend/src/handlers/concert-logs/get.ts
+++ b/backend/src/handlers/concert-logs/get.ts
@@ -1,14 +1,14 @@
-import { createHandler } from "@/utils/middleware";
-import { getIdParam } from "@/utils/path-params";
-import { getUserId } from "@/utils/auth";
+import { withHandler } from "@/utils/handler";
 import { ok } from "@/utils/response";
 import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
-export const handler = createHandler(async (event) => {
-  const id = getIdParam(event, ConcertLogId.from);
-  const userId = getUserId(event);
-  const log = await usecase.get(id, userId);
-  return ok(log);
+export const handler = withHandler({
+  idFrom: ConcertLogId.from,
+  userId: true,
+  handler: async ({ id, userId }) => {
+    const log = await usecase.get(id, userId);
+    return ok(log);
+  },
 });

--- a/backend/src/handlers/concert-logs/list.ts
+++ b/backend/src/handlers/concert-logs/list.ts
@@ -1,12 +1,13 @@
-import { createHandler } from "@/utils/middleware";
-import { getUserId } from "@/utils/auth";
+import { withHandler } from "@/utils/handler";
 import { ok } from "@/utils/response";
 import { createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
-export const handler = createHandler(async (event) => {
-  const userId = getUserId(event);
-  const logs = await usecase.list(userId);
-  return ok(logs);
+export const handler = withHandler({
+  userId: true,
+  handler: async ({ userId }) => {
+    const logs = await usecase.list(userId);
+    return ok(logs);
+  },
 });

--- a/backend/src/handlers/concert-logs/update.ts
+++ b/backend/src/handlers/concert-logs/update.ts
@@ -1,17 +1,16 @@
-import { createHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { updateConcertLogSchema } from "@/utils/schemas";
-import { getIdParam } from "@/utils/path-params";
-import { getUserId } from "@/utils/auth";
 import { ok } from "@/utils/response";
 import { ConcertLogId, createConcertLogUsecase } from "@/usecases/concert-log-usecase";
 
 const usecase = createConcertLogUsecase();
 
-export const handler = createHandler(async (event) => {
-  const id = getIdParam(event, ConcertLogId.from);
-  const input = parseRequestBody(event.body, updateConcertLogSchema);
-  const userId = getUserId(event);
-  const updated = await usecase.update(id, input, userId);
-  return ok(updated);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  idFrom: ConcertLogId.from,
+  schema: updateConcertLogSchema,
+  userId: true,
+  handler: async ({ id, body, userId }) => {
+    const updated = await usecase.update(id, body, userId);
+    return ok(updated);
+  },
+});

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -2,6 +2,7 @@ import type { Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/create";
 import { makeAuthEvent, makeComposer, makeEvent, makePiece, TEST_PIECE_ID } from "@/test/fixtures";
+import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {
@@ -26,16 +27,9 @@ const mocks = vi.hoisted(() => ({
     removeMovement: vi.fn(),
     replaceMovements: vi.fn(),
   },
-  composerRepo: {
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findPage: vi.fn(),
-    save: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
 }));
 
+vi.mock("@/repositories/composer-repository");
 vi.mock("../../repositories/listening-log-repository", () => ({
   DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
     return mocks.listeningLogRepo;
@@ -44,11 +38,6 @@ vi.mock("../../repositories/listening-log-repository", () => ({
 vi.mock("../../repositories/piece-repository", () => ({
   DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
     return mocks.pieceRepo;
-  }),
-}));
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mocks.composerRepo;
   }),
 }));
 
@@ -69,7 +58,7 @@ describe("POST /listening-logs (create)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.pieceRepo.findById.mockResolvedValue(makePiece());
-    mocks.composerRepo.findById.mockResolvedValue(makeComposer());
+    mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
   describe("リクエストボディ異常系", () => {

--- a/backend/src/handlers/listening-logs/delete.test.ts
+++ b/backend/src/handlers/listening-logs/delete.test.ts
@@ -31,16 +31,9 @@ const mocks = vi.hoisted(() => ({
     removeMovement: vi.fn(),
     replaceMovements: vi.fn(),
   },
-  composerRepo: {
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findPage: vi.fn(),
-    save: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
 }));
 
+vi.mock("@/repositories/composer-repository");
 vi.mock("../../repositories/listening-log-repository", () => ({
   DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
     return mocks.listeningLogRepo;
@@ -49,11 +42,6 @@ vi.mock("../../repositories/listening-log-repository", () => ({
 vi.mock("../../repositories/piece-repository", () => ({
   DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
     return mocks.pieceRepo;
-  }),
-}));
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mocks.composerRepo;
   }),
 }));
 

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -2,6 +2,7 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/get";
 import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
+import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {
@@ -26,16 +27,9 @@ const mocks = vi.hoisted(() => ({
     removeMovement: vi.fn(),
     replaceMovements: vi.fn(),
   },
-  composerRepo: {
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findPage: vi.fn(),
-    save: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
 }));
 
+vi.mock("@/repositories/composer-repository");
 vi.mock("../../repositories/listening-log-repository", () => ({
   DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
     return mocks.listeningLogRepo;
@@ -44,11 +38,6 @@ vi.mock("../../repositories/listening-log-repository", () => ({
 vi.mock("../../repositories/piece-repository", () => ({
   DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
     return mocks.pieceRepo;
-  }),
-}));
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mocks.composerRepo;
   }),
 }));
 
@@ -81,7 +70,7 @@ describe("GET /listening-logs/:id (get)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.pieceRepo.findById.mockResolvedValue(makePiece());
-    mocks.composerRepo.findById.mockResolvedValue(makeComposer());
+    mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
   it("id がない場合は 400 を返す", async () => {

--- a/backend/src/handlers/listening-logs/list.test.ts
+++ b/backend/src/handlers/listening-logs/list.test.ts
@@ -9,6 +9,7 @@ import {
   makePiece,
   TEST_PIECE_ID,
 } from "@/test/fixtures";
+import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {
@@ -33,16 +34,9 @@ const mocks = vi.hoisted(() => ({
     removeMovement: vi.fn(),
     replaceMovements: vi.fn(),
   },
-  composerRepo: {
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findPage: vi.fn(),
-    save: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
 }));
 
+vi.mock("@/repositories/composer-repository");
 vi.mock("../../repositories/listening-log-repository", () => ({
   DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
     return mocks.listeningLogRepo;
@@ -51,11 +45,6 @@ vi.mock("../../repositories/listening-log-repository", () => ({
 vi.mock("../../repositories/piece-repository", () => ({
   DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
     return mocks.pieceRepo;
-  }),
-}));
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mocks.composerRepo;
   }),
 }));
 
@@ -71,8 +60,8 @@ describe("GET /listening-logs (list)", () => {
     mocks.pieceRepo.findById.mockResolvedValue(makePiece());
     mocks.pieceRepo.findByIds.mockResolvedValue([makePiece()]);
     mocks.pieceRepo.findRootById.mockResolvedValue(makePiece());
-    mocks.composerRepo.findById.mockResolvedValue(makeComposer());
-    mocks.composerRepo.findByIds.mockResolvedValue([makeComposer()]);
+    mockComposerRepo.findById.mockResolvedValue(makeComposer());
+    mockComposerRepo.findByIds.mockResolvedValue([makeComposer()]);
   });
 
   it("空リストの場合は 200 で空配列を返す", async () => {

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -3,6 +3,7 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/update";
 import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
+import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 
 const mocks = vi.hoisted(() => ({
   listeningLogRepo: {
@@ -27,16 +28,9 @@ const mocks = vi.hoisted(() => ({
     removeMovement: vi.fn(),
     replaceMovements: vi.fn(),
   },
-  composerRepo: {
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findPage: vi.fn(),
-    save: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
 }));
 
+vi.mock("@/repositories/composer-repository");
 vi.mock("../../repositories/listening-log-repository", () => ({
   DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
     return mocks.listeningLogRepo;
@@ -45,11 +39,6 @@ vi.mock("../../repositories/listening-log-repository", () => ({
 vi.mock("../../repositories/piece-repository", () => ({
   DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
     return mocks.pieceRepo;
-  }),
-}));
-vi.mock("../../repositories/composer-repository", () => ({
-  DynamoDBComposerRepository: vi.fn().mockImplementation(function () {
-    return mocks.composerRepo;
   }),
 }));
 
@@ -84,7 +73,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.pieceRepo.findById.mockResolvedValue(makePiece());
-    mocks.composerRepo.findById.mockResolvedValue(makeComposer());
+    mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
   it("id がない場合は 400 を返す", async () => {

--- a/backend/src/handlers/pieces/children.ts
+++ b/backend/src/handlers/pieces/children.ts
@@ -1,5 +1,4 @@
-import { createHandler } from "@/utils/middleware";
-import { getIdParam } from "@/utils/path-params";
+import { withHandler } from "@/utils/handler";
 import { ok } from "@/utils/response";
 import { createMovementUsecase, PieceId } from "@/usecases/piece-usecase";
 
@@ -14,8 +13,10 @@ const usecase = createMovementUsecase();
  * Movement のレスポンスには `composerId` は含まれない（親 Work から継承）。
  * 親が存在しない場合は空配列を返す（GSI Query は親 Work の存在を要求しない）。
  */
-export const handler = createHandler(async (event) => {
-  const id = getIdParam(event, PieceId.from);
-  const movements = await usecase.listChildren(id);
-  return ok(movements);
+export const handler = withHandler({
+  idFrom: PieceId.from,
+  handler: async ({ id }) => {
+    const movements = await usecase.listChildren(id);
+    return ok(movements);
+  },
 });

--- a/backend/src/handlers/pieces/create.ts
+++ b/backend/src/handlers/pieces/create.ts
@@ -1,13 +1,15 @@
-import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { createPieceSchema } from "@/utils/schemas";
 import { created } from "@/utils/response";
 import { createPieceUsecase } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createAdminHandler(async (event) => {
-  const input = parseRequestBody(event.body, createPieceSchema);
-  const piece = await usecase.create(input);
-  return created(piece);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  admin: true,
+  schema: createPieceSchema,
+  handler: async ({ body }) => {
+    const piece = await usecase.create(body);
+    return created(piece);
+  },
+});

--- a/backend/src/handlers/pieces/delete.ts
+++ b/backend/src/handlers/pieces/delete.ts
@@ -1,12 +1,14 @@
-import { createAdminHandler } from "@/utils/middleware";
-import { getIdParam } from "@/utils/path-params";
+import { withHandler } from "@/utils/handler";
 import { noContent } from "@/utils/response";
 import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event, PieceId.from);
-  await usecase.delete(id);
-  return noContent();
+export const handler = withHandler({
+  admin: true,
+  idFrom: PieceId.from,
+  handler: async ({ id }) => {
+    await usecase.delete(id);
+    return noContent();
+  },
 });

--- a/backend/src/handlers/pieces/get.ts
+++ b/backend/src/handlers/pieces/get.ts
@@ -1,5 +1,4 @@
-import { createHandler } from "@/utils/middleware";
-import { getIdParam } from "@/utils/path-params";
+import { withHandler } from "@/utils/handler";
 import { ok } from "@/utils/response";
 import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
@@ -11,8 +10,10 @@ const usecase = createPieceUsecase();
  * kind を問わず単一ノード（Work または Movement）を返す。
  * Movement のレスポンスには `composerId` は含まれない（親 Work からの継承）。
  */
-export const handler = createHandler(async (event) => {
-  const id = getIdParam(event, PieceId.from);
-  const piece = await usecase.getNode(id);
-  return ok(piece);
+export const handler = withHandler({
+  idFrom: PieceId.from,
+  handler: async ({ id }) => {
+    const piece = await usecase.getNode(id);
+    return ok(piece);
+  },
 });

--- a/backend/src/handlers/pieces/list.ts
+++ b/backend/src/handlers/pieces/list.ts
@@ -1,4 +1,4 @@
-import { createHandler } from "@/utils/middleware";
+import { withHandler } from "@/utils/handler";
 import { parseListQuery } from "@/utils/parsing";
 import { ok } from "@/utils/response";
 import { listPiecesQuerySchema } from "@/utils/schemas";
@@ -6,11 +6,13 @@ import { createPieceUsecase } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createHandler(async (event) => {
-  const { limit, exclusiveStartKey } = parseListQuery(
-    event.queryStringParameters,
-    listPiecesQuerySchema,
-  );
-  const page = await usecase.list({ limit, exclusiveStartKey });
-  return ok(page);
+export const handler = withHandler({
+  handler: async ({ event }) => {
+    const { limit, exclusiveStartKey } = parseListQuery(
+      event.queryStringParameters,
+      listPiecesQuerySchema,
+    );
+    const page = await usecase.list({ limit, exclusiveStartKey });
+    return ok(page);
+  },
 });

--- a/backend/src/handlers/pieces/replace-movements.ts
+++ b/backend/src/handlers/pieces/replace-movements.ts
@@ -1,6 +1,4 @@
-import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
-import { getIdParam } from "@/utils/path-params";
+import { withHandler } from "@/utils/handler";
 import { ok } from "@/utils/response";
 import { replaceMovementsSchema } from "@/utils/schemas";
 import { createMovementUsecase, PieceId } from "@/usecases/piece-usecase";
@@ -20,9 +18,12 @@ const usecase = createMovementUsecase();
  *   競合時は 409 Conflict を返す。
  * - 上限: `MOVEMENTS_PER_WORK_MAX = 49` 件まで。
  */
-export const handler = createAdminHandler(async (event) => {
-  const workId = getIdParam(event, PieceId.from);
-  const input = parseRequestBody(event.body, replaceMovementsSchema);
-  const movements = await usecase.replaceAll(workId, input.movements);
-  return ok({ movements });
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  admin: true,
+  idFrom: PieceId.from,
+  schema: replaceMovementsSchema,
+  handler: async ({ id, body }) => {
+    const movements = await usecase.replaceAll(id, body.movements);
+    return ok({ movements });
+  },
+});

--- a/backend/src/handlers/pieces/update.ts
+++ b/backend/src/handlers/pieces/update.ts
@@ -1,15 +1,16 @@
-import { createAdminHandler, jsonBodyParser } from "@/utils/middleware";
-import { parseRequestBody } from "@/utils/parsing";
+import { withHandler } from "@/utils/handler";
 import { updatePieceSchema } from "@/utils/schemas";
-import { getIdParam } from "@/utils/path-params";
 import { ok } from "@/utils/response";
 import { createPieceUsecase, PieceId } from "@/usecases/piece-usecase";
 
 const usecase = createPieceUsecase();
 
-export const handler = createAdminHandler(async (event) => {
-  const id = getIdParam(event, PieceId.from);
-  const input = parseRequestBody(event.body, updatePieceSchema);
-  const piece = await usecase.update(id, input);
-  return ok(piece);
-}).use(jsonBodyParser);
+export const handler = withHandler({
+  admin: true,
+  idFrom: PieceId.from,
+  schema: updatePieceSchema,
+  handler: async ({ id, body }) => {
+    const piece = await usecase.update(id, body);
+    return ok(piece);
+  },
+});

--- a/backend/src/repositories/__mocks__/composer-repository.ts
+++ b/backend/src/repositories/__mocks__/composer-repository.ts
@@ -1,0 +1,12 @@
+export const mockComposerRepo = {
+  findById: vi.fn(),
+  findByIds: vi.fn(),
+  findPage: vi.fn(),
+  save: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+};
+
+export const DynamoDBComposerRepository = vi.fn().mockImplementation(function () {
+  return mockComposerRepo;
+});


### PR DESCRIPTION
## Summary

- `createHandler` / `createAdminHandler` を直接使っていた18ハンドラをすべて `withHandler` に移行
- `middleware.ts` の3関数（`createHandler` / `createAdminHandler` / `jsonBodyParser`）は `handler.ts` 内部からのみ参照される実装詳細になった
- パスパラメータ取得・ボディパース・userId取得・admin チェックが宣言的オプションに集約され、ハンドラ本体がビジネスロジックのみになった

## 対象ファイル

| ディレクトリ | ファイル |
|---|---|
| `handlers/auth/` | `login` / `register` / `verify-email` / `resend-verification-code` / `refresh` |
| `handlers/composers/` | `list` |
| `handlers/concert-logs/` | `create` / `get` / `list` / `update` / `delete` |
| `handlers/pieces/` | `children` / `get` / `list` / `create` / `update` / `delete` / `replace-movements` |

## Test plan

- [x] `pnpm run test:backend` — 55ファイル798テストすべてパス
- [x] `pnpm run test:frontend` — 105ファイル786テストすべてパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)