### PR TITLE
test(backend): 認証ハンドラの Cognito エラー系テストを共通ヘルパーに集約

### DIFF
--- a/backend/src/handlers/auth/login.test.ts
+++ b/backend/src/handlers/auth/login.test.ts
@@ -4,7 +4,7 @@ import {
   mockContext,
   mockCallback,
   describeInvalidBodyCases,
-  makeCognitoError,
+  describeCognitoErrorCases,
 } from "@/test/fixtures";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
@@ -78,22 +78,15 @@ describe("POST /auth/login", () => {
     });
   });
 
-  describe("Cognito エラー系", () => {
-    it.each<[string, number, string | undefined]>([
-      ["NotAuthorizedException", 401, "InvalidCredentials"],
-      ["UserNotFoundException", 401, "InvalidCredentials"],
-      ["UserNotConfirmedException", 403, "UserNotConfirmed"],
-      ["TooManyRequestsException", 429, "TooManyRequests"],
-      ["ServiceUnavailableException", 500, undefined],
-    ])("%s のとき %i を返す", async (name, statusCode, errorCode) => {
-      mockRepo.initiateAuth.mockRejectedValueOnce(makeCognitoError(name, "error"));
-
-      const result = await handler(makeLoginEvent(), mockContext, mockCallback);
-
-      expect(result?.statusCode).toBe(statusCode);
-      if (errorCode !== undefined) {
-        expect(JSON.parse(result?.body ?? "{}").error).toBe(errorCode);
-      }
-    });
-  });
+  describeCognitoErrorCases(
+    mockRepo.initiateAuth,
+    () => handler(makeLoginEvent(), mockContext, mockCallback),
+    [
+      { name: "NotAuthorizedException", statusCode: 401, error: "InvalidCredentials" },
+      { name: "UserNotFoundException", statusCode: 401, error: "InvalidCredentials" },
+      { name: "UserNotConfirmedException", statusCode: 403, error: "UserNotConfirmed" },
+      { name: "TooManyRequestsException", statusCode: 429, error: "TooManyRequests" },
+      { name: "ServiceUnavailableException", statusCode: 500 },
+    ],
+  );
 });

--- a/backend/src/handlers/auth/refresh.test.ts
+++ b/backend/src/handlers/auth/refresh.test.ts
@@ -4,7 +4,7 @@ import {
   mockContext,
   mockCallback,
   describeInvalidBodyCases,
-  makeCognitoError,
+  describeCognitoErrorCases,
 } from "@/test/fixtures";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
@@ -55,20 +55,13 @@ describe("POST /auth/refresh", () => {
     });
   });
 
-  describe("Cognito エラー系", () => {
-    it.each<[string, number, string | undefined]>([
-      ["NotAuthorizedException", 401, "InvalidRefreshToken"],
-      ["TooManyRequestsException", 429, "TooManyRequests"],
-      ["ServiceUnavailableException", 500, undefined],
-    ])("%s のとき %i を返す", async (name, statusCode, errorCode) => {
-      mockRepo.refreshToken.mockRejectedValueOnce(makeCognitoError(name));
-
-      const result = await handler(makeRefreshEvent(), mockContext, mockCallback);
-
-      expect(result?.statusCode).toBe(statusCode);
-      if (errorCode !== undefined) {
-        expect(JSON.parse(result?.body ?? "{}").error).toBe(errorCode);
-      }
-    });
-  });
+  describeCognitoErrorCases(
+    mockRepo.refreshToken,
+    () => handler(makeRefreshEvent(), mockContext, mockCallback),
+    [
+      { name: "NotAuthorizedException", statusCode: 401, error: "InvalidRefreshToken" },
+      { name: "TooManyRequestsException", statusCode: 429, error: "TooManyRequests" },
+      { name: "ServiceUnavailableException", statusCode: 500 },
+    ],
+  );
 });

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -4,7 +4,7 @@ import {
   mockContext,
   mockCallback,
   describeInvalidBodyCases,
-  makeCognitoError,
+  describeCognitoErrorCases,
 } from "@/test/fixtures";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
@@ -63,21 +63,14 @@ describe("POST /auth/register", () => {
     });
   });
 
-  describe("Cognito エラー系", () => {
-    it.each<[string, number, string | undefined]>([
-      ["UsernameExistsException", 400, "already"],
-      ["InvalidPasswordException", 400, "password"],
-      ["TooManyRequestsException", 429, "again later"],
-      ["ServiceUnavailableException", 500, undefined],
-    ])("%s のとき %i を返す", async (name, statusCode, messageSubstring) => {
-      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError(name));
-
-      const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
-
-      expect(result?.statusCode).toBe(statusCode);
-      if (messageSubstring !== undefined) {
-        expect(JSON.parse(result?.body ?? "{}").message.toLowerCase()).toContain(messageSubstring);
-      }
-    });
-  });
+  describeCognitoErrorCases(
+    mockRepo.signUp,
+    () => handler(makeRegisterEvent(), mockContext, mockCallback),
+    [
+      { name: "UsernameExistsException", statusCode: 400, messageIncludes: "already" },
+      { name: "InvalidPasswordException", statusCode: 400, messageIncludes: "password" },
+      { name: "TooManyRequestsException", statusCode: 429, messageIncludes: "again later" },
+      { name: "ServiceUnavailableException", statusCode: 500 },
+    ],
+  );
 });

--- a/backend/src/handlers/auth/register.test.ts
+++ b/backend/src/handlers/auth/register.test.ts
@@ -64,31 +64,20 @@ describe("POST /auth/register", () => {
   });
 
   describe("Cognito エラー系", () => {
-    it("メール重複時に 400 を返す", async () => {
-      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError("UsernameExistsException"));
-      const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(400);
-      expect(JSON.parse(result?.body ?? "{}").message).toContain("already");
-    });
+    it.each<[string, number, string | undefined]>([
+      ["UsernameExistsException", 400, "already"],
+      ["InvalidPasswordException", 400, "password"],
+      ["TooManyRequestsException", 429, "again later"],
+      ["ServiceUnavailableException", 500, undefined],
+    ])("%s のとき %i を返す", async (name, statusCode, messageSubstring) => {
+      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError(name));
 
-    it("無効なパスワード時に 400 を返す", async () => {
-      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError("InvalidPasswordException"));
       const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(400);
-      expect(JSON.parse(result?.body ?? "{}").message.toLowerCase()).toContain("password");
-    });
 
-    it("リクエスト過多時に 429 を返す", async () => {
-      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError("TooManyRequestsException"));
-      const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(429);
-      expect(JSON.parse(result?.body ?? "{}").message).toContain("again later");
-    });
-
-    it("その他の Cognito エラー時に 500 を返す", async () => {
-      mockRepo.signUp.mockRejectedValueOnce(makeCognitoError("ServiceUnavailableException"));
-      const result = await handler(makeRegisterEvent(), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(500);
+      expect(result?.statusCode).toBe(statusCode);
+      if (messageSubstring !== undefined) {
+        expect(JSON.parse(result?.body ?? "{}").message.toLowerCase()).toContain(messageSubstring);
+      }
     });
   });
 });

--- a/backend/src/handlers/auth/resend-verification-code.test.ts
+++ b/backend/src/handlers/auth/resend-verification-code.test.ts
@@ -4,7 +4,7 @@ import {
   mockContext,
   mockCallback,
   describeInvalidBodyCases,
-  makeCognitoError,
+  describeCognitoErrorCases,
 } from "@/test/fixtures";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
@@ -51,21 +51,14 @@ describe("POST /auth/resend-verification-code", () => {
     });
   });
 
-  describe("Cognito エラー系", () => {
-    it.each<[string, number, string | undefined]>([
-      ["InvalidParameterException", 400, "UserAlreadyConfirmed"],
-      ["UserNotFoundException", 400, undefined],
-      ["TooManyRequestsException", 429, undefined],
-      ["ServiceUnavailableException", 500, undefined],
-    ])("%s のとき %i を返す", async (name, statusCode, errorCode) => {
-      mockRepo.resendConfirmationCode.mockRejectedValueOnce(makeCognitoError(name));
-
-      const result = await handler(makeResendEvent(), mockContext, mockCallback);
-
-      expect(result?.statusCode).toBe(statusCode);
-      if (errorCode !== undefined) {
-        expect(JSON.parse(result?.body ?? "{}").error).toBe(errorCode);
-      }
-    });
-  });
+  describeCognitoErrorCases(
+    mockRepo.resendConfirmationCode,
+    () => handler(makeResendEvent(), mockContext, mockCallback),
+    [
+      { name: "InvalidParameterException", statusCode: 400, error: "UserAlreadyConfirmed" },
+      { name: "UserNotFoundException", statusCode: 400 },
+      { name: "TooManyRequestsException", statusCode: 429 },
+      { name: "ServiceUnavailableException", statusCode: 500 },
+    ],
+  );
 });

--- a/backend/src/handlers/auth/verify-email.test.ts
+++ b/backend/src/handlers/auth/verify-email.test.ts
@@ -4,7 +4,7 @@ import {
   mockContext,
   mockCallback,
   describeInvalidBodyCases,
-  makeCognitoError,
+  describeCognitoErrorCases,
 } from "@/test/fixtures";
 import { mockCognitoAuthRepo as mockRepo } from "@/repositories/__mocks__/cognito-auth-repository";
 
@@ -59,22 +59,15 @@ describe("POST /auth/verify-email", () => {
     });
   });
 
-  describe("Cognito エラー系", () => {
-    it.each<[string, number, string | undefined]>([
-      ["CodeMismatchException", 400, "CodeMismatch"],
-      ["ExpiredCodeException", 400, "ExpiredCode"],
-      ["NotAuthorizedException", 400, "NotAuthorized"],
-      ["TooManyRequestsException", 429, undefined],
-      ["ServiceUnavailableException", 500, undefined],
-    ])("%s のとき %i を返す", async (name, statusCode, errorCode) => {
-      mockRepo.confirmSignUp.mockRejectedValueOnce(makeCognitoError(name));
-
-      const result = await handler(makeVerifyEmailEvent(), mockContext, mockCallback);
-
-      expect(result?.statusCode).toBe(statusCode);
-      if (errorCode !== undefined) {
-        expect(JSON.parse(result?.body ?? "{}").error).toBe(errorCode);
-      }
-    });
-  });
+  describeCognitoErrorCases(
+    mockRepo.confirmSignUp,
+    () => handler(makeVerifyEmailEvent(), mockContext, mockCallback),
+    [
+      { name: "CodeMismatchException", statusCode: 400, error: "CodeMismatch" },
+      { name: "ExpiredCodeException", statusCode: 400, error: "ExpiredCode" },
+      { name: "NotAuthorizedException", statusCode: 400, error: "NotAuthorized" },
+      { name: "TooManyRequestsException", statusCode: 429 },
+      { name: "ServiceUnavailableException", statusCode: 500 },
+    ],
+  );
 });

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, type Mock } from "vitest";
 import type { Composer, ListeningLog, ListeningLogRecord, Piece } from "@/types";
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
@@ -185,6 +185,46 @@ type HandlerFn = (
 
 export const makeCognitoError = (name: string, message = "error") =>
   Object.assign(new Error(message), { name });
+
+/**
+ * Cognito 例外を投げたときのハンドラ応答（ステータスコードと error / message）を
+ * テーブル駆動で検証する。auth 系ハンドラに共通する「Cognito エラー系」ブロックを共通化する。
+ *
+ * - `error`: レスポンスボディの `error` フィールドの完全一致を検証する
+ * - `messageIncludes`: レスポンスボディの `message` の部分一致を検証する（大文字小文字を無視）
+ */
+type CognitoErrorCase = {
+  name: string;
+  statusCode: number;
+  error?: string;
+  messageIncludes?: string;
+};
+
+export const describeCognitoErrorCases = (
+  mockMethod: Mock,
+  invoke: () => Promise<{ statusCode?: number; body?: string } | null | undefined>,
+  cases: CognitoErrorCase[],
+) => {
+  describe("Cognito エラー系", () => {
+    it.each(cases)(
+      "$name のとき $statusCode を返す",
+      async ({ name, statusCode, error, messageIncludes }) => {
+        mockMethod.mockRejectedValueOnce(makeCognitoError(name));
+
+        const result = await invoke();
+
+        expect(result?.statusCode).toBe(statusCode);
+        const body = JSON.parse(result?.body ?? "{}");
+        if (error !== undefined) {
+          expect(body.error).toBe(error);
+        }
+        if (messageIncludes !== undefined) {
+          expect(String(body.message).toLowerCase()).toContain(messageIncludes.toLowerCase());
+        }
+      },
+    );
+  });
+};
 
 export const describeInvalidBodyCases = (handler: HandlerFn, path: string) => {
   describe("リクエストボディ異常系", () => {


### PR DESCRIPTION
## Summary
- auth ハンドラ5ファイル（login / verify-email / refresh / resend-verification-code / register）にそれぞれ重複していた「Cognito エラー系」の table-driven な `it.each` ブロックを、共通ヘルパー `describeCognitoErrorCases`（`@/test/fixtures`）に抽出
- 各テストファイルは「Cognito 例外名・期待ステータス・期待 `error` / `message`」のテーブルを渡すだけになり、検証ロジックの重複を解消
- `error` フィールド検証（login など）と `message` 部分一致検証（register）の両方をヘルパー側でサポート（`messageIncludes` は大文字小文字を無視した部分一致）

## Test plan
- [x] `pnpm -C backend test -- --run src/handlers/auth/`（5 files / 68 passed）
- [x] pre-push フックでフロント（786）・バック（798）の全テストがグリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)