### PR TITLE
test(backend): ハンドラテストのリポジトリモックを __mocks__ ファイルに共通化

### DIFF
--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -2,20 +2,9 @@ import type { Context } from "aws-lambda";
 
 import { handler } from "@/handlers/concert-logs/create";
 import { makeEvent, makeAuthEvent } from "@/test/fixtures";
+import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/concert-log-repository", () => ({
-  DynamoDBConcertLogRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/concert-log-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -128,7 +117,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -148,7 +137,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("任意フィールドを含めて正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify({
@@ -172,7 +161,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("作成アイテムに UUID が付与される", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -187,7 +176,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("createdAt と updatedAt が同じ値で設定される", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -202,7 +191,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("userId が保存される", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -213,12 +202,12 @@ describe("POST /concert-logs (create)", () => {
       mockCallback,
     );
 
-    const savedItem = mockRepo.save.mock.calls[0][0];
+    const savedItem = mockConcertLogRepo.save.mock.calls[0][0];
     expect(savedItem.userId).toBe(TEST_USER_ID);
   });
 
   it("レスポンスボディに userId が含まれる", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -233,7 +222,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockConcertLogRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -247,7 +236,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("pieceIds を含めて正常に作成して 201 を返す", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const pieceIds = [
       "550e8400-e29b-41d4-a716-446655440000",
       "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
@@ -267,7 +256,7 @@ describe("POST /concert-logs (create)", () => {
   });
 
   it("pieceIds が空配列でも正常に作成できる", async () => {
-    mockRepo.save.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify({ ...validInput, pieceIds: [] }),

--- a/backend/src/handlers/concert-logs/delete.test.ts
+++ b/backend/src/handlers/concert-logs/delete.test.ts
@@ -6,20 +6,9 @@ import {
   OTHER_USER_ID,
   makeDeleteEvent,
 } from "@/test/fixtures";
+import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/concert-log-repository", () => ({
-  DynamoDBConcertLogRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/concert-log-repository");
 
 const existingItem = {
   id: "abc-123",
@@ -48,7 +37,7 @@ describe("DELETE /concert-logs/:id (delete)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeDeleteEvent("concert-logs", "not-found-id", TEST_USER_ID),
       mockContext,
@@ -58,19 +47,19 @@ describe("DELETE /concert-logs/:id (delete)", () => {
   });
 
   it("他ユーザーのアイテムを削除しようとした場合は 404 を返す（存在を隠蔽）", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingItem);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingItem);
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", OTHER_USER_ID),
       mockContext,
       mockCallback,
     );
     expect(result?.statusCode).toBe(404);
-    expect(mockRepo.remove).not.toHaveBeenCalled();
+    expect(mockConcertLogRepo.remove).not.toHaveBeenCalled();
   });
 
   it("正常削除して 204 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingItem);
-    mockRepo.remove.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingItem);
+    mockConcertLogRepo.remove.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", TEST_USER_ID),
       mockContext,
@@ -78,11 +67,11 @@ describe("DELETE /concert-logs/:id (delete)", () => {
     );
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
-    expect(mockRepo.remove).toHaveBeenCalledTimes(1);
+    expect(mockConcertLogRepo.remove).toHaveBeenCalledTimes(1);
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockConcertLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeDeleteEvent("concert-logs", "abc-123", TEST_USER_ID),
       mockContext,

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -2,20 +2,9 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 
 import { handler } from "@/handlers/concert-logs/get";
+import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/concert-log-repository", () => ({
-  DynamoDBConcertLogRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/concert-log-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -66,7 +55,7 @@ describe("GET /concert-logs/:id (get)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
@@ -76,13 +65,13 @@ describe("GET /concert-logs/:id (get)", () => {
   });
 
   it("他ユーザーのアイテムにアクセスした場合は 404 を返す（存在を隠蔽）", async () => {
-    mockRepo.findById.mockResolvedValueOnce(testLog);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(testLog);
     const result = await handler(makeEvent("abc-123", OTHER_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
   });
 
   it("正常取得して 200 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(testLog);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(testLog);
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
 
@@ -93,14 +82,14 @@ describe("GET /concert-logs/:id (get)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockConcertLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });
 
   it("pieceIds を含むログを正常取得して 200 を返す", async () => {
     const pieceId = "550e8400-e29b-41d4-a716-446655440000";
-    mockRepo.findById.mockResolvedValueOnce({
+    mockConcertLogRepo.findById.mockResolvedValueOnce({
       ...testLog,
       pieceIds: [pieceId],
     });

--- a/backend/src/handlers/concert-logs/list.test.ts
+++ b/backend/src/handlers/concert-logs/list.test.ts
@@ -3,20 +3,9 @@ import type { ConcertLog } from "@/types";
 import { UserId } from "@/domain/value-objects/ids";
 import { handler } from "@/handlers/concert-logs/list";
 import { makeAuthEvent } from "@/test/fixtures";
+import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/concert-log-repository", () => ({
-  DynamoDBConcertLogRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/concert-log-repository");
 
 const mockContext = {} as Parameters<typeof handler>[1];
 const mockCallback = { signal: new AbortController().signal };
@@ -40,7 +29,7 @@ describe("GET /concert-logs (list)", () => {
   });
 
   it("空リストの場合は 200 で空配列を返す", async () => {
-    mockRepo.findByUserId.mockResolvedValueOnce([]);
+    mockConcertLogRepo.findByUserId.mockResolvedValueOnce([]);
     const result = await handler(mockEvent, mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
     expect(JSON.parse(result?.body ?? "[]")).toEqual([]);
@@ -52,7 +41,7 @@ describe("GET /concert-logs (list)", () => {
       makeConcertLog("2", "2024-01-15T00:00:00.000Z"),
       makeConcertLog("3", "2024-01-05T00:00:00.000Z"),
     ];
-    mockRepo.findByUserId.mockResolvedValueOnce(logs);
+    mockConcertLogRepo.findByUserId.mockResolvedValueOnce(logs);
 
     const result = await handler(mockEvent, mockContext, mockCallback);
     const body: ConcertLog[] = JSON.parse(result?.body ?? "[]");
@@ -64,15 +53,15 @@ describe("GET /concert-logs (list)", () => {
 
   it("userId でフィルタリングして自分のログのみ返す", async () => {
     const logs = [makeConcertLog("1", "2024-01-10T00:00:00.000Z", TEST_USER_ID)];
-    mockRepo.findByUserId.mockResolvedValueOnce(logs);
+    mockConcertLogRepo.findByUserId.mockResolvedValueOnce(logs);
 
     await handler(mockEvent, mockContext, mockCallback);
 
-    expect(mockRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
+    expect(mockConcertLogRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findByUserId.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockConcertLogRepo.findByUserId.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(mockEvent, mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -3,20 +3,9 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 
 import { handler } from "@/handlers/concert-logs/update";
+import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/concert-log-repository", () => ({
-  DynamoDBConcertLogRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/concert-log-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -131,18 +120,18 @@ describe("PUT /concert-logs/:id (update)", () => {
   });
 
   it("他ユーザーのアイテムを更新しようとした場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingLog);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLog);
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), OTHER_USER_ID),
       mockContext,
       mockCallback,
     );
     expect(result?.statusCode).toBe(404);
-    expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
+    expect(mockConcertLogRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
@@ -152,8 +141,8 @@ describe("PUT /concert-logs/:id (update)", () => {
   });
 
   it("正常更新して 200 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockConcertLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
@@ -165,15 +154,15 @@ describe("PUT /concert-logs/:id (update)", () => {
     const body = JSON.parse(result?.body ?? "{}");
     expect(body.id).toBe("abc-123");
     expect(body.venue).toBe("東京文化会館");
-    expect(mockRepo.saveWithOptimisticLock).toHaveBeenCalledWith(
+    expect(mockConcertLogRepo.saveWithOptimisticLock).toHaveBeenCalledWith(
       expect.objectContaining({ id: "abc-123", venue: "東京文化会館" }),
       existingLog.updatedAt,
     );
   });
 
   it("venue のみ更新して concertDate はそのままであること", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockConcertLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
@@ -186,8 +175,8 @@ describe("PUT /concert-logs/:id (update)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.saveWithOptimisticLock.mockRejectedValueOnce(
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockConcertLogRepo.saveWithOptimisticLock.mockRejectedValueOnce(
       new Conflict("Concert log was updated by another request"),
     );
     const result = await handler(
@@ -202,7 +191,7 @@ describe("PUT /concert-logs/:id (update)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockConcertLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ venue: "東京文化会館" }), TEST_USER_ID),
       mockContext,
@@ -213,8 +202,8 @@ describe("PUT /concert-logs/:id (update)", () => {
 
   it("pieceIds を更新できる", async () => {
     const pieceId = "550e8400-e29b-41d4-a716-446655440000";
-    mockRepo.findById.mockResolvedValueOnce(existingLog);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockConcertLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [pieceId] }), TEST_USER_ID),
@@ -231,8 +220,8 @@ describe("PUT /concert-logs/:id (update)", () => {
       ...existingLog,
       pieceIds: ["550e8400-e29b-41d4-a716-446655440000"],
     };
-    mockRepo.findById.mockResolvedValueOnce(existingLogWithPieces);
-    mockRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockConcertLogRepo.findById.mockResolvedValueOnce(existingLogWithPieces);
+    mockConcertLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ pieceIds: [] }), TEST_USER_ID),

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -3,43 +3,12 @@ import type { Context } from "aws-lambda";
 import { handler } from "@/handlers/listening-logs/create";
 import { makeAuthEvent, makeComposer, makeEvent, makePiece, TEST_PIECE_ID } from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
-
-const mocks = vi.hoisted(() => ({
-  listeningLogRepo: {
-    save: vi.fn(),
-    findById: vi.fn(),
-    findByUserId: vi.fn(),
-    existsByPieceIds: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
-  pieceRepo: {
-    findRootById: vi.fn(),
-    findRootPage: vi.fn(),
-    saveWork: vi.fn(),
-    saveWorkWithOptimisticLock: vi.fn(),
-    removeWorkCascade: vi.fn(),
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findChildren: vi.fn(),
-    saveMovement: vi.fn(),
-    saveMovementWithOptimisticLock: vi.fn(),
-    removeMovement: vi.fn(),
-    replaceMovements: vi.fn(),
-  },
-}));
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/composer-repository");
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mocks.listeningLogRepo;
-  }),
-}));
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mocks.pieceRepo;
-  }),
-}));
+vi.mock("@/repositories/listening-log-repository");
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -57,7 +26,7 @@ const TEST_USER_ID = "cognito-sub-user-123";
 describe("POST /listening-logs (create)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.pieceRepo.findById.mockResolvedValue(makePiece());
+    mockPieceRepo.findById.mockResolvedValue(makePiece());
     mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
@@ -138,7 +107,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("正常に作成して 201 を返す（派生値 pieceTitle / composerName を含む）", async () => {
-    mocks.listeningLogRepo.save.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -160,7 +129,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("作成アイテムに UUID が付与される", async () => {
-    mocks.listeningLogRepo.save.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -175,7 +144,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("createdAt と updatedAt が同じ値で設定される", async () => {
-    mocks.listeningLogRepo.save.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -190,7 +159,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("永続化レコードに userId / pieceId が保存される（派生値 pieceTitle 等は保存しない）", async () => {
-    mocks.listeningLogRepo.save.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.save.mockResolvedValueOnce(undefined);
     await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -201,7 +170,7 @@ describe("POST /listening-logs (create)", () => {
       mockCallback,
     );
 
-    const savedItem = mocks.listeningLogRepo.save.mock.calls[0][0];
+    const savedItem = mockListeningLogRepo.save.mock.calls[0][0];
     expect(savedItem.userId).toBe(TEST_USER_ID);
     expect(savedItem.pieceId).toBe(TEST_PIECE_ID);
     expect(savedItem.pieceTitle).toBeUndefined();
@@ -209,7 +178,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("レスポンスボディに userId が含まれる", async () => {
-    mocks.listeningLogRepo.save.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.save.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -224,7 +193,7 @@ describe("POST /listening-logs (create)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mocks.listeningLogRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockListeningLogRepo.save.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeAuthEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),

--- a/backend/src/handlers/listening-logs/delete.test.ts
+++ b/backend/src/handlers/listening-logs/delete.test.ts
@@ -7,43 +7,11 @@ import {
   makeDeleteEvent,
   makeLogRecord,
 } from "@/test/fixtures";
-
-const mocks = vi.hoisted(() => ({
-  listeningLogRepo: {
-    save: vi.fn(),
-    findById: vi.fn(),
-    findByUserId: vi.fn(),
-    existsByPieceIds: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
-  pieceRepo: {
-    findRootById: vi.fn(),
-    findRootPage: vi.fn(),
-    saveWork: vi.fn(),
-    saveWorkWithOptimisticLock: vi.fn(),
-    removeWorkCascade: vi.fn(),
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findChildren: vi.fn(),
-    saveMovement: vi.fn(),
-    saveMovementWithOptimisticLock: vi.fn(),
-    removeMovement: vi.fn(),
-    replaceMovements: vi.fn(),
-  },
-}));
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
 
 vi.mock("@/repositories/composer-repository");
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mocks.listeningLogRepo;
-  }),
-}));
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mocks.pieceRepo;
-  }),
-}));
+vi.mock("@/repositories/listening-log-repository");
+vi.mock("@/repositories/piece-repository");
 
 describe("DELETE /listening-logs/:id (delete)", () => {
   beforeEach(() => {
@@ -63,7 +31,7 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeDeleteEvent("listening-logs", "not-found-id", TEST_USER_ID),
       mockContext,
@@ -73,19 +41,19 @@ describe("DELETE /listening-logs/:id (delete)", () => {
   });
 
   it("他ユーザーのアイテムを削除しようとした場合は 404 を返す（存在を隠蔽）", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(ownItem);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(ownItem);
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", OTHER_USER_ID),
       mockContext,
       mockCallback,
     );
     expect(result?.statusCode).toBe(404);
-    expect(mocks.listeningLogRepo.remove).not.toHaveBeenCalled();
+    expect(mockListeningLogRepo.remove).not.toHaveBeenCalled();
   });
 
   it("正常削除して 204 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(ownItem);
-    mocks.listeningLogRepo.remove.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(ownItem);
+    mockListeningLogRepo.remove.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", TEST_USER_ID),
       mockContext,
@@ -93,11 +61,11 @@ describe("DELETE /listening-logs/:id (delete)", () => {
     );
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
-    expect(mocks.listeningLogRepo.remove).toHaveBeenCalledTimes(1);
+    expect(mockListeningLogRepo.remove).toHaveBeenCalledTimes(1);
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockListeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeDeleteEvent("listening-logs", "abc-123", TEST_USER_ID),
       mockContext,

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -3,43 +3,12 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import { handler } from "@/handlers/listening-logs/get";
 import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
-
-const mocks = vi.hoisted(() => ({
-  listeningLogRepo: {
-    save: vi.fn(),
-    findById: vi.fn(),
-    findByUserId: vi.fn(),
-    existsByPieceIds: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
-  pieceRepo: {
-    findRootById: vi.fn(),
-    findRootPage: vi.fn(),
-    saveWork: vi.fn(),
-    saveWorkWithOptimisticLock: vi.fn(),
-    removeWorkCascade: vi.fn(),
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findChildren: vi.fn(),
-    saveMovement: vi.fn(),
-    saveMovementWithOptimisticLock: vi.fn(),
-    removeMovement: vi.fn(),
-    replaceMovements: vi.fn(),
-  },
-}));
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/composer-repository");
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mocks.listeningLogRepo;
-  }),
-}));
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mocks.pieceRepo;
-  }),
-}));
+vi.mock("@/repositories/listening-log-repository");
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -69,7 +38,7 @@ function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
 describe("GET /listening-logs/:id (get)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.pieceRepo.findById.mockResolvedValue(makePiece());
+    mockPieceRepo.findById.mockResolvedValue(makePiece());
     mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
@@ -80,7 +49,7 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent("not-found-id", TEST_USER_ID),
       mockContext,
@@ -90,7 +59,7 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("他ユーザーのアイテムにアクセスした場合は 404 を返す（存在を隠蔽）", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(
+    mockListeningLogRepo.findById.mockResolvedValueOnce(
       makeLogRecord("abc-123", "2024-01-15T20:00:00.000Z", TEST_USER_ID),
     );
     const result = await handler(makeEvent("abc-123", OTHER_USER_ID), mockContext, mockCallback);
@@ -98,7 +67,7 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("正常取得して 200 を返す（派生値 pieceTitle / composerName を含む）", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(
+    mockListeningLogRepo.findById.mockResolvedValueOnce(
       makeLogRecord("abc-123", "2024-01-15T20:00:00.000Z", TEST_USER_ID),
     );
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
@@ -111,7 +80,7 @@ describe("GET /listening-logs/:id (get)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockListeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123", TEST_USER_ID), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/listening-logs/list.test.ts
+++ b/backend/src/handlers/listening-logs/list.test.ts
@@ -10,43 +10,12 @@ import {
   TEST_PIECE_ID,
 } from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
-
-const mocks = vi.hoisted(() => ({
-  listeningLogRepo: {
-    save: vi.fn(),
-    findById: vi.fn(),
-    findByUserId: vi.fn(),
-    existsByPieceIds: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
-  pieceRepo: {
-    findRootById: vi.fn(),
-    findRootPage: vi.fn(),
-    saveWork: vi.fn(),
-    saveWorkWithOptimisticLock: vi.fn(),
-    removeWorkCascade: vi.fn(),
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findChildren: vi.fn(),
-    saveMovement: vi.fn(),
-    saveMovementWithOptimisticLock: vi.fn(),
-    removeMovement: vi.fn(),
-    replaceMovements: vi.fn(),
-  },
-}));
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/composer-repository");
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mocks.listeningLogRepo;
-  }),
-}));
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mocks.pieceRepo;
-  }),
-}));
+vi.mock("@/repositories/listening-log-repository");
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Parameters<typeof handler>[1];
 const mockCallback = { signal: new AbortController().signal };
@@ -57,15 +26,15 @@ const mockEvent = makeAuthEvent(TEST_USER_ID);
 describe("GET /listening-logs (list)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.pieceRepo.findById.mockResolvedValue(makePiece());
-    mocks.pieceRepo.findByIds.mockResolvedValue([makePiece()]);
-    mocks.pieceRepo.findRootById.mockResolvedValue(makePiece());
+    mockPieceRepo.findById.mockResolvedValue(makePiece());
+    mockPieceRepo.findByIds.mockResolvedValue([makePiece()]);
+    mockPieceRepo.findRootById.mockResolvedValue(makePiece());
     mockComposerRepo.findById.mockResolvedValue(makeComposer());
     mockComposerRepo.findByIds.mockResolvedValue([makeComposer()]);
   });
 
   it("空リストの場合は 200 で空配列を返す", async () => {
-    mocks.listeningLogRepo.findByUserId.mockResolvedValueOnce([]);
+    mockListeningLogRepo.findByUserId.mockResolvedValueOnce([]);
     const result = await handler(mockEvent, mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
     expect(JSON.parse(result?.body ?? "[]")).toEqual([]);
@@ -77,7 +46,7 @@ describe("GET /listening-logs (list)", () => {
       makeLogRecord("2", "2024-01-15T00:00:00.000Z"),
       makeLogRecord("3", "2024-01-05T00:00:00.000Z"),
     ];
-    mocks.listeningLogRepo.findByUserId.mockResolvedValueOnce(records);
+    mockListeningLogRepo.findByUserId.mockResolvedValueOnce(records);
 
     const result = await handler(mockEvent, mockContext, mockCallback);
     const body: ListeningLog[] = JSON.parse(result?.body ?? "[]");
@@ -92,15 +61,15 @@ describe("GET /listening-logs (list)", () => {
 
   it("userId でフィルタリングして自分のログのみ返す", async () => {
     const records = [makeLogRecord("1", "2024-01-10T00:00:00.000Z", TEST_USER_ID)];
-    mocks.listeningLogRepo.findByUserId.mockResolvedValueOnce(records);
+    mockListeningLogRepo.findByUserId.mockResolvedValueOnce(records);
 
     await handler(mockEvent, mockContext, mockCallback);
 
-    expect(mocks.listeningLogRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
+    expect(mockListeningLogRepo.findByUserId).toHaveBeenCalledWith(UserId.from(TEST_USER_ID));
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mocks.listeningLogRepo.findByUserId.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockListeningLogRepo.findByUserId.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(mockEvent, mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -4,43 +4,12 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import { handler } from "@/handlers/listening-logs/update";
 import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
-
-const mocks = vi.hoisted(() => ({
-  listeningLogRepo: {
-    save: vi.fn(),
-    findById: vi.fn(),
-    findByUserId: vi.fn(),
-    existsByPieceIds: vi.fn(),
-    saveWithOptimisticLock: vi.fn(),
-    remove: vi.fn(),
-  },
-  pieceRepo: {
-    findRootById: vi.fn(),
-    findRootPage: vi.fn(),
-    saveWork: vi.fn(),
-    saveWorkWithOptimisticLock: vi.fn(),
-    removeWorkCascade: vi.fn(),
-    findById: vi.fn(),
-    findByIds: vi.fn().mockResolvedValue([]),
-    findChildren: vi.fn(),
-    saveMovement: vi.fn(),
-    saveMovementWithOptimisticLock: vi.fn(),
-    removeMovement: vi.fn(),
-    replaceMovements: vi.fn(),
-  },
-}));
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/composer-repository");
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mocks.listeningLogRepo;
-  }),
-}));
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mocks.pieceRepo;
-  }),
-}));
+vi.mock("@/repositories/listening-log-repository");
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -72,7 +41,7 @@ const existingLog = makeLogRecord("abc-123", "2024-01-15T20:00:00.000Z", TEST_US
 describe("PUT /listening-logs/:id (update)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.pieceRepo.findById.mockResolvedValue(makePiece());
+    mockPieceRepo.findById.mockResolvedValue(makePiece());
     mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
@@ -136,18 +105,18 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("他ユーザーのアイテムを更新しようとした場合は 404 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), OTHER_USER_ID),
       mockContext,
       mockCallback,
     );
     expect(result?.statusCode).toBe(404);
-    expect(mocks.listeningLogRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
+    expect(mockListeningLogRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent("not-found-id", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,
@@ -157,8 +126,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("rating を含まない更新は rating のバリデーションをスキップする", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ isFavorite: true }), TEST_USER_ID),
@@ -169,8 +138,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("正常更新して 200 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4, isFavorite: true }), TEST_USER_ID),
@@ -189,8 +158,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("updatedAt が更新されること", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const before = new Date(existingLog.updatedAt).getTime();
     const result = await handler(
@@ -203,8 +172,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("id は上書きされない", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ id: "tampered-id", rating: 4 }), TEST_USER_ID),
@@ -216,8 +185,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("pieceId を別の UUID に更新できる", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const newPieceId = "00000000-0000-4000-8000-00000000aaaa";
     const result = await handler(
@@ -241,8 +210,8 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockResolvedValueOnce(existingLog);
-    mocks.listeningLogRepo.saveWithOptimisticLock.mockRejectedValueOnce(
+    mockListeningLogRepo.findById.mockResolvedValueOnce(existingLog);
+    mockListeningLogRepo.saveWithOptimisticLock.mockRejectedValueOnce(
       new Conflict("Listening log was updated by another request"),
     );
     const result = await handler(
@@ -257,7 +226,7 @@ describe("PUT /listening-logs/:id (update)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mocks.listeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockListeningLogRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeEvent("abc-123", JSON.stringify({ rating: 4 }), TEST_USER_ID),
       mockContext,

--- a/backend/src/handlers/pieces/children.test.ts
+++ b/backend/src/handlers/pieces/children.test.ts
@@ -1,27 +1,9 @@
 import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/pieces/children";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  findByIds: vi.fn().mockResolvedValue([]),
-  findChildren: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -75,7 +57,7 @@ describe("GET /pieces/{id}/children (children)", () => {
         updatedAt: "2024-01-15T21:00:00.000Z",
       },
     ];
-    mockRepo.findChildren.mockResolvedValueOnce(movements);
+    mockPieceRepo.findChildren.mockResolvedValueOnce(movements);
 
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
@@ -87,7 +69,7 @@ describe("GET /pieces/{id}/children (children)", () => {
   });
 
   it("該当する子 Movement が無ければ空配列を返す", async () => {
-    mockRepo.findChildren.mockResolvedValueOnce([]);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([]);
 
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
@@ -95,7 +77,7 @@ describe("GET /pieces/{id}/children (children)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findChildren.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.findChildren.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -8,25 +8,9 @@ import {
   TEST_COMPOSER_ID,
   TEST_USER_ID,
 } from "@/test/fixtures";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 const validInput = {
   kind: "work" as const,
@@ -151,7 +135,7 @@ describe("POST /pieces (create)", () => {
   });
 
   it("videoUrls なしで正常に作成して 201 を返す", async () => {
-    mockRepo.saveWork.mockResolvedValueOnce(undefined);
+    mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -174,7 +158,7 @@ describe("POST /pieces (create)", () => {
   });
 
   it("有効な videoUrls を指定して作成できる", async () => {
-    mockRepo.saveWork.mockResolvedValueOnce(undefined);
+    mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
     const urls = [
       "https://www.youtube.com/watch?v=abc123",
       "https://www.youtube.com/watch?v=def456",
@@ -194,7 +178,7 @@ describe("POST /pieces (create)", () => {
   });
 
   it("作成アイテムに UUID が付与される", async () => {
-    mockRepo.saveWork.mockResolvedValueOnce(undefined);
+    mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -213,7 +197,7 @@ describe("POST /pieces (create)", () => {
     vi.useFakeTimers();
     vi.setSystemTime(now);
 
-    mockRepo.saveWork.mockResolvedValueOnce(undefined);
+    mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -231,7 +215,7 @@ describe("POST /pieces (create)", () => {
 
   describe("カテゴリフィールド", () => {
     it("全カテゴリを指定して作成できる", async () => {
-      mockRepo.saveWork.mockResolvedValueOnce(undefined);
+      mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({
@@ -256,7 +240,7 @@ describe("POST /pieces (create)", () => {
     });
 
     it("カテゴリなしで作成できる（後方互換性）", async () => {
-      mockRepo.saveWork.mockResolvedValueOnce(undefined);
+      mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify(validInput),
@@ -275,7 +259,7 @@ describe("POST /pieces (create)", () => {
     });
 
     it("一部のカテゴリのみ指定して作成できる", async () => {
-      mockRepo.saveWork.mockResolvedValueOnce(undefined);
+      mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
           body: JSON.stringify({ ...validInput, genre: "協奏曲", era: "ロマン派" }),
@@ -348,7 +332,7 @@ describe("POST /pieces (create)", () => {
 
   describe("Movement 作成", () => {
     it("kind=movement で作成して 201 を返す", async () => {
-      mockRepo.saveMovement.mockResolvedValueOnce(undefined);
+      mockPieceRepo.saveMovement.mockResolvedValueOnce(undefined);
       const parentId = "00000000-0000-4000-8000-0000000000aa";
       const result = await handler(
         makeAdminEvent(TEST_USER_ID, {
@@ -393,7 +377,7 @@ describe("POST /pieces (create)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.saveWork.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.saveWork.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeAdminEvent(TEST_USER_ID, {
         body: JSON.stringify(validInput),
@@ -419,7 +403,7 @@ describe("POST /pieces (create)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.saveWork).not.toHaveBeenCalled();
+      expect(mockPieceRepo.saveWork).not.toHaveBeenCalled();
     });
 
     it("認証クレームがない場合は 403 を返し、データを保存しない", async () => {
@@ -430,7 +414,7 @@ describe("POST /pieces (create)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.saveWork).not.toHaveBeenCalled();
+      expect(mockPieceRepo.saveWork).not.toHaveBeenCalled();
     });
 
     it("cognito:groups がカンマ区切り文字列で admin を含まない場合は 403", async () => {
@@ -444,11 +428,11 @@ describe("POST /pieces (create)", () => {
         mockCallback,
       );
       expect(result?.statusCode).toBe(403);
-      expect(mockRepo.saveWork).not.toHaveBeenCalled();
+      expect(mockPieceRepo.saveWork).not.toHaveBeenCalled();
     });
 
     it("cognito:groups がカンマ区切り文字列で admin を含む場合は 201", async () => {
-      mockRepo.saveWork.mockResolvedValueOnce(undefined);
+      mockPieceRepo.saveWork.mockResolvedValueOnce(undefined);
       const result = await handler(
         makeAuthEvent(
           TEST_USER_ID,

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -10,41 +10,11 @@ import {
   mockContext,
   TEST_USER_ID,
 } from "@/test/fixtures";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
+import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  findByIds: vi.fn().mockResolvedValue([]),
-  findChildren: vi.fn().mockResolvedValue([]),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-const mockListeningLogRepo = vi.hoisted(() => ({
-  save: vi.fn(),
-  findById: vi.fn(),
-  findByUserId: vi.fn(),
-  existsByPieceIds: vi.fn().mockResolvedValue(false),
-  saveWithOptimisticLock: vi.fn(),
-  remove: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
-vi.mock("../../repositories/listening-log-repository", () => ({
-  DynamoDBListeningLogRepository: vi.fn().mockImplementation(function () {
-    return mockListeningLogRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
+vi.mock("@/repositories/listening-log-repository");
 
 type AuthMode = "admin" | "non-admin" | "none";
 
@@ -85,7 +55,7 @@ const movementItem = {
 describe("DELETE /pieces/{id} (delete)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRepo.findChildren.mockResolvedValue([]);
+    mockPieceRepo.findChildren.mockResolvedValue([]);
     mockListeningLogRepo.existsByPieceIds.mockResolvedValue(false);
   });
 
@@ -96,62 +66,62 @@ describe("DELETE /pieces/{id} (delete)", () => {
   });
 
   it("Work を指定すると removeWorkCascade で cascade 削除し 204 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(workItem);
-    mockRepo.removeWorkCascade.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(workItem);
+    mockPieceRepo.removeWorkCascade.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
     expect(result?.body).toBe("");
-    expect(mockRepo.removeWorkCascade).toHaveBeenCalledWith(PieceId.from("test-id-123"));
-    expect(mockRepo.removeMovement).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeWorkCascade).toHaveBeenCalledWith(PieceId.from("test-id-123"));
+    expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
   });
 
   it("Movement を指定すると removeMovement で単独削除し 204 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(movementItem);
-    mockRepo.removeMovement.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(movementItem);
+    mockPieceRepo.removeMovement.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("mov-1"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
-    expect(mockRepo.removeMovement).toHaveBeenCalledWith(PieceId.from("mov-1"));
-    expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeMovement).toHaveBeenCalledWith(PieceId.from("mov-1"));
+    expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
   });
 
   it("存在しない id は冪等に 204 を返し、削除呼び出しは行わない", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("not-found"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(204);
-    expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
-    expect(mockRepo.removeMovement).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
   });
 
   it("ListeningLog から参照されている Work は 409 を返し、削除しない", async () => {
-    mockRepo.findById.mockResolvedValueOnce(workItem);
+    mockPieceRepo.findById.mockResolvedValueOnce(workItem);
     mockListeningLogRepo.existsByPieceIds.mockResolvedValueOnce(true);
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(409);
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
       "Cannot delete piece referenced by existing listening logs",
     );
-    expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
   });
 
   it("Work 配下の Movement が ListeningLog から参照されている場合も 409 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(workItem);
-    mockRepo.findChildren.mockResolvedValueOnce([movementItem]);
+    mockPieceRepo.findById.mockResolvedValueOnce(workItem);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([movementItem]);
     mockListeningLogRepo.existsByPieceIds.mockResolvedValueOnce(true);
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(409);
   });
 
   it("ListeningLog から参照されている Movement は 409 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(movementItem);
+    mockPieceRepo.findById.mockResolvedValueOnce(movementItem);
     mockListeningLogRepo.existsByPieceIds.mockResolvedValueOnce(true);
     const result = await handler(makeEvent("mov-1"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(409);
-    expect(mockRepo.removeMovement).not.toHaveBeenCalled();
+    expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(workItem);
-    mockRepo.removeWorkCascade.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.findById.mockResolvedValueOnce(workItem);
+    mockPieceRepo.removeWorkCascade.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("test-id-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });
@@ -165,17 +135,17 @@ describe("DELETE /pieces/{id} (delete)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-      expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
-      expect(mockRepo.removeMovement).not.toHaveBeenCalled();
+      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
+      expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
+      expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
     });
 
     it("認証クレームがない場合は 403 を返し、削除しない", async () => {
       const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
       expect(result?.statusCode).toBe(403);
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-      expect(mockRepo.removeWorkCascade).not.toHaveBeenCalled();
-      expect(mockRepo.removeMovement).not.toHaveBeenCalled();
+      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
+      expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
+      expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/handlers/pieces/get.test.ts
+++ b/backend/src/handlers/pieces/get.test.ts
@@ -2,25 +2,9 @@ import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Piece, PieceWork } from "@/types";
 
 import { handler } from "@/handlers/pieces/get";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 const mockContext = {} as Context;
 const mockCallback = { signal: new AbortController().signal };
@@ -63,14 +47,14 @@ describe("GET /pieces/{id} (get)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(makeEvent("not-found-id"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(404);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("Piece not found");
   });
 
   it("正常に取得して 200 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(testPiece);
+    mockPieceRepo.findById.mockResolvedValueOnce(testPiece);
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
 
@@ -82,7 +66,7 @@ describe("GET /pieces/{id} (get)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });
@@ -97,7 +81,7 @@ describe("GET /pieces/{id} (get)", () => {
       createdAt: "2024-01-15T21:00:00.000Z",
       updatedAt: "2024-01-15T21:00:00.000Z",
     };
-    mockRepo.findById.mockResolvedValueOnce(movement);
+    mockPieceRepo.findById.mockResolvedValueOnce(movement);
     const result = await handler(makeEvent("mov-1"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "{}");

--- a/backend/src/handlers/pieces/list.test.ts
+++ b/backend/src/handlers/pieces/list.test.ts
@@ -3,25 +3,9 @@ import { makeEvent, makePiece, mockContext, mockCallback } from "@/test/fixtures
 import { encodeCursor } from "@/utils/cursor";
 import { PIECES_PAGE_SIZE_DEFAULT, PIECES_PAGE_SIZE_MAX } from "@/types";
 import type { Paginated, Piece } from "@/types";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 const parseBody = (result: { body?: string } | null | undefined): Paginated<Piece> =>
   JSON.parse(result?.body ?? '{"items":[],"nextCursor":null}') as Paginated<Piece>;
@@ -33,7 +17,7 @@ describe("GET /pieces (list)", () => {
 
   describe("正常系", () => {
     it("空の場合は items=[], nextCursor=null を返す", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
 
       const result = await handler(makeEvent(), mockContext, mockCallback);
 
@@ -45,7 +29,10 @@ describe("GET /pieces (list)", () => {
 
     it("Repository から取得したアイテムを items に入れて返す", async () => {
       const pieces = [makePiece("1", "交響曲第9番"), makePiece("2", "アイーダ")];
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: pieces, lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({
+        items: pieces,
+        lastEvaluatedKey: undefined,
+      });
 
       const result = await handler(makeEvent(), mockContext, mockCallback);
 
@@ -56,18 +43,18 @@ describe("GET /pieces (list)", () => {
     });
 
     it("limit 未指定の場合は既定値で findRootPage を呼ぶ", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
 
       await handler(makeEvent(), mockContext, mockCallback);
 
-      expect(mockRepo.findRootPage).toHaveBeenCalledWith({
+      expect(mockPieceRepo.findRootPage).toHaveBeenCalledWith({
         limit: PIECES_PAGE_SIZE_DEFAULT,
         exclusiveStartKey: undefined,
       });
     });
 
     it("limit クエリを指定すると数値変換して findRootPage に渡す", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
 
       await handler(
         makeEvent({ queryStringParameters: { limit: "20" } }),
@@ -75,26 +62,26 @@ describe("GET /pieces (list)", () => {
         mockCallback,
       );
 
-      expect(mockRepo.findRootPage).toHaveBeenCalledWith({
+      expect(mockPieceRepo.findRootPage).toHaveBeenCalledWith({
         limit: 20,
         exclusiveStartKey: undefined,
       });
     });
 
     it("cursor クエリを指定するとデコードして exclusiveStartKey として findRootPage に渡す", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
       const cursor = encodeCursor({ id: "piece-prev" });
 
       await handler(makeEvent({ queryStringParameters: { cursor } }), mockContext, mockCallback);
 
-      expect(mockRepo.findRootPage).toHaveBeenCalledWith({
+      expect(mockPieceRepo.findRootPage).toHaveBeenCalledWith({
         limit: PIECES_PAGE_SIZE_DEFAULT,
         exclusiveStartKey: { id: "piece-prev" },
       });
     });
 
     it("LastEvaluatedKey がある場合はエンコードして nextCursor に入れて返す", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({
         items: [makePiece("1", "a")],
         lastEvaluatedKey: { id: "piece-1" },
       });
@@ -107,7 +94,7 @@ describe("GET /pieces (list)", () => {
     });
 
     it("LastEvaluatedKey なしの場合は nextCursor が null", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({
         items: [makePiece("1", "a")],
         lastEvaluatedKey: undefined,
       });
@@ -119,7 +106,7 @@ describe("GET /pieces (list)", () => {
     });
 
     it("LastEvaluatedKey があるが Items が空でも nextCursor を返す", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({
         items: [],
         lastEvaluatedKey: { id: "piece-x" },
       });
@@ -132,7 +119,7 @@ describe("GET /pieces (list)", () => {
     });
 
     it("ラウンドトリップ: 前ページの nextCursor を次リクエストの cursor として利用できる", async () => {
-      mockRepo.findRootPage.mockResolvedValueOnce({
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({
         items: [makePiece("1", "a")],
         lastEvaluatedKey: { id: "piece-1" },
       });
@@ -141,7 +128,7 @@ describe("GET /pieces (list)", () => {
       const { nextCursor } = parseBody(firstResult);
       expect(nextCursor).not.toBeNull();
 
-      mockRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
+      mockPieceRepo.findRootPage.mockResolvedValueOnce({ items: [], lastEvaluatedKey: undefined });
 
       await handler(
         makeEvent({ queryStringParameters: { cursor: nextCursor ?? "" } }),
@@ -149,7 +136,7 @@ describe("GET /pieces (list)", () => {
         mockCallback,
       );
 
-      expect(mockRepo.findRootPage).toHaveBeenLastCalledWith({
+      expect(mockPieceRepo.findRootPage).toHaveBeenLastCalledWith({
         limit: PIECES_PAGE_SIZE_DEFAULT,
         exclusiveStartKey: { id: "piece-1" },
       });
@@ -216,7 +203,7 @@ describe("GET /pieces (list)", () => {
     });
 
     it("Repository エラー時に 500 を返す", async () => {
-      mockRepo.findRootPage.mockRejectedValueOnce(new Error("DynamoDB error"));
+      mockPieceRepo.findRootPage.mockRejectedValueOnce(new Error("DynamoDB error"));
       const result = await handler(makeEvent(), mockContext, mockCallback);
       expect(result?.statusCode).toBe(500);
     });

--- a/backend/src/handlers/pieces/replace-movements.test.ts
+++ b/backend/src/handlers/pieces/replace-movements.test.ts
@@ -11,27 +11,9 @@ import {
   TEST_COMPOSER_ID,
   TEST_USER_ID,
 } from "@/test/fixtures";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  findByIds: vi.fn().mockResolvedValue([]),
-  findChildren: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 const TEST_WORK_ID = "00000000-0000-4000-8000-00000000aaaa";
 
@@ -112,7 +94,7 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe(
       "movements must not contain duplicate index values",
     );
-    expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+    expect(mockPieceRepo.replaceMovements).not.toHaveBeenCalled();
   });
 
   it("movements に title が空の項目があると 400 を返す", async () => {
@@ -140,7 +122,7 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
   });
 
   it("Work が存在しない場合は 404 を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findRootById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] })),
       mockContext,
@@ -150,9 +132,9 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
   });
 
   it("正常に置換して 200 と movements 配列を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
-    mockRepo.findChildren.mockResolvedValueOnce([]);
-    mockRepo.replaceMovements.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([]);
+    mockPieceRepo.replaceMovements.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent(
@@ -186,9 +168,9 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
       createdAt: "2024-01-15T20:00:00.000Z",
       updatedAt: "2024-01-15T20:00:00.000Z",
     };
-    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
-    mockRepo.findChildren.mockResolvedValueOnce([existingMovement]);
-    mockRepo.replaceMovements.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([existingMovement]);
+    mockPieceRepo.replaceMovements.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [] })),
@@ -200,9 +182,9 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
-    mockRepo.findChildren.mockResolvedValueOnce([]);
-    mockRepo.replaceMovements.mockRejectedValueOnce(
+    mockPieceRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([]);
+    mockPieceRepo.replaceMovements.mockRejectedValueOnce(
       new createError.Conflict("Piece was updated by another request"),
     );
 
@@ -216,9 +198,9 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findRootById.mockResolvedValueOnce(existingWork);
-    mockRepo.findChildren.mockResolvedValueOnce([]);
-    mockRepo.replaceMovements.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.findRootById.mockResolvedValueOnce(existingWork);
+    mockPieceRepo.findChildren.mockResolvedValueOnce([]);
+    mockPieceRepo.replaceMovements.mockRejectedValueOnce(new Error("DynamoDB error"));
 
     const result = await handler(
       makeEvent(TEST_WORK_ID, JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] })),
@@ -241,8 +223,8 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.findRootById).not.toHaveBeenCalled();
-      expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+      expect(mockPieceRepo.findRootById).not.toHaveBeenCalled();
+      expect(mockPieceRepo.replaceMovements).not.toHaveBeenCalled();
     });
 
     it("認証クレームがない場合は 403 を返す", async () => {
@@ -256,7 +238,7 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
         mockCallback,
       );
       expect(result?.statusCode).toBe(403);
-      expect(mockRepo.replaceMovements).not.toHaveBeenCalled();
+      expect(mockPieceRepo.replaceMovements).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -12,25 +12,9 @@ import {
   TEST_COMPOSER_ID,
   TEST_USER_ID,
 } from "@/test/fixtures";
+import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
-const mockRepo = vi.hoisted(() => ({
-  saveWork: vi.fn(),
-  saveWorkWithOptimisticLock: vi.fn(),
-  removeWorkCascade: vi.fn(),
-  findRootById: vi.fn(),
-  findRootPage: vi.fn(),
-  findById: vi.fn(),
-  saveMovement: vi.fn(),
-  saveMovementWithOptimisticLock: vi.fn(),
-  removeMovement: vi.fn(),
-  replaceMovements: vi.fn(),
-}));
-
-vi.mock("../../repositories/piece-repository", () => ({
-  DynamoDBPieceRepository: vi.fn().mockImplementation(function () {
-    return mockRepo;
-  }),
-}));
+vi.mock("@/repositories/piece-repository");
 
 type AuthMode = "admin" | "non-admin" | "none";
 
@@ -138,8 +122,8 @@ describe("PUT /pieces/{id} (update)", () => {
   );
 
   it("title を含まない更新は title のバリデーションをスキップする", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", work({ composerId: OTHER_COMPOSER_ID })),
@@ -150,7 +134,7 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("アイテムが存在しない場合は 404 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(undefined);
     const result = await handler(
       makeEvent("not-found-id", work({ title: "新タイトル" })),
       mockContext,
@@ -160,8 +144,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("正常更新して 200 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", work({ title: "交響曲第5番", composerId: OTHER_COMPOSER_ID })),
@@ -178,8 +162,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("updatedAt が更新されること", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const before = new Date(existingPiece.updatedAt).getTime();
     const result = await handler(
@@ -192,8 +176,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("createdAt は上書きされない", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", work({ title: "交響曲第5番" })),
@@ -205,8 +189,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("id は上書きされない", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", work({ title: "交響曲第5番" })),
@@ -218,8 +202,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("楽観的ロック競合時に 409 を返す", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockRejectedValueOnce(
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockRejectedValueOnce(
       new createError.Conflict("Piece was updated by another request"),
     );
 
@@ -233,7 +217,7 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("Repository エラー時に 500 を返す", async () => {
-    mockRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
+    mockPieceRepo.findById.mockRejectedValueOnce(new Error("DynamoDB error"));
     const result = await handler(
       makeEvent("abc-123", work({ title: "交響曲第5番" })),
       mockContext,
@@ -243,8 +227,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("videoUrls を追加して更新できる", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPiece);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const urls = ["https://www.youtube.com/watch?v=xyz", "https://www.youtube.com/watch?v=qrs"];
     const result = await handler(
@@ -258,8 +242,8 @@ describe("PUT /pieces/{id} (update)", () => {
   });
 
   it("videoUrls を空配列で送信すると削除される", async () => {
-    mockRepo.findById.mockResolvedValueOnce(existingPieceWithVideoUrls);
-    mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+    mockPieceRepo.findById.mockResolvedValueOnce(existingPieceWithVideoUrls);
+    mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
     const result = await handler(
       makeEvent("abc-123", work({ videoUrls: [] })),
@@ -273,8 +257,8 @@ describe("PUT /pieces/{id} (update)", () => {
 
   describe("カテゴリフィールド", () => {
     it("カテゴリを追加して更新できる", async () => {
-      mockRepo.findById.mockResolvedValueOnce(existingPiece);
-      mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+      mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+      mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
       const result = await handler(
         makeEvent(
@@ -303,8 +287,8 @@ describe("PUT /pieces/{id} (update)", () => {
         genre: "交響曲",
         era: "古典派",
       };
-      mockRepo.findById.mockResolvedValueOnce(existingWithCategory);
-      mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+      mockPieceRepo.findById.mockResolvedValueOnce(existingWithCategory);
+      mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
       const result = await handler(
         makeEvent("abc-123", work({ genre: "協奏曲", era: "ロマン派" })),
@@ -325,8 +309,8 @@ describe("PUT /pieces/{id} (update)", () => {
         formation: "管弦楽",
         region: "ドイツ・オーストリア",
       };
-      mockRepo.findById.mockResolvedValueOnce(existingWithCategory);
-      mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+      mockPieceRepo.findById.mockResolvedValueOnce(existingWithCategory);
+      mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
       const result = await handler(
         makeEvent("abc-123", work({ genre: "", era: "", formation: "", region: "" })),
@@ -342,8 +326,8 @@ describe("PUT /pieces/{id} (update)", () => {
     });
 
     it("一部のカテゴリのみ更新できる", async () => {
-      mockRepo.findById.mockResolvedValueOnce(existingPiece);
-      mockRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
+      mockPieceRepo.findById.mockResolvedValueOnce(existingPiece);
+      mockPieceRepo.saveWorkWithOptimisticLock.mockResolvedValueOnce(undefined);
 
       const result = await handler(
         makeEvent("abc-123", work({ genre: "室内楽" })),
@@ -412,8 +396,8 @@ describe("PUT /pieces/{id} (update)", () => {
       );
       expect(result?.statusCode).toBe(403);
       expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-      expect(mockRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
+      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
+      expect(mockPieceRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
     });
 
     it("認証クレームがない場合は 403 を返し、データを更新しない", async () => {
@@ -423,8 +407,8 @@ describe("PUT /pieces/{id} (update)", () => {
         mockCallback,
       );
       expect(result?.statusCode).toBe(403);
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-      expect(mockRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
+      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
+      expect(mockPieceRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
     });
   });
 });

--- a/backend/src/repositories/__mocks__/concert-log-repository.ts
+++ b/backend/src/repositories/__mocks__/concert-log-repository.ts
@@ -1,0 +1,11 @@
+export const mockConcertLogRepo = {
+  save: vi.fn(),
+  findById: vi.fn(),
+  findByUserId: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+};
+
+export const DynamoDBConcertLogRepository = vi.fn().mockImplementation(function () {
+  return mockConcertLogRepo;
+});

--- a/backend/src/repositories/__mocks__/listening-log-repository.ts
+++ b/backend/src/repositories/__mocks__/listening-log-repository.ts
@@ -1,0 +1,12 @@
+export const mockListeningLogRepo = {
+  save: vi.fn(),
+  findById: vi.fn(),
+  findByUserId: vi.fn(),
+  existsByPieceIds: vi.fn(),
+  saveWithOptimisticLock: vi.fn(),
+  remove: vi.fn(),
+};
+
+export const DynamoDBListeningLogRepository = vi.fn().mockImplementation(function () {
+  return mockListeningLogRepo;
+});

--- a/backend/src/repositories/__mocks__/piece-repository.ts
+++ b/backend/src/repositories/__mocks__/piece-repository.ts
@@ -1,0 +1,18 @@
+export const mockPieceRepo = {
+  saveWork: vi.fn(),
+  saveWorkWithOptimisticLock: vi.fn(),
+  removeWorkCascade: vi.fn(),
+  findRootById: vi.fn(),
+  findRootPage: vi.fn(),
+  findById: vi.fn(),
+  findByIds: vi.fn().mockResolvedValue([]),
+  findChildren: vi.fn().mockResolvedValue([]),
+  saveMovement: vi.fn(),
+  saveMovementWithOptimisticLock: vi.fn(),
+  removeMovement: vi.fn(),
+  replaceMovements: vi.fn(),
+};
+
+export const DynamoDBPieceRepository = vi.fn().mockImplementation(function () {
+  return mockPieceRepo;
+});


### PR DESCRIPTION
## Summary

- `piece-repository`・`listening-log-repository`・`concert-log-repository` の3つの `__mocks__` ファイルを新規作成し、`mockPieceRepo` / `mockListeningLogRepo` / `mockConcertLogRepo` を export
- handlers 配下17テストファイルで繰り返されていた `vi.hoisted()` + `vi.mock(..., () => ({...}))` のボイラープレートを削除し、`vi.mock("@/repositories/xxx")` + import の2行に統一
- `composer-repository` / `cognito-auth-repository` と同じ `__mocks__/` パターンに揃えた

## Test plan

- [x] `pnpm run test:backend` — 55ファイル・798テストすべてグリーン
- [x] `pnpm run test:frontend` — 105ファイル・786テストすべてグリーン
- [x] `pnpm run format:check` — Prettier チェックパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)