### PR TITLE
fix(cdk): 視聴ログ系 Lambda に pieces / composers テーブルの Read 権限を追加

### DIFF
--- a/cdk/lib/classical-music-lake-stack.ts
+++ b/cdk/lib/classical-music-lake-stack.ts
@@ -499,6 +499,16 @@ export class ClassicalMusicLakeStack extends cdk.Stack {
     listeningLogsTable.grantWriteData(listeningLogsCreate);
     listeningLogsTable.grantReadWriteData(listeningLogsUpdate);
     listeningLogsTable.grantWriteData(listeningLogsDelete);
+    // ListeningLogDetail の組み立てで pieceRepo / composerRepo を参照するため Read 権限が必要
+    // （list / get / create / update はレスポンスに派生値を載せる。delete は noContent のため不要）
+    piecesTable.grantReadData(listeningLogsList);
+    piecesTable.grantReadData(listeningLogsGet);
+    piecesTable.grantReadData(listeningLogsCreate);
+    piecesTable.grantReadData(listeningLogsUpdate);
+    composersTable.grantReadData(listeningLogsList);
+    composersTable.grantReadData(listeningLogsGet);
+    composersTable.grantReadData(listeningLogsCreate);
+    composersTable.grantReadData(listeningLogsUpdate);
     piecesTable.grantReadData(listPieces);
     piecesTable.grantWriteData(createPiece);
     piecesTable.grantReadData(getPiece);

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -414,6 +414,7 @@ interface ConcertLog {
 - **関数数**: 28 個（本スタック。データ移行用 Lambda は `MigrationsStack` に分離）
   - 視聴ログ × 5 / 楽曲マスタ × 7（CRUD 5 + `getPieceChildren` + `replacePieceMovements`）/ 作曲家マスタ × 5 / コンサート記録 × 5 / 認証系 × 5（register・login・verify-email・resend-verification-code・refresh）/ PreSignUp トリガー × 1
 - **環境変数**: `DYNAMO_TABLE_{LISTENING_LOGS,PIECES,CONCERT_LOGS,COMPOSERS}`、`COGNITO_USER_POOL_ID` / `COGNITO_CLIENT_ID`（認証系のみ）、`CORS_ALLOW_ORIGIN`
+- **IAM 権限ポリシー（視聴ログ系）**: `list` / `get` / `create` / `update` の各 Lambda は `ListeningLogDetail` の組み立てで `PieceRepository` / `ComposerRepository` を参照するため、`listening-logs` テーブルに加えて `pieces` テーブルと `composers` テーブルへの Read 権限も必要。`delete` は `204 No Content` を返すだけなので不要
 
 #### Cognito
 


### PR DESCRIPTION
## Summary

- `ListeningLogDetail` の組み立てで `PieceRepository` / `ComposerRepository` を参照するようになったにもかかわらず、CDK の IAM ポリシーに `pieces` / `composers` テーブルへの `GetItem` 権限が付与されておらず、本番で `AccessDeniedException` による 500 エラーが発生していた
- `list` / `get` / `create` / `update` の4 Lambda に `piecesTable.grantReadData` / `composersTable.grantReadData` を追加
- `delete` は `204 No Content` を返すだけで両テーブルを参照しないため対象外

## Root cause

CloudWatch ログ（`ClassicalMusicLakeStack-ListeningLogsListLogGroup...`）にて以下のエラーを確認：

```
AccessDeniedException: ... is not authorized to perform: dynamodb:GetItem
on resource: .../table/classical-music-pieces
because no identity-based policy allows the dynamodb:GetItem action
at async e.findById (/var/task/index.js:...)
```

`GET /listening-logs` と `POST /listening-logs` のみが 500 で、`GET /pieces` `GET /composers` は 200 正常。middy のバンプは関係なく、IAM 権限の欠落が原因。

Closes #720

## Test plan

- [x] `pnpm run test:backend` — 55 ファイル 798 テストすべてパス
- [x] `pnpm run test:frontend` — 105 ファイル 786 テストすべてパス
- [ ] stg デプロイ後に `GET /listening-logs` が 200 を返すことを確認してから prod へ

🤖 Generated with [Claude Code](https://claude.com/claude-code)