### PR TITLE
test(backend): ハンドラテストの重複を共通ヘルパーに集約

### DIFF
--- a/backend/src/handlers/composers/create.test.ts
+++ b/backend/src/handlers/composers/create.test.ts
@@ -1,5 +1,7 @@
 import { handler } from "@/handlers/composers/create";
 import {
+  describeAdminForbiddenCases,
+  describeInvalidBodyCases,
   makeAdminEvent,
   makeAuthEvent,
   makeEvent,
@@ -24,22 +26,9 @@ describe("POST /composers (create)", () => {
     vi.useRealTimers();
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/composers" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/composers", (body) =>
+    makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/composers" }),
+  );
 
   it("name がない場合は 400 を返す", async () => {
     const result = await handler(
@@ -304,30 +293,17 @@ describe("POST /composers (create)", () => {
     expect(result?.statusCode).toBe(500);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、データを保存しない", async () => {
-      const result = await handler(
-        makeAuthEvent(TEST_USER_ID, {
-          body: JSON.stringify(validInput),
-          httpMethod: "POST",
-          path: "/composers",
-        }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockRepo.save).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返し、データを保存しない", async () => {
-      const result = await handler(
-        makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/composers" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockRepo.save).not.toHaveBeenCalled();
-    });
-  });
+  describeAdminForbiddenCases(
+    (auth) => {
+      const overrides = {
+        body: JSON.stringify(validInput),
+        httpMethod: "POST",
+        path: "/composers",
+      };
+      const event =
+        auth === "non-admin" ? makeAuthEvent(TEST_USER_ID, overrides) : makeEvent(overrides);
+      return handler(event, mockContext, mockCallback);
+    },
+    [mockRepo.save],
+  );
 });

--- a/backend/src/handlers/composers/delete.test.ts
+++ b/backend/src/handlers/composers/delete.test.ts
@@ -1,36 +1,19 @@
-import type { APIGatewayProxyEvent } from "aws-lambda";
-
 import { ComposerId } from "@/domain/value-objects/ids";
 import { handler } from "@/handlers/composers/delete";
 import {
-  makeAdminEvent,
-  makeAuthEvent,
-  makeEvent as makeBaseEvent,
+  describeAdminForbiddenCases,
+  makeAdminDeleteEvent,
   mockCallback,
   mockContext,
-  TEST_USER_ID,
+  type WriteAuthMode,
 } from "@/test/fixtures";
 
 import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
 vi.mock("@/repositories/composer-repository");
 
-type AuthMode = "admin" | "non-admin" | "none";
-
-function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxyEvent {
-  const overrides: Partial<APIGatewayProxyEvent> = {
-    httpMethod: "DELETE",
-    path: `/composers/${id ?? ""}`,
-    pathParameters: id === null ? null : { id },
-  };
-  if (auth === "admin") {
-    return makeAdminEvent(TEST_USER_ID, overrides);
-  }
-  if (auth === "non-admin") {
-    return makeAuthEvent(TEST_USER_ID, overrides);
-  }
-  return makeBaseEvent(overrides);
-}
+const makeEvent = (id: string | null, auth: WriteAuthMode = "admin") =>
+  makeAdminDeleteEvent("composers", id, auth);
 
 describe("DELETE /composers/{id} (delete)", () => {
   beforeEach(() => {
@@ -63,21 +46,8 @@ describe("DELETE /composers/{id} (delete)", () => {
     expect(result?.statusCode).toBe(500);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、削除しない", async () => {
-      const result = await handler(
-        makeEvent("test-id-123", "non-admin"),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockRepo.remove).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返し、削除しない", async () => {
-      const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(403);
-      expect(mockRepo.remove).not.toHaveBeenCalled();
-    });
-  });
+  describeAdminForbiddenCases(
+    (auth) => handler(makeEvent("test-id-123", auth), mockContext, mockCallback),
+    [mockRepo.remove],
+  );
 });

--- a/backend/src/handlers/composers/get.test.ts
+++ b/backend/src/handlers/composers/get.test.ts
@@ -1,31 +1,13 @@
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Composer } from "@/types";
 
 import { handler } from "@/handlers/composers/get";
+import { makeGetEvent, mockCallback, mockContext } from "@/test/fixtures";
 
 import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
 vi.mock("@/repositories/composer-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-function makeEvent(id?: string): APIGatewayProxyEvent {
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "GET",
-    isBase64Encoded: false,
-    path: `/composers/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {} as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string) => makeGetEvent("composers", id);
 
 const testComposer: Composer = {
   id: "abc-123",

--- a/backend/src/handlers/composers/update.test.ts
+++ b/backend/src/handlers/composers/update.test.ts
@@ -1,42 +1,21 @@
-import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 import type { Composer } from "@/types";
 
 import { handler } from "@/handlers/composers/update";
 import {
-  makeAdminEvent,
-  makeAuthEvent,
-  makeEvent as makeBaseEvent,
+  describeAdminForbiddenCases,
+  makeAdminPutEvent,
   mockCallback,
   mockContext,
-  TEST_USER_ID,
+  type WriteAuthMode,
 } from "@/test/fixtures";
 
 import { mockComposerRepo as mockRepo } from "@/repositories/__mocks__/composer-repository";
 
 vi.mock("@/repositories/composer-repository");
 
-type AuthMode = "admin" | "non-admin" | "none";
-
-function makeEvent(
-  id?: string,
-  body?: string | null,
-  auth: AuthMode = "admin",
-): APIGatewayProxyEvent {
-  const overrides: Partial<APIGatewayProxyEvent> = {
-    body: body === undefined ? null : body,
-    httpMethod: "PUT",
-    path: `/composers/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-  };
-  if (auth === "admin") {
-    return makeAdminEvent(TEST_USER_ID, overrides);
-  }
-  if (auth === "non-admin") {
-    return makeAuthEvent(TEST_USER_ID, overrides);
-  }
-  return makeBaseEvent(overrides);
-}
+const makeEvent = (id?: string, body?: string | null, auth: WriteAuthMode = "admin") =>
+  makeAdminPutEvent("composers", id, body, auth);
 
 const existingComposer: Composer = {
   id: "abc-123",
@@ -259,26 +238,13 @@ describe("PUT /composers/{id} (update)", () => {
     expect(result?.statusCode).toBe(409);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、データを更新しない", async () => {
-      const result = await handler(
-        makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "non-admin"),
+  describeAdminForbiddenCases(
+    (auth) =>
+      handler(
+        makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), auth),
         mockContext,
         mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-      expect(mockRepo.saveWithOptimisticLock).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返し、データを更新しない", async () => {
-      const result = await handler(
-        makeEvent("abc-123", JSON.stringify({ name: "新しい名前" }), "none"),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockRepo.findById).not.toHaveBeenCalled();
-    });
-  });
+      ),
+    [mockRepo.findById, mockRepo.saveWithOptimisticLock],
+  );
 });

--- a/backend/src/handlers/concert-logs/create.test.ts
+++ b/backend/src/handlers/concert-logs/create.test.ts
@@ -1,13 +1,15 @@
-import type { Context } from "aws-lambda";
-
 import { handler } from "@/handlers/concert-logs/create";
-import { makeEvent, makeAuthEvent } from "@/test/fixtures";
+import {
+  describeInvalidBodyCases,
+  makeAuthEvent,
+  makeEvent,
+  mockCallback,
+  mockContext,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
 vi.mock("@/repositories/concert-log-repository");
-
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
 
 const validInput = {
   title: "定期演奏会 第123回",
@@ -15,29 +17,12 @@ const validInput = {
   venue: "サントリーホール",
 };
 
-const TEST_USER_ID = "cognito-sub-user-123";
-
 describe("POST /concert-logs (create)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeEvent({ body, httpMethod: "POST", path: "/concert-logs" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/concert-logs");
 
   it.each(["   ", "\t", "\n"])(
     "venue が空白のみ（%j）の場合は 400 を返す",

--- a/backend/src/handlers/concert-logs/get.test.ts
+++ b/backend/src/handlers/concert-logs/get.test.ts
@@ -1,35 +1,18 @@
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 
 import { handler } from "@/handlers/concert-logs/get";
+import {
+  makeGetEvent,
+  mockCallback,
+  mockContext,
+  OTHER_USER_ID,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
 vi.mock("@/repositories/concert-log-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-const TEST_USER_ID = "cognito-sub-user-123";
-const OTHER_USER_ID = "cognito-sub-other-user";
-
-function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "GET",
-    isBase64Encoded: false,
-    path: `/concert-logs/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {
-      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
-    } as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string, userId?: string) => makeGetEvent("concert-logs", id, userId);
 
 const testLog: ConcertLog = {
   id: "abc-123",

--- a/backend/src/handlers/concert-logs/update.test.ts
+++ b/backend/src/handlers/concert-logs/update.test.ts
@@ -1,36 +1,21 @@
 import { Conflict } from "http-errors";
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { ConcertLog } from "@/types";
 
 import { handler } from "@/handlers/concert-logs/update";
+import {
+  describeInvalidBodyCases,
+  makeUserPutEvent,
+  mockCallback,
+  mockContext,
+  OTHER_USER_ID,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockConcertLogRepo } from "@/repositories/__mocks__/concert-log-repository";
 
 vi.mock("@/repositories/concert-log-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-const TEST_USER_ID = "cognito-sub-user-123";
-const OTHER_USER_ID = "cognito-sub-other-user";
-
-function makeEvent(id?: string, body?: string | null, userId?: string): APIGatewayProxyEvent {
-  return {
-    body: body === undefined ? null : body,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "PUT",
-    isBase64Encoded: false,
-    path: `/concert-logs/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {
-      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
-    } as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string, body?: string | null, userId?: string) =>
+  makeUserPutEvent("concert-logs", id, body, userId);
 
 const existingLog: ConcertLog = {
   id: "abc-123",
@@ -58,22 +43,9 @@ describe("PUT /concert-logs/:id (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeEvent("abc-123", body, TEST_USER_ID),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/concert-logs/abc-123", (body) =>
+    makeEvent("abc-123", body, TEST_USER_ID),
+  );
 
   it.each(["   ", "\t", "\n"])(
     "venue が空白のみ（%j）の場合は 400 を返す",

--- a/backend/src/handlers/listening-logs/create.test.ts
+++ b/backend/src/handlers/listening-logs/create.test.ts
@@ -1,7 +1,15 @@
-import type { Context } from "aws-lambda";
-
 import { handler } from "@/handlers/listening-logs/create";
-import { makeAuthEvent, makeComposer, makeEvent, makePiece, TEST_PIECE_ID } from "@/test/fixtures";
+import {
+  describeInvalidBodyCases,
+  makeAuthEvent,
+  makeComposer,
+  makeEvent,
+  makePiece,
+  mockCallback,
+  mockContext,
+  TEST_PIECE_ID,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
@@ -9,9 +17,6 @@ import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 vi.mock("@/repositories/composer-repository");
 vi.mock("@/repositories/listening-log-repository");
 vi.mock("@/repositories/piece-repository");
-
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
 
 const validInput = {
   listenedAt: "2024-01-15T20:00:00.000Z",
@@ -21,8 +26,6 @@ const validInput = {
   memo: "素晴らしい演奏",
 };
 
-const TEST_USER_ID = "cognito-sub-user-123";
-
 describe("POST /listening-logs (create)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,22 +33,7 @@ describe("POST /listening-logs (create)", () => {
     mockComposerRepo.findById.mockResolvedValue(makeComposer());
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeEvent({ body, httpMethod: "POST", path: "/listening-logs" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/listening-logs");
 
   it.each([0, 6, -1, 1.5, "5", null])(
     "rating が不正な値（%s）の場合は 400 を返す",

--- a/backend/src/handlers/listening-logs/get.test.ts
+++ b/backend/src/handlers/listening-logs/get.test.ts
@@ -1,7 +1,14 @@
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-
 import { handler } from "@/handlers/listening-logs/get";
-import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
+import {
+  makeComposer,
+  makeGetEvent,
+  makeLogRecord,
+  makePiece,
+  mockCallback,
+  mockContext,
+  OTHER_USER_ID,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
@@ -10,30 +17,7 @@ vi.mock("@/repositories/composer-repository");
 vi.mock("@/repositories/listening-log-repository");
 vi.mock("@/repositories/piece-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-const TEST_USER_ID = "cognito-sub-user-123";
-const OTHER_USER_ID = "cognito-sub-other-user";
-
-function makeEvent(id?: string, userId?: string): APIGatewayProxyEvent {
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "GET",
-    isBase64Encoded: false,
-    path: `/listening-logs/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {
-      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
-    } as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string, userId?: string) => makeGetEvent("listening-logs", id, userId);
 
 describe("GET /listening-logs/:id (get)", () => {
   beforeEach(() => {

--- a/backend/src/handlers/listening-logs/update.test.ts
+++ b/backend/src/handlers/listening-logs/update.test.ts
@@ -1,8 +1,17 @@
 import { Conflict } from "http-errors";
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 
 import { handler } from "@/handlers/listening-logs/update";
-import { makeComposer, makeLogRecord, makePiece } from "@/test/fixtures";
+import {
+  describeInvalidBodyCases,
+  makeComposer,
+  makeLogRecord,
+  makePiece,
+  makeUserPutEvent,
+  mockCallback,
+  mockContext,
+  OTHER_USER_ID,
+  TEST_USER_ID,
+} from "@/test/fixtures";
 import { mockComposerRepo } from "@/repositories/__mocks__/composer-repository";
 import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
@@ -11,30 +20,8 @@ vi.mock("@/repositories/composer-repository");
 vi.mock("@/repositories/listening-log-repository");
 vi.mock("@/repositories/piece-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-const TEST_USER_ID = "cognito-sub-user-123";
-const OTHER_USER_ID = "cognito-sub-other-user";
-
-function makeEvent(id?: string, body?: string | null, userId?: string): APIGatewayProxyEvent {
-  return {
-    body: body === undefined ? null : body,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "PUT",
-    isBase64Encoded: false,
-    path: `/listening-logs/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {
-      authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
-    } as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string, body?: string | null, userId?: string) =>
+  makeUserPutEvent("listening-logs", id, body, userId);
 
 const existingLog = makeLogRecord("abc-123", "2024-01-15T20:00:00.000Z", TEST_USER_ID);
 
@@ -55,22 +42,9 @@ describe("PUT /listening-logs/:id (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeEvent("abc-123", body, TEST_USER_ID),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/listening-logs/abc-123", (body) =>
+    makeEvent("abc-123", body, TEST_USER_ID),
+  );
 
   it.each([0, 6, -1, 1.5, "5", null])(
     "rating が不正な値（%s）の場合は 400 を返す",

--- a/backend/src/handlers/pieces/children.test.ts
+++ b/backend/src/handlers/pieces/children.test.ts
@@ -1,29 +1,15 @@
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
-
 import { handler } from "@/handlers/pieces/children";
+import { makeEvent, mockCallback, mockContext } from "@/test/fixtures";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/piece-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-function makeEvent(id?: string): APIGatewayProxyEvent {
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
+const makeChildrenEvent = (id?: string) =>
+  makeEvent({
     httpMethod: "GET",
-    isBase64Encoded: false,
     path: `/pieces/${id ?? ""}/children`,
     pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {} as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+  });
 
 describe("GET /pieces/{id}/children (children)", () => {
   beforeEach(() => {
@@ -31,7 +17,7 @@ describe("GET /pieces/{id}/children (children)", () => {
   });
 
   it("id がない場合は 400 を返す", async () => {
-    const result = await handler(makeEvent(), mockContext, mockCallback);
+    const result = await handler(makeChildrenEvent(), mockContext, mockCallback);
     expect(result?.statusCode).toBe(400);
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
@@ -59,7 +45,7 @@ describe("GET /pieces/{id}/children (children)", () => {
     ];
     mockPieceRepo.findChildren.mockResolvedValueOnce(movements);
 
-    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    const result = await handler(makeChildrenEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
     const body = JSON.parse(result?.body ?? "[]");
     expect(body).toHaveLength(2);
@@ -71,14 +57,14 @@ describe("GET /pieces/{id}/children (children)", () => {
   it("該当する子 Movement が無ければ空配列を返す", async () => {
     mockPieceRepo.findChildren.mockResolvedValueOnce([]);
 
-    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    const result = await handler(makeChildrenEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(200);
     expect(JSON.parse(result?.body ?? "[]")).toEqual([]);
   });
 
   it("Repository エラー時に 500 を返す", async () => {
     mockPieceRepo.findChildren.mockRejectedValueOnce(new Error("DynamoDB error"));
-    const result = await handler(makeEvent("abc-123"), mockContext, mockCallback);
+    const result = await handler(makeChildrenEvent("abc-123"), mockContext, mockCallback);
     expect(result?.statusCode).toBe(500);
   });
 });

--- a/backend/src/handlers/pieces/create.test.ts
+++ b/backend/src/handlers/pieces/create.test.ts
@@ -1,5 +1,7 @@
 import { handler } from "@/handlers/pieces/create";
 import {
+  describeAdminForbiddenCases,
+  describeInvalidBodyCases,
   makeAdminEvent,
   makeAuthEvent,
   makeEvent,
@@ -27,22 +29,9 @@ describe("POST /pieces (create)", () => {
     vi.useRealTimers();
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/pieces" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/pieces", (body) =>
+    makeAdminEvent(TEST_USER_ID, { body, httpMethod: "POST", path: "/pieces" }),
+  );
 
   it("title がない場合は 400 を返す", async () => {
     const result = await handler(
@@ -390,33 +379,17 @@ describe("POST /pieces (create)", () => {
     expect(result?.statusCode).toBe(500);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、データを保存しない", async () => {
-      const result = await handler(
-        makeAuthEvent(TEST_USER_ID, {
-          body: JSON.stringify(validInput),
-          httpMethod: "POST",
-          path: "/pieces",
-        }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockPieceRepo.saveWork).not.toHaveBeenCalled();
-    });
+  describeAdminForbiddenCases(
+    (auth) => {
+      const overrides = { body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" };
+      const event =
+        auth === "non-admin" ? makeAuthEvent(TEST_USER_ID, overrides) : makeEvent(overrides);
+      return handler(event, mockContext, mockCallback);
+    },
+    [mockPieceRepo.saveWork],
+  );
 
-    it("認証クレームがない場合は 403 を返し、データを保存しない", async () => {
-      const result = await handler(
-        makeEvent({ body: JSON.stringify(validInput), httpMethod: "POST", path: "/pieces" }),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockPieceRepo.saveWork).not.toHaveBeenCalled();
-    });
-
+  describe("認可: cognito:groups が文字列形式", () => {
     it("cognito:groups がカンマ区切り文字列で admin を含まない場合は 403", async () => {
       const result = await handler(
         makeAuthEvent(

--- a/backend/src/handlers/pieces/delete.test.ts
+++ b/backend/src/handlers/pieces/delete.test.ts
@@ -1,14 +1,11 @@
-import type { APIGatewayProxyEvent } from "aws-lambda";
-
 import { PieceId } from "@/domain/value-objects/ids";
 import { handler } from "@/handlers/pieces/delete";
 import {
-  makeAdminEvent,
-  makeAuthEvent,
-  makeEvent as makeBaseEvent,
+  describeAdminForbiddenCases,
+  makeAdminDeleteEvent,
   mockCallback,
   mockContext,
-  TEST_USER_ID,
+  type WriteAuthMode,
 } from "@/test/fixtures";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-repository";
@@ -16,22 +13,8 @@ import { mockListeningLogRepo } from "@/repositories/__mocks__/listening-log-rep
 vi.mock("@/repositories/piece-repository");
 vi.mock("@/repositories/listening-log-repository");
 
-type AuthMode = "admin" | "non-admin" | "none";
-
-function makeEvent(id: string | null, auth: AuthMode = "admin"): APIGatewayProxyEvent {
-  const overrides: Partial<APIGatewayProxyEvent> = {
-    httpMethod: "DELETE",
-    path: `/pieces/${id ?? ""}`,
-    pathParameters: id === null ? null : { id },
-  };
-  if (auth === "admin") {
-    return makeAdminEvent(TEST_USER_ID, overrides);
-  }
-  if (auth === "non-admin") {
-    return makeAuthEvent(TEST_USER_ID, overrides);
-  }
-  return makeBaseEvent(overrides);
-}
+const makeEvent = (id: string | null, auth: WriteAuthMode = "admin") =>
+  makeAdminDeleteEvent("pieces", id, auth);
 
 const workItem = {
   kind: "work" as const,
@@ -126,26 +109,8 @@ describe("DELETE /pieces/{id} (delete)", () => {
     expect(result?.statusCode).toBe(500);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、削除しない", async () => {
-      const result = await handler(
-        makeEvent("test-id-123", "non-admin"),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
-      expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
-      expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返し、削除しない", async () => {
-      const result = await handler(makeEvent("test-id-123", "none"), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(403);
-      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
-      expect(mockPieceRepo.removeWorkCascade).not.toHaveBeenCalled();
-      expect(mockPieceRepo.removeMovement).not.toHaveBeenCalled();
-    });
-  });
+  describeAdminForbiddenCases(
+    (auth) => handler(makeEvent("test-id-123", auth), mockContext, mockCallback),
+    [mockPieceRepo.findById, mockPieceRepo.removeWorkCascade, mockPieceRepo.removeMovement],
+  );
 });

--- a/backend/src/handlers/pieces/get.test.ts
+++ b/backend/src/handlers/pieces/get.test.ts
@@ -1,30 +1,12 @@
-import type { APIGatewayProxyEvent, Context } from "aws-lambda";
 import type { Piece, PieceWork } from "@/types";
 
 import { handler } from "@/handlers/pieces/get";
+import { makeGetEvent, mockCallback, mockContext } from "@/test/fixtures";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/piece-repository");
 
-const mockContext = {} as Context;
-const mockCallback = { signal: new AbortController().signal };
-
-function makeEvent(id?: string): APIGatewayProxyEvent {
-  return {
-    body: null,
-    headers: {},
-    multiValueHeaders: {},
-    httpMethod: "GET",
-    isBase64Encoded: false,
-    path: `/pieces/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-    queryStringParameters: null,
-    multiValueQueryStringParameters: null,
-    stageVariables: null,
-    requestContext: {} as APIGatewayProxyEvent["requestContext"],
-    resource: "",
-  };
-}
+const makeEvent = (id?: string) => makeGetEvent("pieces", id);
 
 const testPiece: PieceWork = {
   kind: "work",

--- a/backend/src/handlers/pieces/replace-movements.test.ts
+++ b/backend/src/handlers/pieces/replace-movements.test.ts
@@ -1,15 +1,14 @@
-import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 
 import { handler } from "@/handlers/pieces/replace-movements";
 import {
-  makeAdminEvent,
-  makeAuthEvent,
-  makeEvent as makeBaseEvent,
+  describeAdminForbiddenCases,
+  describeInvalidBodyCases,
+  makeWriteEvent,
   mockCallback,
   mockContext,
   TEST_COMPOSER_ID,
-  TEST_USER_ID,
+  type WriteAuthMode,
 } from "@/test/fixtures";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
@@ -26,27 +25,16 @@ const existingWork = {
   updatedAt: "2024-01-15T20:00:00.000Z",
 };
 
-type AuthMode = "admin" | "non-admin" | "none";
-
-function makeEvent(
-  workId?: string,
-  body?: string | null,
-  auth: AuthMode = "admin",
-): APIGatewayProxyEvent {
-  const overrides: Partial<APIGatewayProxyEvent> = {
-    body: body === undefined ? null : body,
-    httpMethod: "PUT",
-    path: `/pieces/${workId ?? ""}/movements`,
-    pathParameters: workId === undefined ? null : { id: workId },
-  };
-  if (auth === "admin") {
-    return makeAdminEvent(TEST_USER_ID, overrides);
-  }
-  if (auth === "non-admin") {
-    return makeAuthEvent(TEST_USER_ID, overrides);
-  }
-  return makeBaseEvent(overrides);
-}
+const makeEvent = (workId?: string, body?: string | null, auth: WriteAuthMode = "admin") =>
+  makeWriteEvent(
+    {
+      body: body === undefined ? null : body,
+      httpMethod: "PUT",
+      path: `/pieces/${workId ?? ""}/movements`,
+      pathParameters: workId === undefined ? null : { id: workId },
+    },
+    auth,
+  );
 
 describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
   beforeEach(() => {
@@ -63,18 +51,9 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(makeEvent(TEST_WORK_ID, body), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, `/pieces/${TEST_WORK_ID}/movements`, (body) =>
+    makeEvent(TEST_WORK_ID, body),
+  );
 
   it("movements に index 重複があると 400 を返す", async () => {
     const result = await handler(
@@ -210,35 +189,17 @@ describe("PUT /pieces/{workId}/movements (replace-movements)", () => {
     expect(result?.statusCode).toBe(500);
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返す", async () => {
-      const result = await handler(
+  describeAdminForbiddenCases(
+    (auth) =>
+      handler(
         makeEvent(
           TEST_WORK_ID,
           JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] }),
-          "non-admin",
+          auth,
         ),
         mockContext,
         mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockPieceRepo.findRootById).not.toHaveBeenCalled();
-      expect(mockPieceRepo.replaceMovements).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返す", async () => {
-      const result = await handler(
-        makeEvent(
-          TEST_WORK_ID,
-          JSON.stringify({ movements: [{ index: 0, title: "第1楽章" }] }),
-          "none",
-        ),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockPieceRepo.replaceMovements).not.toHaveBeenCalled();
-    });
-  });
+      ),
+    [mockPieceRepo.findRootById, mockPieceRepo.replaceMovements],
+  );
 });

--- a/backend/src/handlers/pieces/update.test.ts
+++ b/backend/src/handlers/pieces/update.test.ts
@@ -1,42 +1,22 @@
-import type { APIGatewayProxyEvent } from "aws-lambda";
 import createError from "http-errors";
 import type { Piece, PieceWork } from "@/types";
 
 import { handler } from "@/handlers/pieces/update";
 import {
-  makeAdminEvent,
-  makeAuthEvent,
-  makeEvent as makeBaseEvent,
+  describeAdminForbiddenCases,
+  describeInvalidBodyCases,
+  makeAdminPutEvent,
   mockCallback,
   mockContext,
   TEST_COMPOSER_ID,
-  TEST_USER_ID,
+  type WriteAuthMode,
 } from "@/test/fixtures";
 import { mockPieceRepo } from "@/repositories/__mocks__/piece-repository";
 
 vi.mock("@/repositories/piece-repository");
 
-type AuthMode = "admin" | "non-admin" | "none";
-
-function makeEvent(
-  id?: string,
-  body?: string | null,
-  auth: AuthMode = "admin",
-): APIGatewayProxyEvent {
-  const overrides: Partial<APIGatewayProxyEvent> = {
-    body: body === undefined ? null : body,
-    httpMethod: "PUT",
-    path: `/pieces/${id ?? ""}`,
-    pathParameters: id === undefined ? null : { id },
-  };
-  if (auth === "admin") {
-    return makeAdminEvent(TEST_USER_ID, overrides);
-  }
-  if (auth === "non-admin") {
-    return makeAuthEvent(TEST_USER_ID, overrides);
-  }
-  return makeBaseEvent(overrides);
-}
+const makeEvent = (id?: string, body?: string | null, auth: WriteAuthMode = "admin") =>
+  makeAdminPutEvent("pieces", id, body, auth);
 
 const existingPiece: PieceWork = {
   kind: "work",
@@ -72,18 +52,7 @@ describe("PUT /pieces/{id} (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("id is required");
   });
 
-  describe("リクエストボディ異常系", () => {
-    it.each<[string | null, number, string]>([
-      [null, 400, "Request body is required"],
-      ["null", 400, "Request body is required"],
-      ["[]", 400, "Request body must be a JSON object"],
-      ["invalid json", 422, "Invalid or malformed JSON was provided"],
-    ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(makeEvent("abc-123", body), mockContext, mockCallback);
-      expect(result?.statusCode).toBe(statusCode);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
-    });
-  });
+  describeInvalidBodyCases(handler, "/pieces/abc-123", (body) => makeEvent("abc-123", body));
 
   it.each(["", "   ", "\t", "\n"])(
     "title が空または空白のみ（%j）の場合は 400 を返す",
@@ -387,28 +356,9 @@ describe("PUT /pieces/{id} (update)", () => {
     expect(JSON.parse(result?.body ?? "{}").message).toBe("videoUrls must contain valid URLs");
   });
 
-  describe("認可", () => {
-    it("admin グループに属さないユーザーは 403 を返し、データを更新しない", async () => {
-      const result = await handler(
-        makeEvent("abc-123", work({ title: "新タイトル" }), "non-admin"),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
-      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
-      expect(mockPieceRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
-    });
-
-    it("認証クレームがない場合は 403 を返し、データを更新しない", async () => {
-      const result = await handler(
-        makeEvent("abc-123", work({ title: "新タイトル" }), "none"),
-        mockContext,
-        mockCallback,
-      );
-      expect(result?.statusCode).toBe(403);
-      expect(mockPieceRepo.findById).not.toHaveBeenCalled();
-      expect(mockPieceRepo.saveWorkWithOptimisticLock).not.toHaveBeenCalled();
-    });
-  });
+  describeAdminForbiddenCases(
+    (auth) =>
+      handler(makeEvent("abc-123", work({ title: "新タイトル" }), auth), mockContext, mockCallback),
+    [mockPieceRepo.findById, mockPieceRepo.saveWorkWithOptimisticLock],
+  );
 });

--- a/backend/src/test/fixtures.ts
+++ b/backend/src/test/fixtures.ts
@@ -131,6 +131,102 @@ export const makeDeleteEvent = (
 });
 
 /**
+ * 参照系ハンドラ（GET /{prefix}/{id}）のイベントを生成する。
+ * `userId` を渡すとユーザースコープの authorizer クレームを付与する（参照公開系では省略）。
+ */
+export const makeGetEvent = (
+  pathPrefix: string,
+  id?: string,
+  userId?: string,
+): APIGatewayProxyEvent => ({
+  ...makeEvent({
+    httpMethod: "GET",
+    path: `/${pathPrefix}/${id ?? ""}`,
+    pathParameters: id === undefined ? null : { id },
+  }),
+  requestContext: {
+    authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
+  } as APIGatewayProxyEvent["requestContext"],
+});
+
+/**
+ * admin 限定の書き込み系ハンドラで、認可状態を切り替えてイベントを生成するための区分。
+ * - `admin`: admin グループ所属の認証済みユーザー
+ * - `non-admin`: 認証済みだが admin グループ非所属
+ * - `none`: 認証クレームなし
+ */
+export type WriteAuthMode = "admin" | "non-admin" | "none";
+
+/**
+ * 認可区分に応じて admin / 非 admin / 認証なしのイベントを生成する。
+ * admin 書き込み系のうち、パスが定型でないエンドポイント（例: PUT /pieces/{id}/movements）でも
+ * overrides を直接組み立てて再利用できる。
+ */
+export const makeWriteEvent = (
+  overrides: Partial<APIGatewayProxyEvent>,
+  auth: WriteAuthMode,
+): APIGatewayProxyEvent => {
+  if (auth === "admin") {
+    return makeAdminEvent(TEST_USER_ID, overrides);
+  }
+  if (auth === "non-admin") {
+    return makeAuthEvent(TEST_USER_ID, overrides);
+  }
+  return makeEvent(overrides);
+};
+
+export const makeAdminPutEvent = (
+  pathPrefix: string,
+  id?: string,
+  body?: string | null,
+  auth: WriteAuthMode = "admin",
+): APIGatewayProxyEvent =>
+  makeWriteEvent(
+    {
+      body: body === undefined ? null : body,
+      httpMethod: "PUT",
+      path: `/${pathPrefix}/${id ?? ""}`,
+      pathParameters: id === undefined ? null : { id },
+    },
+    auth,
+  );
+
+export const makeAdminDeleteEvent = (
+  pathPrefix: string,
+  id: string | null,
+  auth: WriteAuthMode = "admin",
+): APIGatewayProxyEvent =>
+  makeWriteEvent(
+    {
+      httpMethod: "DELETE",
+      path: `/${pathPrefix}/${id ?? ""}`,
+      pathParameters: id === null ? null : { id },
+    },
+    auth,
+  );
+
+/**
+ * ユーザースコープの更新系ハンドラ（PUT /{prefix}/{id}）のイベントを生成する。
+ * `userId` を渡すと authorizer クレームを付与する。
+ */
+export const makeUserPutEvent = (
+  pathPrefix: string,
+  id?: string,
+  body?: string | null,
+  userId?: string,
+): APIGatewayProxyEvent => ({
+  ...makeEvent({
+    body: body === undefined ? null : body,
+    httpMethod: "PUT",
+    path: `/${pathPrefix}/${id ?? ""}`,
+    pathParameters: id === undefined ? null : { id },
+  }),
+  requestContext: {
+    authorizer: userId === undefined ? undefined : { claims: { sub: userId } },
+  } as APIGatewayProxyEvent["requestContext"],
+});
+
+/**
  * ListeningLog 系ハンドラ／ユースケースのテストで使うリポジトリモック群を生成する。
  * ListeningLogUsecase が `pieceRepo.findById` / `composerRepo.findById` を呼ぶため、
  * これらの戻り値も既定で fixture から提供する（必要に応じて override 可能）。
@@ -226,7 +322,17 @@ export const describeCognitoErrorCases = (
   });
 };
 
-export const describeInvalidBodyCases = (handler: HandlerFn, path: string) => {
+/**
+ * リクエストボディの欠落・型不正・JSON 破損に対するハンドラ応答を共通検証する。
+ * 既定では認証なしの POST イベントを使うが、admin 必須エンドポイントや PUT など
+ * 別のイベント生成が必要な場合は `makeBodyEvent` でファクトリを差し替える。
+ */
+export const describeInvalidBodyCases = (
+  handler: HandlerFn,
+  path: string,
+  makeBodyEvent: (body: string | null) => APIGatewayProxyEvent = (body) =>
+    makeEvent({ body, httpMethod: "POST", path }),
+) => {
   describe("リクエストボディ異常系", () => {
     it.each<[string | null, number, string]>([
       [null, 400, "Request body is required"],
@@ -234,13 +340,36 @@ export const describeInvalidBodyCases = (handler: HandlerFn, path: string) => {
       ["[]", 400, "Request body must be a JSON object"],
       ["invalid json", 422, "Invalid or malformed JSON was provided"],
     ])("body=%j のとき %i を返す", async (body, statusCode, message) => {
-      const result = await handler(
-        makeEvent({ body, httpMethod: "POST", path }),
-        mockContext,
-        mockCallback,
-      );
+      const result = await handler(makeBodyEvent(body), mockContext, mockCallback);
       expect(result?.statusCode).toBe(statusCode);
       expect(JSON.parse(result?.body ?? "{}").message).toBe(message);
+    });
+  });
+};
+
+/**
+ * admin 限定の書き込み系ハンドラに共通する「認可」ブロックを共通化する。
+ * 非 admin・認証クレームなしのいずれでも 403 を返し、副作用（リポジトリ書き込み等）が
+ * 起きないことを検証する。`invoke` は認可区分を受け取りハンドラを呼び出す。
+ */
+type HandlerResult = { statusCode?: number; body?: string } | null | undefined;
+
+export const describeAdminForbiddenCases = (
+  invoke: (auth: "non-admin" | "none") => HandlerResult | Promise<HandlerResult>,
+  notCalledMocks: Mock[],
+) => {
+  describe("認可", () => {
+    it("admin グループに属さないユーザーは 403 を返し、副作用を起こさない", async () => {
+      const result = await invoke("non-admin");
+      expect(result?.statusCode).toBe(403);
+      expect(JSON.parse(result?.body ?? "{}").message).toBe("Admin privilege required");
+      notCalledMocks.forEach((mock) => expect(mock).not.toHaveBeenCalled());
+    });
+
+    it("認証クレームがない場合は 403 を返し、副作用を起こさない", async () => {
+      const result = await invoke("none");
+      expect(result?.statusCode).toBe(403);
+      notCalledMocks.forEach((mock) => expect(mock).not.toHaveBeenCalled());
     });
   });
 };


### PR DESCRIPTION
## Summary
- `backend/src/handlers` 配下のテストに散在していた重複（イベント生成・admin 認可ブロック・リクエストボディ異常系ブロック）を `backend/src/test/fixtures.ts` の共通ヘルパーに集約
- 既存の集約方針（#718 の `describeCognitoErrorCases`、#719 の `__mocks__` 共通化）の延長線上の整理で、テストの挙動・件数は変更なし

## 追加・拡張したヘルパー（fixtures.ts）
- `makeGetEvent(prefix, id?, userId?)` — 参照系 GET イベント生成
- `makeAdminPutEvent` / `makeAdminDeleteEvent` — admin 書き込み系 PUT/DELETE（認可区分付き）
- `makeUserPutEvent` — ユーザースコープ PUT
- `makeWriteEvent(overrides, auth)` — 非定型パス（`PUT /pieces/{id}/movements`）用の認可分岐
- `describeAdminForbiddenCases(invoke, notCalledMocks)` — admin 403 ブロックのテーブル駆動化
- `describeInvalidBodyCases` にイベントファクトリ引数を追加（admin / PUT でも再利用可能に）

## 集約対象
- ローカル `makeEvent` / `mockContext` / `mockCallback` の再定義（composers/get・pieces/get・pieces/children・concert-logs/get・listening-logs/get）
- AuthMode 分岐の `makeEvent`（composers/pieces の update・delete）
- インライン「リクエストボディ異常系」ブロック（composers/pieces create・update、listening-logs/concert-logs create・update、replace-movements）
- インライン「認可」403 ブロック（composers/pieces の create・update・delete、replace-movements）

差分は 17 files changed, +315 / -589。

## Test plan
- [x] `pnpm run test:backend`（55 files / 798 tests passed）
- [x] `pnpm run lint`（ESLint クリーン）
- [x] `pnpm run format:check`（Prettier クリーン）
- [x] pre-push フック（format:check + フロント/バックテスト）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)