### PR TITLE
test: vitest の teardown レース対策を dynamicImportSettled に置き換え

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,28 +1,15 @@
+import { afterEach, vi } from "vitest";
+
 /**
- * @nuxt/test-utils のルート遅延解決に起因する EnvironmentTeardownError を抑制する。
+ * mountSuspended() でページコンポーネントをマウントすると、Nuxt ルーターが
+ * すべてのルートを遅延的に解決し、その動的 import がテスト環境の teardown 後に
+ * 完了して EnvironmentTeardownError（unhandled rejection）として表面化することがある。
  *
- * mountSuspended() でページコンポーネントをマウントすると、Nuxt のルーターが
- * すべてのルートを遅延的に解決し始める。一部の動的インポートが vitest 4.1+ の
- * テスト環境ティアダウン後に完了するため、EnvironmentTeardownError が
- * unhandled rejection として発生する。テスト自体はすべて合格しており、
- * クリーンアップのタイミング問題にすぎない。
- *
- * Vite の reviveInvokeError が元の EnvironmentTeardownError を通常の Error でラップ
- * するため、name だけでなく message でも判定する。
- *
- * TODO: vitest の上流修正が入ったらこのファイルごと削除する。
- *   - 上流 issue: https://github.com/vitest-dev/vitest/issues/9872
- *   - トラッキング: https://github.com/konabe/classical-music-lake/issues/574
- *   検証履歴: vitest 4.1.5 + @nuxt/test-utils 4.0.3 の組み合わせでも未解消（2026-04-29 時点）。
+ * 各テスト終了時に保留中の動的 import を待ち合わせ、teardown 前に確実に
+ * 解決させることでこのレースを根本から防ぐ。上流 vitest はこれをバグではなく
+ * dynamicImportSettled の利用案件として扱っている。
+ *   - https://github.com/vitest-dev/vitest/issues/9872
  */
-process.on("unhandledRejection", (reason: unknown) => {
-  if (
-    reason instanceof Error &&
-    (reason.name === "EnvironmentTeardownError" ||
-      reason.message.includes("after the environment was torn down") ||
-      (reason.cause instanceof Error && reason.cause.name === "EnvironmentTeardownError"))
-  ) {
-    return;
-  }
-  throw reason;
+afterEach(async () => {
+  await vi.dynamicImportSettled();
 });


### PR DESCRIPTION
## Summary

- `vitest.setup.ts` のグローバルな `process.on("unhandledRejection")` による `EnvironmentTeardownError` 握り潰しを廃止し、`afterEach` で `vi.dynamicImportSettled()` を待ち合わせる方式に置き換え
- `mountSuspended()` 時の Nuxt ルーター遅延 import を teardown 前に確実に解決させることでレースを根本から防ぐ。本物の unhandled rejection をマスクするリスクも解消

## 背景

#574 の workaround の恒久対応。上流 vitest の [issue #9872](https://github.com/vitest-dev/vitest/issues/9872) はバグではなく `dynamicImportSettled` の利用案件としてメンテナが discussion 化・クローズ済みで、「修正リリースを待つ」路線は成立しないことが判明したため、コード側で対処した。

## 検証

- workaround を外した状態で全フロントエンドスイート（786 テスト）を 4 回連続実行 → いずれも unhandled rejection ゼロ・exit 0（vitest 4.1.5 / @nuxt/test-utils 4.0.3）
- `dynamicImportSettled` 方式でも全 786 テストを 3 回連続実行 → いずれも unhandled rejection ゼロ・exit 0
- pre-push フック（`format:check` + フロント・バックテスト）通過

## Test plan

- [ ] CI でフロントエンドテストがグリーンであること
- [ ] CI 環境（負荷条件が異なる）でも `EnvironmentTeardownError` が再発しないこと

Closes #574

🤖 Generated with [Claude Code](https://claude.com/claude-code)