### PR TITLE
refactor(backend): 値オブジェクトの共通不変条件を基底クラスへ集約

### DIFF
--- a/backend/src/domain/value-objects/bounded-integer.test.ts
+++ b/backend/src/domain/value-objects/bounded-integer.test.ts
@@ -1,0 +1,17 @@
+import { MovementIndex } from "@/domain/value-objects/movement-index";
+import { Year } from "@/domain/value-objects/year";
+
+describe("BoundedInteger", () => {
+  it("同じ値でも異なる具象クラス同士は等しくない", () => {
+    expect(MovementIndex.of(5).equals(Year.of(5))).toBe(false);
+  });
+
+  it("同じ具象クラスかつ同じ値なら等しい", () => {
+    expect(MovementIndex.of(5).equals(MovementIndex.of(5))).toBe(true);
+  });
+
+  it("プリミティブやプレーンオブジェクトとは等しくない", () => {
+    expect(MovementIndex.of(5).equals(5)).toBe(false);
+    expect(MovementIndex.of(5).equals({ value: 5 })).toBe(false);
+  });
+});

--- a/backend/src/domain/value-objects/bounded-integer.ts
+++ b/backend/src/domain/value-objects/bounded-integer.ts
@@ -1,0 +1,34 @@
+/**
+ * 「指定された範囲内の整数」を表す値オブジェクトの基底。
+ *
+ * - 整数以外（非数値・非整数・NaN・Infinity）は `RangeError` を投げる。
+ * - 範囲外も `RangeError` を投げる。
+ * - 等価判定は「同じ具象クラス」かつ「同じ値」のときのみ `true`。
+ *
+ * 型パラメータ `T` で `.value` の型を絞れる（例: `Rating` は `1 | 2 | 3 | 4 | 5`）。
+ */
+export abstract class BoundedInteger<T extends number = number> {
+  public readonly value: T;
+
+  protected constructor(value: number, label: string, min: number, max: number) {
+    if (typeof value !== "number" || !Number.isInteger(value)) {
+      throw new RangeError(`${label} must be an integer`);
+    }
+    if (value < min || value > max) {
+      throw new RangeError(`${label} must be between ${min} and ${max}`);
+    }
+    this.value = value as T;
+  }
+
+  equals(other: unknown): boolean {
+    return (
+      other instanceof BoundedInteger &&
+      this.constructor === other.constructor &&
+      this.value === other.value
+    );
+  }
+
+  toString(): string {
+    return String(this.value);
+  }
+}

--- a/backend/src/domain/value-objects/composer-name.ts
+++ b/backend/src/domain/value-objects/composer-name.ts
@@ -1,3 +1,5 @@
+import { BoundedText } from "@/domain/value-objects/non-empty-text";
+
 /**
  * 作曲家の名前を表す値オブジェクト。
  *
@@ -7,32 +9,12 @@
  */
 const MAX_LENGTH = 100;
 
-export class ComposerName {
-  public readonly value: string;
-
+export class ComposerName extends BoundedText {
   private constructor(value: string) {
-    this.value = value;
+    super(value, "ComposerName", MAX_LENGTH);
   }
 
   static of(value: string): ComposerName {
-    if (typeof value !== "string") {
-      throw new TypeError("ComposerName must be a string");
-    }
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      throw new RangeError("ComposerName must be a non-empty string");
-    }
-    if (trimmed.length > MAX_LENGTH) {
-      throw new RangeError(`ComposerName must be ${MAX_LENGTH} characters or less`);
-    }
-    return new ComposerName(trimmed);
-  }
-
-  equals(other: ComposerName): boolean {
-    return other instanceof ComposerName && this.value === other.value;
-  }
-
-  toString(): string {
-    return this.value;
+    return new ComposerName(value);
   }
 }

--- a/backend/src/domain/value-objects/concert-title.ts
+++ b/backend/src/domain/value-objects/concert-title.ts
@@ -1,3 +1,5 @@
+import { BoundedText } from "@/domain/value-objects/non-empty-text";
+
 /**
  * コンサートのタイトルを表す値オブジェクト。
  *
@@ -7,32 +9,12 @@
  */
 const MAX_LENGTH = 200;
 
-export class ConcertTitle {
-  public readonly value: string;
-
+export class ConcertTitle extends BoundedText {
   private constructor(value: string) {
-    this.value = value;
+    super(value, "ConcertTitle", MAX_LENGTH);
   }
 
   static of(value: string): ConcertTitle {
-    if (typeof value !== "string") {
-      throw new TypeError("ConcertTitle must be a string");
-    }
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      throw new RangeError("ConcertTitle must be a non-empty string");
-    }
-    if (trimmed.length > MAX_LENGTH) {
-      throw new RangeError(`ConcertTitle must be ${MAX_LENGTH} characters or less`);
-    }
-    return new ConcertTitle(trimmed);
-  }
-
-  equals(other: ConcertTitle): boolean {
-    return other instanceof ConcertTitle && this.value === other.value;
-  }
-
-  toString(): string {
-    return this.value;
+    return new ConcertTitle(value);
   }
 }

--- a/backend/src/domain/value-objects/movement-index.ts
+++ b/backend/src/domain/value-objects/movement-index.ts
@@ -1,3 +1,7 @@
+import { MOVEMENT_INDEX_MAX, MOVEMENT_INDEX_MIN } from "@shared/constants";
+
+import { BoundedInteger } from "@/domain/value-objects/bounded-integer";
+
 /**
  * Movement の演奏順を表す値オブジェクト。
  *
@@ -5,32 +9,12 @@
  * - 範囲は 0 〜 999。1 楽曲に持てる楽章数の現実的な上限を考慮。
  * - 値の取り出しは `.value` または `toString()`、等価判定は `.equals(other)`。
  */
-import { MOVEMENT_INDEX_MAX, MOVEMENT_INDEX_MIN } from "@shared/constants";
-
-export class MovementIndex {
-  public readonly value: number;
-
+export class MovementIndex extends BoundedInteger {
   private constructor(value: number) {
-    this.value = value;
+    super(value, "MovementIndex", MOVEMENT_INDEX_MIN, MOVEMENT_INDEX_MAX);
   }
 
   static of(value: number): MovementIndex {
-    if (typeof value !== "number" || !Number.isInteger(value)) {
-      throw new RangeError("MovementIndex must be an integer");
-    }
-    if (value < MOVEMENT_INDEX_MIN || value > MOVEMENT_INDEX_MAX) {
-      throw new RangeError(
-        `MovementIndex must be between ${MOVEMENT_INDEX_MIN} and ${MOVEMENT_INDEX_MAX}`,
-      );
-    }
     return new MovementIndex(value);
-  }
-
-  equals(other: MovementIndex): boolean {
-    return other instanceof MovementIndex && this.value === other.value;
-  }
-
-  toString(): string {
-    return String(this.value);
   }
 }

--- a/backend/src/domain/value-objects/non-empty-text.test.ts
+++ b/backend/src/domain/value-objects/non-empty-text.test.ts
@@ -1,0 +1,17 @@
+import { PieceTitle } from "@/domain/value-objects/piece-title";
+import { Venue } from "@/domain/value-objects/venue";
+
+describe("NonEmptyText / BoundedText", () => {
+  it("同じ値でも異なる具象クラス同士は等しくない", () => {
+    expect(PieceTitle.of("Symphony").equals(Venue.of("Symphony"))).toBe(false);
+  });
+
+  it("同じ具象クラスかつ同じ値なら等しい", () => {
+    expect(PieceTitle.of("Symphony").equals(PieceTitle.of("Symphony"))).toBe(true);
+  });
+
+  it("プリミティブやプレーンオブジェクトとは等しくない", () => {
+    expect(PieceTitle.of("Symphony").equals("Symphony")).toBe(false);
+    expect(PieceTitle.of("Symphony").equals({ value: "Symphony" })).toBe(false);
+  });
+});

--- a/backend/src/domain/value-objects/non-empty-text.ts
+++ b/backend/src/domain/value-objects/non-empty-text.ts
@@ -1,0 +1,46 @@
+/**
+ * 「前後の空白を除去し、空文字を拒否する文字列」を表す値オブジェクトの基底。
+ *
+ * - 文字列以外は `TypeError`、trim 後に空文字なら `RangeError` を投げる。
+ * - 等価判定は「同じ具象クラス」かつ「同じ値」のときのみ `true`。
+ *   異なる具象クラス（例: `Venue` と `PieceTitle`）同士は `false`。
+ */
+export abstract class NonEmptyText {
+  public readonly value: string;
+
+  protected constructor(value: string, label: string) {
+    if (typeof value !== "string") {
+      throw new TypeError(`${label} must be a string`);
+    }
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      throw new RangeError(`${label} must be a non-empty string`);
+    }
+    this.value = trimmed;
+  }
+
+  equals(other: unknown): boolean {
+    return (
+      other instanceof NonEmptyText &&
+      this.constructor === other.constructor &&
+      this.value === other.value
+    );
+  }
+
+  toString(): string {
+    return this.value;
+  }
+}
+
+/**
+ * `NonEmptyText` に「最大文字数」の不変条件を加えた基底。
+ * 文字数は trim 後の長さで判定する。
+ */
+export abstract class BoundedText extends NonEmptyText {
+  protected constructor(value: string, label: string, maxLength: number) {
+    super(value, label);
+    if (this.value.length > maxLength) {
+      throw new RangeError(`${label} must be ${maxLength} characters or less`);
+    }
+  }
+}

--- a/backend/src/domain/value-objects/piece-title.ts
+++ b/backend/src/domain/value-objects/piece-title.ts
@@ -1,3 +1,5 @@
+import { BoundedText } from "@/domain/value-objects/non-empty-text";
+
 /**
  * 楽曲のタイトルを表す値オブジェクト。
  *
@@ -10,32 +12,12 @@
  */
 const MAX_LENGTH = 200;
 
-export class PieceTitle {
-  public readonly value: string;
-
+export class PieceTitle extends BoundedText {
   private constructor(value: string) {
-    this.value = value;
+    super(value, "PieceTitle", MAX_LENGTH);
   }
 
   static of(value: string): PieceTitle {
-    if (typeof value !== "string") {
-      throw new TypeError("PieceTitle must be a string");
-    }
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      throw new RangeError("PieceTitle must be a non-empty string");
-    }
-    if (trimmed.length > MAX_LENGTH) {
-      throw new RangeError(`PieceTitle must be ${MAX_LENGTH} characters or less`);
-    }
-    return new PieceTitle(trimmed);
-  }
-
-  equals(other: PieceTitle): boolean {
-    return other instanceof PieceTitle && this.value === other.value;
-  }
-
-  toString(): string {
-    return this.value;
+    return new PieceTitle(value);
   }
 }

--- a/backend/src/domain/value-objects/rating.ts
+++ b/backend/src/domain/value-objects/rating.ts
@@ -1,3 +1,5 @@
+import { BoundedInteger } from "@/domain/value-objects/bounded-integer";
+
 /**
  * 鑑賞ログの評価を表す値オブジェクト。
  *
@@ -9,25 +11,12 @@
  */
 export type RatingValue = 1 | 2 | 3 | 4 | 5;
 
-export class Rating {
-  public readonly value: RatingValue;
-
-  private constructor(value: RatingValue) {
-    this.value = value;
+export class Rating extends BoundedInteger<RatingValue> {
+  private constructor(value: number) {
+    super(value, "Rating", 1, 5);
   }
 
   static of(value: number): Rating {
-    if (!Number.isInteger(value) || value < 1 || value > 5) {
-      throw new RangeError("Rating must be an integer between 1 and 5");
-    }
-    return new Rating(value as RatingValue);
-  }
-
-  equals(other: Rating): boolean {
-    return other instanceof Rating && this.value === other.value;
-  }
-
-  toString(): string {
-    return String(this.value);
+    return new Rating(value);
   }
 }

--- a/backend/src/domain/value-objects/url.ts
+++ b/backend/src/domain/value-objects/url.ts
@@ -1,3 +1,5 @@
+import { NonEmptyText } from "@/domain/value-objects/non-empty-text";
+
 /**
  * URL を表す値オブジェクト。
  *
@@ -9,34 +11,17 @@
  * 不変条件をドメイン層で単独に保証する。videoUrl / imageUrl など
  * URL を扱うフィールド全般で共通利用することを想定している。
  */
-export class Url {
-  public readonly value: string;
-
+export class Url extends NonEmptyText {
   private constructor(value: string) {
-    this.value = value;
-  }
-
-  static of(value: string): Url {
-    if (typeof value !== "string") {
-      throw new TypeError("Url must be a string");
-    }
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      throw new RangeError("Url must be a non-empty string");
-    }
+    super(value, "Url");
     try {
-      new URL(trimmed);
+      new URL(this.value);
     } catch {
       throw new RangeError("Url must be a valid URL");
     }
-    return new Url(trimmed);
   }
 
-  equals(other: Url): boolean {
-    return other instanceof Url && this.value === other.value;
-  }
-
-  toString(): string {
-    return this.value;
+  static of(value: string): Url {
+    return new Url(value);
   }
 }

--- a/backend/src/domain/value-objects/venue.ts
+++ b/backend/src/domain/value-objects/venue.ts
@@ -1,3 +1,5 @@
+import { BoundedText } from "@/domain/value-objects/non-empty-text";
+
 /**
  * コンサートの開催会場名を表す値オブジェクト。
  *
@@ -7,32 +9,12 @@
  */
 const MAX_LENGTH = 200;
 
-export class Venue {
-  public readonly value: string;
-
+export class Venue extends BoundedText {
   private constructor(value: string) {
-    this.value = value;
+    super(value, "Venue", MAX_LENGTH);
   }
 
   static of(value: string): Venue {
-    if (typeof value !== "string") {
-      throw new TypeError("Venue must be a string");
-    }
-    const trimmed = value.trim();
-    if (trimmed.length === 0) {
-      throw new RangeError("Venue must be a non-empty string");
-    }
-    if (trimmed.length > MAX_LENGTH) {
-      throw new RangeError(`Venue must be ${MAX_LENGTH} characters or less`);
-    }
-    return new Venue(trimmed);
-  }
-
-  equals(other: Venue): boolean {
-    return other instanceof Venue && this.value === other.value;
-  }
-
-  toString(): string {
-    return this.value;
+    return new Venue(value);
   }
 }

--- a/backend/src/domain/value-objects/year.ts
+++ b/backend/src/domain/value-objects/year.ts
@@ -1,3 +1,5 @@
+import { BoundedInteger } from "@/domain/value-objects/bounded-integer";
+
 /**
  * 西暦の年を表す値オブジェクト。
  *
@@ -8,28 +10,12 @@
 const MIN_YEAR = -3000;
 const MAX_YEAR = 9999;
 
-export class Year {
-  public readonly value: number;
-
+export class Year extends BoundedInteger {
   private constructor(value: number) {
-    this.value = value;
+    super(value, "Year", MIN_YEAR, MAX_YEAR);
   }
 
   static of(value: number): Year {
-    if (typeof value !== "number" || !Number.isInteger(value)) {
-      throw new RangeError("Year must be an integer");
-    }
-    if (value < MIN_YEAR || value > MAX_YEAR) {
-      throw new RangeError(`Year must be between ${MIN_YEAR} and ${MAX_YEAR}`);
-    }
     return new Year(value);
-  }
-
-  equals(other: Year): boolean {
-    return other instanceof Year && this.value === other.value;
-  }
-
-  toString(): string {
-    return String(this.value);
   }
 }

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -647,6 +647,8 @@ ID 以外のドメイン概念も不変条件を VO で保証する。すべて 
 | `Year`          | -3000〜9999 の整数（西暦。BC は負数で表現） | `ComposerEntity.props.birthYear` / `props.deathYear`              |
 
 - 生成は `Xxx.of(value)`。範囲外・文字列以外・空文字・形式不正は `RangeError` / `TypeError` を投げる
+- 共通の不変条件は基底クラスに集約している。テキスト系（`ComposerName` / `ConcertTitle` / `PieceTitle` / `Venue`）は `non-empty-text.ts` の `NonEmptyText`（trim + 空文字拒否）/ `BoundedText`（最大長）を継承し、`Url` は `NonEmptyText` を継承して URL パース検証を加える。数値系（`Rating` / `MovementIndex` / `Year`）は `bounded-integer.ts` の `BoundedInteger<T>`（整数 + 範囲）を継承する。各具象クラスは `static of` とラベル・範囲指定のみを持つ
+- `equals(other)` は基底側で `other instanceof <基底>` かつ `this.constructor === other.constructor` を判定し、同値でも異なる具象クラス同士は等しくない（`ids.ts` の `IdValueObject` と同方針）
 - テキスト系 VO は `value.trim()` を内部適用。最大長は Zod スキーマと数値を揃え二重検証
 - `Url` はスキーム制限なし（Zod の `z.url()` と同等）。空文字は明示削除として VO 化前にハンドラ／ユースケース層で処理する
 - DTO 境界（`types/index.ts`）は従来どおり primitive。VO はエンティティ内部の props 型としてのみ扱い、ハンドラ・ユースケース・リポジトリは引き続き string ベースの DTO を受け渡す


### PR DESCRIPTION
## Summary

`backend/src/domain/value-objects/` の重複を基底クラスへ集約するリファクタリング（API・データモデル・挙動は不変）。

- テキスト系 VO（`ComposerName` / `ConcertTitle` / `PieceTitle` / `Venue`）を `non-empty-text.ts` の `NonEmptyText`（trim + 空文字拒否）/ `BoundedText`（最大長）へ載せ替え。`Url` は `NonEmptyText` を継承して URL パース検証を追加（案1）
- 数値系 VO（`Rating` / `MovementIndex` / `Year`）を `bounded-integer.ts` の `BoundedInteger<T>`（整数 + 範囲）へ載せ替え。`Rating` は型パラメータで `.value` を `1 | 2 | 3 | 4 | 5` に維持（案2）
- `equals` を基底側で `instanceof` + `this.constructor === other.constructor` 判定に統一し、同値でも異なる具象クラス同士は等しくないことを保証（案3）
- 各具象 VO は `static of` とラベル・範囲指定のみを持つ薄いクラスに縮小
- `docs/SPEC.md` §8.5 に基底クラス方針を追記

## Test plan

- [x] `pnpm -C backend test`（804 件パス）
- [x] `pnpm run lint`（ESLint + Stylelint）
- [x] `pnpm run format:check`（Prettier）
- [x] 基底の `equals` で異種 VO が誤一致しないことを新規テストで検証

https://claude.ai/code/session_01V6KLHgH8qedvp8jtS4yxW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6KLHgH8qedvp8jtS4yxW8)_