### PR TITLE
refactor(backend): 値オブジェクトの抽象基底 ValueObject を導入

### DIFF
--- a/backend/src/domain/value-objects/bounded-integer.ts
+++ b/backend/src/domain/value-objects/bounded-integer.ts
@@ -1,15 +1,15 @@
+import { ValueObject } from "@/domain/value-objects/value-object";
+
 /**
  * 「指定された範囲内の整数」を表す値オブジェクトの基底。
  *
  * - 整数以外（非数値・非整数・NaN・Infinity）は `RangeError` を投げる。
  * - 範囲外も `RangeError` を投げる。
- * - 等価判定は「同じ具象クラス」かつ「同じ値」のときのみ `true`。
+ * - 等価判定・`toString` は `ValueObject` の実装に従う。
  *
  * 型パラメータ `T` で `.value` の型を絞れる（例: `Rating` は `1 | 2 | 3 | 4 | 5`）。
  */
-export abstract class BoundedInteger<T extends number = number> {
-  public readonly value: T;
-
+export abstract class BoundedInteger<T extends number = number> extends ValueObject<T> {
   protected constructor(value: number, label: string, min: number, max: number) {
     if (typeof value !== "number" || !Number.isInteger(value)) {
       throw new RangeError(`${label} must be an integer`);
@@ -17,18 +17,6 @@ export abstract class BoundedInteger<T extends number = number> {
     if (value < min || value > max) {
       throw new RangeError(`${label} must be between ${min} and ${max}`);
     }
-    this.value = value as T;
-  }
-
-  equals(other: unknown): boolean {
-    return (
-      other instanceof BoundedInteger &&
-      this.constructor === other.constructor &&
-      this.value === other.value
-    );
-  }
-
-  toString(): string {
-    return String(this.value);
+    super(value as T);
   }
 }

--- a/backend/src/domain/value-objects/ids.ts
+++ b/backend/src/domain/value-objects/ids.ts
@@ -1,5 +1,7 @@
 import { randomUUID } from "node:crypto";
 
+import { ValueObject } from "@/domain/value-objects/value-object";
+
 /**
  * エンティティ ID の値オブジェクト基底クラス。
  *
@@ -10,23 +12,14 @@ import { randomUUID } from "node:crypto";
  * - UUID 形式の厳密な検証は行わない（既存データとの後方互換性のため）。
  *   入力側のスキーマ検証（Zod の `z.uuid()`）と responsibility を分ける。
  * - 空文字・非文字列のみ拒否する。
+ * - 等価判定・`toString` は `ValueObject` の実装に従う（同じ具象クラスかつ同値で `true`）。
  */
-export abstract class IdValueObject {
-  public readonly value: string;
-
+export abstract class IdValueObject extends ValueObject<string> {
   protected constructor(value: string) {
     if (typeof value !== "string" || value.length === 0) {
       throw new TypeError("ID value object must be a non-empty string");
     }
-    this.value = value;
-  }
-
-  toString(): string {
-    return this.value;
-  }
-
-  equals(other: IdValueObject): boolean {
-    return this.constructor === other.constructor && this.value === other.value;
+    super(value);
   }
 }
 

--- a/backend/src/domain/value-objects/non-empty-text.ts
+++ b/backend/src/domain/value-objects/non-empty-text.ts
@@ -1,13 +1,12 @@
+import { ValueObject } from "@/domain/value-objects/value-object";
+
 /**
  * 「前後の空白を除去し、空文字を拒否する文字列」を表す値オブジェクトの基底。
  *
  * - 文字列以外は `TypeError`、trim 後に空文字なら `RangeError` を投げる。
- * - 等価判定は「同じ具象クラス」かつ「同じ値」のときのみ `true`。
- *   異なる具象クラス（例: `Venue` と `PieceTitle`）同士は `false`。
+ * - 等価判定・`toString` は `ValueObject` の実装に従う。
  */
-export abstract class NonEmptyText {
-  public readonly value: string;
-
+export abstract class NonEmptyText extends ValueObject<string> {
   protected constructor(value: string, label: string) {
     if (typeof value !== "string") {
       throw new TypeError(`${label} must be a string`);
@@ -16,19 +15,7 @@ export abstract class NonEmptyText {
     if (trimmed.length === 0) {
       throw new RangeError(`${label} must be a non-empty string`);
     }
-    this.value = trimmed;
-  }
-
-  equals(other: unknown): boolean {
-    return (
-      other instanceof NonEmptyText &&
-      this.constructor === other.constructor &&
-      this.value === other.value
-    );
-  }
-
-  toString(): string {
-    return this.value;
+    super(trimmed);
   }
 }
 

--- a/backend/src/domain/value-objects/value-object.test.ts
+++ b/backend/src/domain/value-objects/value-object.test.ts
@@ -1,0 +1,19 @@
+import { PieceId } from "@/domain/value-objects/ids";
+import { MovementIndex } from "@/domain/value-objects/movement-index";
+import { PieceTitle } from "@/domain/value-objects/piece-title";
+
+describe("ValueObject (root)", () => {
+  it("異なる系統の VO 同士は等しくない（テキスト × 数値 × ID）", () => {
+    expect(PieceTitle.of("x").equals(MovementIndex.of(1))).toBe(false);
+    expect(MovementIndex.of(1).equals(PieceId.from("x"))).toBe(false);
+    expect(PieceId.from("x").equals(PieceTitle.of("x"))).toBe(false);
+  });
+
+  it("プリミティブ・プレーンオブジェクト・null とは等しくない", () => {
+    const vo = PieceTitle.of("x");
+    expect(vo.equals("x")).toBe(false);
+    expect(vo.equals({ value: "x" })).toBe(false);
+    expect(vo.equals(null)).toBe(false);
+    expect(vo.equals(undefined)).toBe(false);
+  });
+});

--- a/backend/src/domain/value-objects/value-object.ts
+++ b/backend/src/domain/value-objects/value-object.ts
@@ -1,0 +1,29 @@
+/**
+ * すべての値オブジェクトの抽象基底。
+ *
+ * - 不変な `value: T` を保持する。
+ * - `equals(other)` は「同じ具象クラス」かつ「`value` が `===` で等しい」のみ `true`。
+ *   異なる具象クラス同士は同値でも `false`（`IdValueObject` / `NonEmptyText` /
+ *   `BoundedInteger` の歴代方針を踏襲）。
+ * - 値オブジェクト固有の不変条件（最大長・範囲・形式など）は派生クラスの
+ *   コンストラクタで検証する。本基底は「同一性」と「文字列化」のみを担う。
+ */
+export abstract class ValueObject<T> {
+  public readonly value: T;
+
+  protected constructor(value: T) {
+    this.value = value;
+  }
+
+  equals(other: unknown): boolean {
+    return (
+      other instanceof ValueObject &&
+      this.constructor === other.constructor &&
+      this.value === (other as ValueObject<T>).value
+    );
+  }
+
+  toString(): string {
+    return String(this.value);
+  }
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -647,8 +647,9 @@ ID 以外のドメイン概念も不変条件を VO で保証する。すべて 
 | `Year`          | -3000〜9999 の整数（西暦。BC は負数で表現） | `ComposerEntity.props.birthYear` / `props.deathYear`              |
 
 - 生成は `Xxx.of(value)`。範囲外・文字列以外・空文字・形式不正は `RangeError` / `TypeError` を投げる
-- 共通の不変条件は基底クラスに集約している。テキスト系（`ComposerName` / `ConcertTitle` / `PieceTitle` / `Venue`）は `non-empty-text.ts` の `NonEmptyText`（trim + 空文字拒否）/ `BoundedText`（最大長）を継承し、`Url` は `NonEmptyText` を継承して URL パース検証を加える。数値系（`Rating` / `MovementIndex` / `Year`）は `bounded-integer.ts` の `BoundedInteger<T>`（整数 + 範囲）を継承する。各具象クラスは `static of` とラベル・範囲指定のみを持つ
-- `equals(other)` は基底側で `other instanceof <基底>` かつ `this.constructor === other.constructor` を判定し、同値でも異なる具象クラス同士は等しくない（`ids.ts` の `IdValueObject` と同方針）
+- すべての VO は `value-object.ts` の抽象基底 `ValueObject<T>` を頂点に持つ。`ValueObject<T>` が `value: T` の保持と `equals(other)` / `toString()` を提供し、その下に系統別の中間基底（`IdValueObject` / `NonEmptyText` / `BoundedInteger<T>`）が並ぶ
+- 共通の不変条件は中間基底に集約している。テキスト系（`ComposerName` / `ConcertTitle` / `PieceTitle` / `Venue`）は `non-empty-text.ts` の `NonEmptyText`（trim + 空文字拒否）/ `BoundedText`（最大長）を継承し、`Url` は `NonEmptyText` を継承して URL パース検証を加える。数値系（`Rating` / `MovementIndex` / `Year`）は `bounded-integer.ts` の `BoundedInteger<T>`（整数 + 範囲）を継承する。各具象クラスは `static of` とラベル・範囲指定のみを持つ
+- `equals(other)` は `ValueObject` 側で `other instanceof ValueObject` かつ `this.constructor === other.constructor` を判定し、同値でも異なる具象クラス同士は等しくない（系統が違っても比較できるが必ず `false`）
 - テキスト系 VO は `value.trim()` を内部適用。最大長は Zod スキーマと数値を揃え二重検証
 - `Url` はスキーム制限なし（Zod の `z.url()` と同等）。空文字は明示削除として VO 化前にハンドラ／ユースケース層で処理する
 - DTO 境界（`types/index.ts`）は従来どおり primitive。VO はエンティティ内部の props 型としてのみ扱い、ハンドラ・ユースケース・リポジトリは引き続き string ベースの DTO を受け渡す


### PR DESCRIPTION
## Summary

- `IdValueObject` / `NonEmptyText` / `BoundedInteger<T>` の共通基底として `ValueObject<T>` を新設
- `value` 保持・`equals`・`toString` を `ValueObject` に集約し、系統別中間基底は不変条件の検証のみを担う形に整理
- 異なる系統の VO 同士の比較（テキスト × 数値 × ID）も `ValueObject.equals` 1 箇所で「同一具象クラスかつ同値」のときのみ `true` に統一
- SPEC §8.5 を更新

## Test plan

- [x] `pnpm -C backend test`（806 passed）
- [x] `pnpm run lint`
- [x] `pnpm run format:check`
- [x] 系統横断の不等価を `value-object.test.ts` で検証

https://claude.ai/code/session_01V6KLHgH8qedvp8jtS4yxW8

---
_Generated by [Claude Code](https://claude.ai/code/session_01V6KLHgH8qedvp8jtS4yxW8)_